### PR TITLE
Improve ACP protocol compliance: stop reasons, tool statuses, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ The agent connects to any ACP-compatible IDE or client over **stdio**, streams r
 
 ## Features
 
-- **Full ACP compliance** – implements `initialize`, `newSession`, `prompt`, `cancel`, `closeSession`, and `listSessions`
+- **Full ACP compliance** – implements `initialize`, `authenticate`, `newSession`, `setSessionMode`, `prompt`, `cancel`, `closeSession`, and `listSessions`
 - **Streaming** – assistant text and reasoning tokens are forwarded as incremental ACP chunks
 - **Tool calling** – agentic loop with up to 20 turns of GLM function-calling
 - **Thinking mode** – GLM-5.1's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's thinking
 - **Six built-in tools** (see below)
+- **Protocol-correct stop reasons** – maps model and runtime conditions to ACP `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, and `cancelled`
+- **Protocol-correct tool statuses** – uses ACP tool lifecycle statuses (`pending`, `in_progress`, `completed`, `failed`)
 
 ---
 
@@ -178,6 +180,7 @@ src/
 ```bash
 npm run build   # one-shot TypeScript compilation → dist/
 npm run dev     # watch mode
+npm test        # build + run protocol-focused unit tests
 ```
 
 TypeScript output lands in `dist/` with source maps and declaration files.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "npm run build && node --test dist/tests/*.test.js"
   },
   "keywords": [
     "acp",

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -245,7 +245,7 @@ export class GlmAcpAgent implements Agent {
     session: SessionState,
     signal: AbortSignal
   ): Promise<{
-    stopReason: "end_turn" | "cancelled" | "max_tokens";
+    stopReason: "end_turn" | "cancelled" | "max_tokens" | "max_turn_requests" | "refusal";
     usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
   }> {
     const MAX_TURNS = 20;
@@ -332,8 +332,9 @@ export class GlmAcpAgent implements Agent {
 
       // If there are no tool calls, we're done
       if (toolCalls.length === 0) {
+        const stopReason = this.mapStopReason(lastStopReason);
         return {
-          stopReason: lastStopReason === "length" ? "max_tokens" : "end_turn",
+          stopReason,
           usage: lastUsage,
         };
       }
@@ -354,9 +355,15 @@ export class GlmAcpAgent implements Agent {
       // Continue the loop (tool_calls finish reason means GLM wants another turn)
     }
 
-    // MAX_TURNS reached: agentic loop exhausted without a natural stop.
-    // "end_turn" is the closest valid ACP stop reason — "max_tokens" is reserved
-    // for the model's own context-window limit, not an agent loop limit.
-    return { stopReason: "end_turn", usage: lastUsage };
+    // MAX_TURNS reached: we exceeded internal model/tool requests for a single user turn.
+    return { stopReason: "max_turn_requests", usage: lastUsage };
+  }
+
+  private mapStopReason(
+    stopReason: string | undefined
+  ): "end_turn" | "max_tokens" | "refusal" {
+    if (stopReason === "length") return "max_tokens";
+    if (stopReason === "content_filter") return "refusal";
+    return "end_turn";
   }
 }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GlmAcpAgent } from "../protocol/agent.js";
+
+function createConnectionStub() {
+  return {
+    updates: [] as Array<Record<string, unknown>>,
+    async sessionUpdate(update: Record<string, unknown>) {
+      this.updates.push(update);
+    },
+  };
+}
+
+test("runPromptLoop maps content_filter stop reason to refusal", async () => {
+  const connection = createConnectionStub();
+  const agent = new GlmAcpAgent(connection as never);
+  (agent as any)._glm = {
+    async *streamChat() {
+      yield { text: "I can't help with that." };
+      yield { done: true, stopReason: "content_filter" };
+    },
+  };
+
+  const result = await (agent as any).runPromptLoop(
+    "s1",
+    {
+      cwd: "/tmp",
+      messages: [],
+      abortController: null,
+      title: null,
+      updatedAt: new Date().toISOString(),
+    },
+    new AbortController().signal
+  );
+
+  assert.equal(result.stopReason, "refusal");
+});
+
+test("runPromptLoop returns max_turn_requests after tool loop limit", async () => {
+  const connection = createConnectionStub();
+  const agent = new GlmAcpAgent(connection as never);
+  (agent as any)._glm = {
+    async *streamChat() {
+      yield { toolCall: { id: "tc1", name: "unknown_tool", arguments: "{}" } };
+      yield { done: true, stopReason: "tool_calls" };
+    },
+  };
+
+  const result = await (agent as any).runPromptLoop(
+    "s2",
+    {
+      cwd: "/tmp",
+      messages: [],
+      abortController: null,
+      title: null,
+      updatedAt: new Date().toISOString(),
+    },
+    new AbortController().signal
+  );
+
+  assert.equal(result.stopReason, "max_turn_requests");
+});

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ToolExecutor } from "../tools/executor.js";
+
+function createConnectionStub() {
+  const updates: Array<Record<string, unknown>> = [];
+  return {
+    updates,
+    async sessionUpdate(payload: Record<string, unknown>) {
+      updates.push(payload);
+    },
+    async readTextFile() {
+      throw new Error("file not found");
+    },
+    async requestPermission() {
+      return { outcome: { outcome: "selected", optionId: "allow" } };
+    },
+  };
+}
+
+test("read_file failures are reported with failed status", async () => {
+  const connection = createConnectionStub();
+  const executor = new ToolExecutor(connection as never, "session-1");
+  const result = await executor.execute("tc1", "read_file", JSON.stringify({ path: "missing.ts" }));
+
+  assert.match(result.content, /Error reading file:/);
+  const lastUpdate = connection.updates[connection.updates.length - 1] as {
+    update?: { status?: string };
+  };
+  assert.equal(lastUpdate.update?.status, "failed");
+});
+
+test("run_command rejects empty command input", async () => {
+  const connection = createConnectionStub();
+  const executor = new ToolExecutor(connection as never, "session-2");
+  const result = await executor.execute("tc2", "run_command", JSON.stringify({ command: "   " }));
+
+  assert.match(result.content, /non-empty string/);
+  const lastUpdate = connection.updates[connection.updates.length - 1] as {
+    update?: { status?: string };
+  };
+  assert.equal(lastUpdate.update?.status, "failed");
+});

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -102,7 +102,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });
@@ -191,7 +191,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });
@@ -258,7 +258,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });
@@ -318,6 +318,20 @@ export class ToolExecutor {
     title: string,
     rawInput: Record<string, unknown>
   ): Promise<ToolResult> {
+    const trimmed = command.trim();
+    if (!trimmed) {
+      await this.connection.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          status: "failed",
+          rawOutput: { error: "Command must be a non-empty string." },
+        },
+      });
+      return { content: "Error running command: command must be a non-empty string." };
+    }
+
     await this.connection.sessionUpdate({
       sessionId: this.sessionId,
       update: {
@@ -337,7 +351,7 @@ export class ToolExecutor {
       // treat `command` as the binary path (not a shell invocation) work correctly.
       // Note: simple whitespace split; commands with quoted or escaped arguments
       // should pass the executable and args separately via run_command tool guidance.
-      const [cmd, ...cmdArgs] = command.trim().split(/\s+/);
+      const [cmd, ...cmdArgs] = trimmed.split(/\s+/);
       terminal = await this.connection.createTerminal({
         sessionId: this.sessionId,
         command: cmd,
@@ -372,7 +386,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });
@@ -470,7 +484,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });
@@ -554,7 +568,7 @@ export class ToolExecutor {
         update: {
           sessionUpdate: "tool_call_update",
           toolCallId,
-          status: "error",
+          status: "failed",
           rawOutput: { error: message },
         },
       });


### PR DESCRIPTION
### Motivation
- Ensure the agent emits ACP-spec stop reasons and tool lifecycle statuses so ACP clients can reliably interpret agent behavior.
- Fix runtime edge-cases (empty run_command input) and make error updates spec-compliant to improve interoperability.
- Add focused unit tests to prevent regressions in protocol semantics.

### Description
- Map model/runtime stop signals to ACP stop reasons by adding `mapStopReason`, returning `max_turn_requests` when the internal tool/model loop cap is reached, and mapping `content_filter` to `refusal` in `runPromptLoop` (`src/protocol/agent.ts`).
- Replace non-spec `status: "error"` with ACP-compliant `status: "failed"` across all tool error/update paths in `ToolExecutor` (`src/tools/executor.ts`).
- Add validation for empty/whitespace `run_command` input so the agent emits a `tool_call_update` with `status: "failed"` and a clear error message instead of attempting terminal creation (`src/tools/executor.ts`).
- Add protocol-focused unit tests covering stop-reason mapping and tool failure/empty-command behavior (`src/tests/agent.test.ts`, `src/tests/executor.test.ts`).
- Add a `test` npm script and update `README.md` to document the added tests and protocol-compliance notes (`package.json`, `README.md`).

### Testing
- Ran `npm run build` which completed successfully and produced the compiled `dist/` output.
- Ran the test suite via `npm test` which executed `node --test dist/tests/*.test.js` and all tests passed (`4` tests; `0` failures).
- Tests included `runPromptLoop maps content_filter stop reason to refusal`, `runPromptLoop returns max_turn_requests after tool loop limit`, `read_file failures are reported with failed status`, and `run_command rejects empty command input`, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00690c320832b95b5dc6a9d434e31)