### PR TITLE
#4 - Implement Contribution Guide Steps

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none">
+  <path fill="currentColor" d="M2 2h12v2H4v8h6V9H8V7h6v7H2V2z"/>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.20.0",
-        "openai": "^6.34.0"
+        "openai": "^6.34.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "glm-acp-agent": "dist/index.js"
@@ -82,11 +83,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "peer": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.20.0",
-    "openai": "^6.34.0"
+    "openai": "^6.34.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,34 @@
+# Registry submission
+
+This directory holds the files that will be copied into a fork of
+[`agentclientprotocol/registry`](https://github.com/agentclientprotocol/registry)
+to list `glm-acp-agent` in the official ACP agent registry.
+
+## Submission steps
+
+The actions below are external to this repo and require credentials the agent
+process does not have, so they are executed by hand:
+
+1. **Publish the npm package**
+   ```sh
+   npm run build
+   npm publish --access public
+   npm view glm-acp-agent version   # confirm the version is live
+   ```
+
+2. **Fork** `agentclientprotocol/registry` and create a working branch.
+
+3. **Copy the contents of `registry/glm-acp-agent/`** in this repo into a
+   `glm-acp-agent/` directory at the registry repo root.
+
+4. **Validate locally** (from the registry repo root):
+   ```sh
+   uv run --with jsonschema .github/workflows/build_registry.py
+   SKIP_URL_VALIDATION=1 uv run --with jsonschema .github/workflows/build_registry.py
+   python3 .github/workflows/verify_agents.py --auth-check --agent glm-acp-agent
+   ```
+
+5. **Open a pull request** against `main`.
+
+The version in `agent.json` and the npm tag pinned in `distribution.npx.package`
+must match the version published to npm.

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -1,0 +1,14 @@
+{
+  "id": "glm-acp-agent",
+  "name": "GLM Agent",
+  "version": "1.0.0",
+  "description": "ACP agent powered by Zhipu AI's GLM model family (GLM-5.1, GLM-4.5, ...)",
+  "repository": "https://github.com/stefandevo/glm-acp-agent",
+  "authors": ["Stefan de Vogelaere"],
+  "license": "Apache-2.0",
+  "distribution": {
+    "npx": {
+      "package": "glm-acp-agent@1.0.0"
+    }
+  }
+}

--- a/registry/glm-acp-agent/icon.svg
+++ b/registry/glm-acp-agent/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none">
+  <path fill="currentColor" d="M2 2h12v2H4v8h6V9H8V7h6v7H2V2z"/>
+</svg>

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -104,9 +104,18 @@ export class GlmAcpAgent implements Agent {
         name: "glm-acp-agent",
         version: "1.0.0",
       },
-      // Declare an environment-variable auth method so clients that respect the
-      // auth-methods proposal know what to ask the user for.
+      // Advertise auth methods so the ACP registry verifier and capable
+      // clients can discover how to configure us. The `agent`-default method
+      // (no `type` discriminator) signals that the agent reads its credentials
+      // itself at startup; the experimental `env_var` method gives clients
+      // that support it the metadata to prompt the user for the right var.
       authMethods: [
+        {
+          id: "z-ai-api-key",
+          name: "Z.AI API key",
+          description:
+            "Set the Z_AI_API_KEY environment variable to authenticate. Generate one at https://z.ai/manage-apikey/apikey-list",
+        },
         {
           type: "env_var",
           id: "z_ai_api_key",

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -105,6 +105,14 @@ test("initialize returns negotiated protocol version, agent info, and auth metho
     (m) => (m as { type?: string }).type === "env_var"
   );
   assert.ok(envVarMethod, "env_var auth method should be advertised");
+  // The ACP registry verifier requires at least one method of type `agent`
+  // (no discriminator) or `terminal`. We advertise an `agent` method since
+  // the agent reads Z_AI_API_KEY itself at startup with no extra UI.
+  const agentMethod = result.authMethods?.find(
+    (m) => (m as { type?: string }).type === undefined
+  );
+  assert.ok(agentMethod, "agent-default auth method should be advertised");
+  assert.equal((agentMethod as { id: string }).id, "z-ai-api-key");
 });
 
 test("initialize negotiates lower protocol version when client requests one", async () => {


### PR DESCRIPTION
## Purpose

This feature prepares `glm-acp-agent` for submission to the official ACP agent registry (`agentclientprotocol/registry`). It closes the in-repo gaps the registry's CI gates would otherwise reject (auth method discovery, icon, broken test gate) and stages the ready-to-copy submission files.

## Key Changes

- Advertise an `agent`-default auth method (id `z-ai-api-key`) ahead of the existing `env_var` method in `initialize` so `verify_agents.py --auth-check` is satisfied. Capable clients still see the `env_var` method with full `Z_AI_API_KEY` metadata.
- Extend the initialize unit test to assert the new auth method is advertised.
- Add `zod ^3.25.0` as a runtime dependency — it's a peer dep of `@agentclientprotocol/sdk@0.20.0` and was missing, which made the SDK unloadable in tests (`agent.test.ts` and `integration.test.ts` were both failing on import).
- Add a 16×16 monochrome `icon.svg` at the repo root using only `fill="currentColor"`/`fill="none"` so it passes registry icon validation.
- Stage `registry/glm-acp-agent/` (`agent.json` + `icon.svg`) and a `registry/README.md` documenting the external steps (npm publish, fork, validate, PR).

## Checks

- [x] `npm run build` succeeds
- [x] `npm test` — 50/50 tests pass
- [x] Icon is 16×16, monochrome, `currentColor` only
- [x] No hardcoded colors in `icon.svg`
- [ ] External: `npm publish` the package so the registry's URL/package check passes (handled outside this PR)
- [ ] External: open the registry PR using files staged in `registry/`

## Task

[#4](https://github.com/stefandevo/glm-acp-agent/issues/4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Z.AI API key authentication method support.

* **Documentation**
  * Added agent registry submission instructions.

* **Tests**
  * Extended authentication method verification coverage.

* **Chores**
  * Added zod library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->