### PR TITLE
#5 - Another round to check feature parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ The agent connects to any ACP-compatible IDE or client over **stdio**, streams r
 
 ## Features
 
-- **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, and `session/list`
+- **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, `session/list`, `session/load`, `session/fork`, `session/resume`, and `session/set_model`
 - **Streaming** – assistant text and reasoning tokens are forwarded as incremental ACP chunks
 - **Tool calling** – agentic loop with up to 20 turns of GLM function calling
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
+- **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
+- **Image input** – `promptCapabilities.image` is advertised; image content blocks are forwarded as data-URL parts so vision-capable models (e.g. `glm-4v-plus`) can ingest them
+- **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Six built-in tools** (see below)
 - **Capability-aware** – every tool is gated on the client capabilities advertised at `initialize` time; tools the client can't run return a clear error to the model instead of crashing
 - **Permissioned writes / commands** – every `write_file` and `run_command` call asks the user via `session/request_permission` before doing anything
@@ -77,15 +80,28 @@ npm run build
 
 ## Configuration
 
-The agent is configured entirely through environment variables.
+The agent reads its configuration from environment variables, plus an optional credentials file written by `glm-acp-agent --setup`.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `Z_AI_API_KEY` | **Yes** | — | API key for the Z.AI / Zhipu AI service |
-| `ACP_GLM_MODEL` | No | `glm-5.1` | Override the GLM model |
+| `Z_AI_API_KEY` | One of env / `--setup` | — | API key for the Z.AI / Zhipu AI service. If unset, the credentials file is consulted. |
+| `ACP_GLM_MODEL` | No | `glm-5.1` | Default GLM model for new sessions |
+| `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
 | `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
 | `ACP_GLM_THINKING` | No | auto-detected | Force thinking mode `true` / `false` |
+| `ACP_GLM_SESSION_DIR` | No | `$XDG_STATE_HOME/glm-acp-agent/sessions` | Where session JSON files are persisted |
+| `XDG_CONFIG_HOME` | No | `~/.config` | Where the credentials file is read/written |
+
+### One-time setup
+
+If you'd rather not pass `Z_AI_API_KEY` through your ACP client's environment block, run the interactive setup once and the agent will read the key from disk on subsequent launches:
+
+```bash
+glm-acp-agent --setup
+```
+
+The key is written to `$XDG_CONFIG_HOME/glm-acp-agent/credentials.json` (default: `~/.config/glm-acp-agent/credentials.json`) with `0600` permissions. The `Z_AI_API_KEY` environment variable, when set, always wins over the file.
 
 ### Supported models
 
@@ -155,7 +171,12 @@ Any client that supports configuring an ACP agent via a `command` + `args` invoc
 
 ### Authentication
 
-The agent advertises a single `env_var` authentication method. ACP clients that support the auth-methods proposal will prompt the user for `Z_AI_API_KEY` automatically; clients that don't yet handle auth methods should set the variable themselves before launching the agent.
+The agent advertises two authentication methods at `initialize` time:
+
+1. An **`agent`-default** method — the agent will read the API key itself, either from the `Z_AI_API_KEY` environment variable or from the credentials file written by `glm-acp-agent --setup`.
+2. An **`env_var`** method (experimental SDK extension) describing the `Z_AI_API_KEY` variable so capable clients can prompt the user and inject it.
+
+ACP clients that support the auth-methods proposal will use whichever method they recognise; clients that don't handle auth methods should set `Z_AI_API_KEY` themselves before launching the agent (or run `glm-acp-agent --setup` once and let the agent read it from disk).
 
 ---
 
@@ -163,17 +184,21 @@ The agent advertises a single `env_var` authentication method. ACP clients that 
 
 ```text
 src/
-├── index.ts                  # Entry point – starts stdio connection
+├── index.ts                  # Entry point – starts stdio connection or --setup flow
+├── setup.ts                  # Interactive credential setup (`--setup`)
 ├── llm/
-│   └── glm-client.ts         # OpenAI-compatible client for Z.AI / Zhipu AI
+│   ├── glm-client.ts         # OpenAI-compatible client for Z.AI / Zhipu AI
+│   └── credentials.ts        # API-key resolution (env var > credentials.json)
 ├── protocol/
 │   ├── connection.ts         # Sets up the ACP stdio connection
-│   └── agent.ts              # GlmAcpAgent – ACP protocol implementation
+│   ├── agent.ts              # GlmAcpAgent – ACP protocol implementation
+│   └── session-store.ts      # On-disk persistence for load/fork/resume
 ├── tools/
 │   ├── definitions.ts        # Tool JSON schemas (function-calling format)
 │   └── executor.ts           # ToolExecutor – dispatches tool calls
 └── tests/
     ├── agent.test.ts         # Protocol-level tests for GlmAcpAgent
+    ├── credentials.test.ts   # Credential resolution and --setup persistence
     ├── executor.test.ts      # Tests for ToolExecutor
     ├── glm-client.test.ts    # Tests for streaming / tool-call assembly
     └── integration.test.ts   # End-to-end tests over the real ACP ndjson transport
@@ -206,7 +231,7 @@ The test suite covers:
 
 ## Troubleshooting
 
-- **`Z_AI_API_KEY environment variable is required but not set.`** — set the env var or configure your ACP client to forward it.
+- **`No API key found.`** — either set `Z_AI_API_KEY` in the environment, or run `glm-acp-agent --setup` once to store the key on disk.
 - **`HTTP 401: Invalid API key`** — your key is wrong or expired; rotate it on <https://z.ai/manage-apikey/apikey-list>.
 - **The agent says "client does not advertise the … capability".** — your ACP client doesn't expose that capability (e.g. terminal). Ask the model to use a different tool, or upgrade the client.
 - **Tools never get to run.** — make sure the client is sending the `clientCapabilities` field in `initialize`; the agent uses it to decide which tools to expose to the model.

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM model family (GLM-5.1, GLM-4.5, ...)",
+  "description": "ACP agent powered by Zhipu AI's GLM model family. Supports streaming, tool calls, mid-session model switching (session/set_model), image input on vision-capable models, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,21 +3,61 @@
  * GLM ACP Agent entry point.
  *
  * Starts an ACP agent over stdio that uses the Zhipu AI GLM model family
- * as its reasoning core.
+ * as its reasoning core. Pass `--setup` instead of starting the protocol
+ * loop to interactively store a Z.AI API key on disk.
  *
  * Environment variables:
- *   Z_AI_API_KEY      - (required) API key for the Z.AI / Zhipu AI service
- *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5-1)
+ *   Z_AI_API_KEY      - API key for the Z.AI / Zhipu AI service. If unset,
+ *                       falls back to the credentials file written by --setup.
+ *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.1)
  */
 import { startConnection } from "./protocol/connection.js";
+import { runSetup } from "./setup.js";
 
-const connection = startConnection();
+const args = process.argv.slice(2);
 
-// Keep the process alive until the connection closes
-connection.closed.then(() => {
+if (args.includes("--setup")) {
+  runSetup()
+    .then(() => process.exit(0))
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`Setup failed: ${message}\n`);
+      process.exit(1);
+    });
+} else if (args.includes("--help") || args.includes("-h")) {
+  process.stdout.write(
+    [
+      "glm-acp-agent — ACP agent using Zhipu AI's GLM models",
+      "",
+      "Usage:",
+      "  glm-acp-agent           Start the ACP stdio loop (run by an ACP client)",
+      "  glm-acp-agent --setup   Interactively store your Z.AI API key on disk",
+      "  glm-acp-agent --help    Show this message",
+      "",
+      "Environment variables:",
+      "  Z_AI_API_KEY                   API key (overrides the stored credentials)",
+      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.1)",
+      "  ACP_GLM_AVAILABLE_MODELS       Comma-separated list of advertised models",
+      "  ACP_GLM_BASE_URL               Override the Z.AI API base URL",
+      "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",
+      "  ACP_GLM_THINKING               Force thinking mode (true / false)",
+      "  ACP_GLM_SESSION_DIR            Where to persist sessions (default: ~/.local/state/glm-acp-agent/sessions)",
+      "  XDG_CONFIG_HOME                Where to read/write credentials.json (default: ~/.config)",
+      "",
+    ].join("\n")
+  );
   process.exit(0);
-}).catch((err: unknown) => {
-  const message = err instanceof Error ? err.message : String(err);
-  process.stderr.write(`Fatal error: ${message}\n`);
-  process.exit(1);
-});
+} else {
+  const connection = startConnection();
+
+  // Keep the process alive until the connection closes
+  connection.closed
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`Fatal error: ${message}\n`);
+      process.exit(1);
+    });
+}

--- a/src/llm/credentials.ts
+++ b/src/llm/credentials.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+/**
+ * Credential management for the Z.AI API key.
+ *
+ * Resolution order on startup:
+ *   1. `Z_AI_API_KEY` environment variable (highest priority — easiest for CI
+ *      and clients that pass env vars).
+ *   2. The credentials file written by `glm-acp-agent --setup`. This lets users
+ *      configure the agent once on their machine without leaking the key into
+ *      shell history.
+ *
+ * The credentials file lives under `$XDG_CONFIG_HOME/glm-acp-agent/credentials.json`
+ * (or `~/.config/glm-acp-agent/credentials.json` if `XDG_CONFIG_HOME` is unset).
+ */
+
+interface CredentialsFile {
+  z_ai_api_key?: string;
+}
+
+/** Path to the credentials JSON file. Honours `$XDG_CONFIG_HOME`. */
+export function credentialsPath(): string {
+  const xdg = process.env["XDG_CONFIG_HOME"];
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".config");
+  return join(base, "glm-acp-agent", "credentials.json");
+}
+
+/** Read the API key from the credentials file, returning undefined if absent. */
+export function readCredentialsKey(path: string = credentialsPath()): string | undefined {
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as CredentialsFile;
+    const key = parsed.z_ai_api_key;
+    return typeof key === "string" && key.length > 0 ? key : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the API key: env var > credentials file. Returns undefined when
+ * neither source has one set.
+ */
+export function resolveApiKey(): string | undefined {
+  const fromEnv = process.env["Z_AI_API_KEY"];
+  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
+  return readCredentialsKey();
+}
+
+/**
+ * Write the API key to the credentials file. Restricts the file to mode 0600
+ * so it isn't world-readable on shared machines.
+ */
+export function writeCredentials(apiKey: string, path: string = credentialsPath()): void {
+  if (!apiKey || apiKey.length === 0) {
+    throw new Error("Refusing to write empty API key");
+  }
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const body: CredentialsFile = { z_ai_api_key: apiKey };
+  writeFileSync(path, JSON.stringify(body, null, 2) + "\n", { mode: 0o600 });
+}

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -289,6 +289,5 @@ function parseThinking(model: string): boolean {
   if (override !== undefined) {
     return override.toLowerCase() === "true" || override === "1";
   }
-  const m = model.toLowerCase();
-  return /^glm-(4\.[567]|5)/.test(m) || m.startsWith("glm-5");
+  return /^glm-(?:4\.[567]|5)/i.test(model);
 }

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -1,7 +1,8 @@
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/resources/index.js";
-import type { Usage } from "@agentclientprotocol/sdk";
+import type { ModelInfo, Usage } from "@agentclientprotocol/sdk";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
+import { resolveApiKey } from "./credentials.js";
 
 /**
  * A single message in the GLM conversation history.
@@ -30,11 +31,76 @@ export interface GlmStreamChunk {
   stopReason?: string;
 }
 
+/** Options applied to a single `streamChat` call. */
+export interface StreamChatOptions {
+  /** GLM model identifier to use for this call. */
+  model: string;
+}
+
 /** Default base URL for the Z.AI / Zhipu OpenAI-compatible API. */
 const DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4";
 
-/** Default GLM model. */
-const DEFAULT_MODEL = "glm-5.1";
+/** Default GLM model when neither client nor user has chosen one. */
+export const DEFAULT_MODEL = "glm-5.1";
+
+/**
+ * Curated list of GLM models the agent advertises to ACP clients via
+ * `SessionModelState.availableModels`. Users can override this list via the
+ * `ACP_GLM_AVAILABLE_MODELS` environment variable (comma-separated model ids).
+ *
+ * The descriptions are intentionally short — clients render them in compact
+ * model pickers.
+ */
+const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
+  {
+    modelId: "glm-5.1",
+    name: "GLM-5.1",
+    description: "Latest GLM reasoning model with thinking mode",
+  },
+  {
+    modelId: "glm-4.6",
+    name: "GLM-4.6",
+    description: "General-purpose reasoning model",
+  },
+  {
+    modelId: "glm-4.5",
+    name: "GLM-4.5",
+    description: "Stable production model",
+  },
+  {
+    modelId: "glm-4.5-air",
+    name: "GLM-4.5 Air",
+    description: "Lightweight, lower-latency model",
+  },
+  {
+    modelId: "glm-4v-plus",
+    name: "GLM-4V Plus",
+    description: "Vision-capable multimodal model",
+  },
+];
+
+/**
+ * Resolve the list of advertised models, allowing the user to override the
+ * built-in list via `ACP_GLM_AVAILABLE_MODELS`.
+ */
+export function getAvailableModels(): ModelInfo[] {
+  const override = process.env["ACP_GLM_AVAILABLE_MODELS"];
+  if (!override) return BUILTIN_AVAILABLE_MODELS;
+  const ids = override
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (ids.length === 0) return BUILTIN_AVAILABLE_MODELS;
+  return ids.map((id) => {
+    const builtin = BUILTIN_AVAILABLE_MODELS.find((m) => m.modelId === id);
+    return builtin ?? { modelId: id, name: id };
+  });
+}
+
+/** Default model for new sessions: env override → built-in default. */
+export function getDefaultModel(): string {
+  return process.env["ACP_GLM_MODEL"] ?? DEFAULT_MODEL;
+}
 
 /**
  * Wrapper around the OpenAI-compatible Zhipu AI (Z.AI) API.
@@ -46,22 +112,18 @@ const DEFAULT_MODEL = "glm-5.1";
  */
 export class GlmClient {
   private client: OpenAI;
-  private model: string;
   private maxTokens: number;
-  private thinkingEnabled: boolean;
 
   constructor() {
-    const apiKey = process.env["Z_AI_API_KEY"];
+    const apiKey = resolveApiKey();
     if (!apiKey) {
       throw new Error(
-        "Z_AI_API_KEY environment variable is required but not set."
+        "No API key found. Set the Z_AI_API_KEY environment variable, or run `glm-acp-agent --setup` to store one."
       );
     }
 
-    this.model = process.env["ACP_GLM_MODEL"] ?? DEFAULT_MODEL;
     const baseURL = process.env["ACP_GLM_BASE_URL"] ?? DEFAULT_BASE_URL;
     this.maxTokens = parseIntEnv("ACP_GLM_MAX_TOKENS", 8192);
-    this.thinkingEnabled = parseThinking(this.model);
 
     this.client = new OpenAI({ apiKey, baseURL });
   }
@@ -75,8 +137,11 @@ export class GlmClient {
    */
   async *streamChat(
     messages: GlmMessage[],
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options?: StreamChatOptions
   ): AsyncGenerator<GlmStreamChunk> {
+    const model = options?.model ?? getDefaultModel();
+    const thinkingEnabled = parseThinking(model);
     const tools: ChatCompletionTool[] = TOOL_DEFINITIONS.map((t) => ({
       type: "function" as const,
       function: {
@@ -89,13 +154,13 @@ export class GlmClient {
     // The OpenAI SDK forwards unknown extra body fields verbatim, so we use
     // that to pass GLM-specific fields like `thinking`.
     const extraBody: Record<string, unknown> = {};
-    if (this.thinkingEnabled) {
+    if (thinkingEnabled) {
       extraBody["thinking"] = { type: "enabled" };
     }
 
     const stream = await this.client.chat.completions.create(
       {
-        model: this.model,
+        model,
         messages,
         tools,
         tool_choice: "auto",

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -17,13 +17,24 @@ import type {
   CloseSessionRequest,
   ListSessionsRequest,
   ListSessionsResponse,
+  SetSessionModelRequest,
+  SetSessionModelResponse,
+  ModelInfo,
   StopReason,
   Usage,
 } from "@agentclientprotocol/sdk";
 import { PROTOCOL_VERSION as VERSION } from "@agentclientprotocol/sdk";
-import { GlmClient, type GlmMessage, type GlmStreamChunk } from "../llm/glm-client.js";
+import {
+  GlmClient,
+  getAvailableModels,
+  getDefaultModel,
+  type GlmMessage,
+  type GlmStreamChunk,
+  type StreamChatOptions,
+} from "../llm/glm-client.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
+import { SessionStore, type PersistedSession } from "./session-store.js";
 
 /** Per-session state */
 interface SessionState {
@@ -38,6 +49,8 @@ interface SessionState {
   promptPromise: Promise<void> | null;
   title: string | null;
   updatedAt: string;
+  /** Active model for this session (clients can change via `session/set_model`). */
+  model: string;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -48,9 +61,22 @@ type InternalStopReason = StopReason;
  */
 export interface GlmAcpAgentOptions {
   /** Override the GLM client (used in tests). */
-  glm?: { streamChat: (messages: GlmMessage[], signal?: AbortSignal) => AsyncIterable<GlmStreamChunk> };
+  glm?: {
+    streamChat: (
+      messages: GlmMessage[],
+      signal?: AbortSignal,
+      options?: StreamChatOptions
+    ) => AsyncIterable<GlmStreamChunk>;
+  };
   /** Maximum number of model/tool turns per single prompt. Default 20. */
   maxTurns?: number;
+  /**
+   * Override the session store (used in tests). When undefined the agent
+   * uses an on-disk store rooted at `$ACP_GLM_SESSION_DIR` /
+   * `$XDG_STATE_HOME/glm-acp-agent/sessions` / `~/.local/state/glm-acp-agent/sessions`.
+   * Pass `null` to disable persistence entirely.
+   */
+  sessionStore?: SessionStore | null;
 }
 
 /**
@@ -65,6 +91,7 @@ export class GlmAcpAgent implements Agent {
   private _glm: NonNullable<GlmAcpAgentOptions["glm"]> | null;
   private maxTurns: number;
   private clientCapabilities: ClientCapabilities | null = null;
+  private sessionStore: SessionStore | null;
 
   constructor(
     private connection: AgentSideConnection,
@@ -76,6 +103,10 @@ export class GlmAcpAgent implements Agent {
       Number.isFinite(candidateMaxTurns) && candidateMaxTurns > 0
         ? Math.floor(candidateMaxTurns)
         : 20;
+    this.sessionStore =
+      options.sessionStore === null
+        ? null
+        : (options.sessionStore ?? new SessionStore());
   }
 
   private get glm(): NonNullable<GlmAcpAgentOptions["glm"]> {
@@ -114,7 +145,7 @@ export class GlmAcpAgent implements Agent {
           id: "z-ai-api-key",
           name: "Z.AI API key",
           description:
-            "Set the Z_AI_API_KEY environment variable to authenticate. Generate one at https://z.ai/manage-apikey/apikey-list",
+            "Set Z_AI_API_KEY in the environment, or run `glm-acp-agent --setup` once to store the key on disk. Generate one at https://z.ai/manage-apikey/apikey-list",
         },
         {
           type: "env_var",
@@ -134,15 +165,19 @@ export class GlmAcpAgent implements Agent {
         },
       ],
       agentCapabilities: {
-        loadSession: false,
+        loadSession: true,
         promptCapabilities: {
           // Baseline (text + resource_link) is implicit; we additionally accept
-          // embedded resources for inline file context.
+          // embedded resources for inline file context, plus images for
+          // vision-capable GLM models (e.g. glm-4v-plus).
           embeddedContext: true,
+          image: true,
         },
         sessionCapabilities: {
           close: {},
           list: {},
+          fork: {},
+          resume: {},
         },
       },
     };
@@ -173,6 +208,8 @@ export class GlmAcpAgent implements Agent {
         `Working directory: ${params.cwd}`,
     };
 
+    const model = getDefaultModel();
+
     this.sessions.set(sessionId, {
       cwd: params.cwd,
       messages: [systemPrompt],
@@ -180,9 +217,45 @@ export class GlmAcpAgent implements Agent {
       promptPromise: null,
       title: null,
       updatedAt: new Date().toISOString(),
+      model,
     });
 
-    return { sessionId };
+    return {
+      sessionId,
+      models: this.modelsState(model),
+    };
+  }
+
+  async unstable_setSessionModel(
+    params: SetSessionModelRequest
+  ): Promise<SetSessionModelResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${params.sessionId}`);
+    }
+    const available = getAvailableModels();
+    const known = available.find((m) => m.modelId === params.modelId);
+    if (!known) {
+      // Allow the caller to pick any model id even if not in the curated list
+      // (Z.AI may offer models we haven't catalogued), but log a stderr hint.
+      process.stderr.write(
+        `[glm-acp-agent] warning: model "${params.modelId}" is not in the advertised list; using as-is.\n`
+      );
+    }
+    session.model = params.modelId;
+    session.updatedAt = new Date().toISOString();
+    return {};
+  }
+
+  /** Build the SessionModelState we advertise on session create/load/resume/fork. */
+  private modelsState(currentModelId: string): {
+    availableModels: ModelInfo[];
+    currentModelId: string;
+  } {
+    return {
+      availableModels: getAvailableModels(),
+      currentModelId,
+    };
   }
 
   async setSessionMode(
@@ -231,10 +304,14 @@ export class GlmAcpAgent implements Agent {
       abortController.abort();
     }
 
-    // Convert ACP content blocks into a GLM user message.
-    // Baseline: text + resource_link. Optional: embedded resources (text only).
-    const userText = renderPromptBlocks(params.prompt);
-    session.messages.push({ role: "user", content: userText });
+    // Convert ACP content blocks into a GLM user message. Baseline: text +
+    // resource_link. Optional: embedded resources, plus image blocks (forwarded
+    // as OpenAI-shaped data-URL parts so vision-capable GLM models like
+    // glm-4v-plus can ingest them).
+    const { content: userContent, plainText: userText } = renderPromptBlocks(
+      params.prompt
+    );
+    session.messages.push({ role: "user", content: userContent });
 
     // Echo back the client-supplied messageId on every response (success,
     // cancelled, or error) so the client can correlate the turn.
@@ -274,6 +351,8 @@ export class GlmAcpAgent implements Agent {
           ...titleUpdate,
         },
       });
+
+      this.persistSession(params.sessionId, session);
 
       const response: PromptResponse = { stopReason };
       if (usage) response.usage = usage;
@@ -316,15 +395,46 @@ export class GlmAcpAgent implements Agent {
   async closeSession(params: CloseSessionRequest): Promise<void> {
     const session = this.sessions.get(params.sessionId);
     session?.abortController?.abort();
+    if (session) {
+      // Persist final state on close so a subsequent loadSession/resume can
+      // pick the conversation back up. closeSession only releases in-memory
+      // resources; the on-disk record is intentionally retained.
+      this.persistSession(params.sessionId, session);
+    }
     this.sessions.delete(params.sessionId);
   }
 
   async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
-    const allSessions = Array.from(this.sessions.entries());
+    // Merge in-memory sessions with anything previously persisted to disk. The
+    // store is the source of truth for closed/restarted sessions; in-memory
+    // state takes precedence when both exist (it has the freshest title /
+    // updatedAt before persistence has fired).
+    const merged = new Map<
+      string,
+      { cwd: string; title: string | null; updatedAt: string }
+    >();
 
+    if (this.sessionStore) {
+      for (const persisted of this.sessionStore.list()) {
+        merged.set(persisted.sessionId, {
+          cwd: persisted.cwd,
+          title: persisted.title,
+          updatedAt: persisted.updatedAt,
+        });
+      }
+    }
+    for (const [sessionId, s] of this.sessions) {
+      merged.set(sessionId, {
+        cwd: s.cwd,
+        title: s.title,
+        updatedAt: s.updatedAt,
+      });
+    }
+
+    const all = Array.from(merged.entries());
     const filtered = params.cwd
-      ? allSessions.filter(([, s]) => s.cwd === params.cwd)
-      : allSessions;
+      ? all.filter(([, s]) => s.cwd === params.cwd)
+      : all;
 
     return {
       sessions: filtered.map(([sessionId, s]) => ({
@@ -334,6 +444,170 @@ export class GlmAcpAgent implements Agent {
         updatedAt: s.updatedAt,
       })),
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Session load / fork / resume
+  // ---------------------------------------------------------------------------
+
+  async loadSession(
+    params: import("@agentclientprotocol/sdk").LoadSessionRequest
+  ): Promise<import("@agentclientprotocol/sdk").LoadSessionResponse> {
+    const persisted = this.requirePersisted(params.sessionId);
+
+    // Restore in-memory state. We do NOT carry over the abortController /
+    // promptPromise — those are transient.
+    const restored: SessionState = {
+      cwd: params.cwd,
+      messages: persisted.messages,
+      abortController: null,
+      promptPromise: null,
+      title: persisted.title,
+      updatedAt: persisted.updatedAt,
+      model: persisted.model,
+    };
+    this.sessions.set(params.sessionId, restored);
+
+    // Replay user/assistant text turns so the client can rehydrate its UI.
+    // Tool / system messages are skipped — they're internal and the client
+    // doesn't render them on its own.
+    await this.replayMessages(params.sessionId, persisted.messages);
+
+    return { models: this.modelsState(persisted.model) };
+  }
+
+  async unstable_forkSession(
+    params: import("@agentclientprotocol/sdk").ForkSessionRequest
+  ): Promise<import("@agentclientprotocol/sdk").ForkSessionResponse> {
+    const source = this.sessions.get(params.sessionId);
+    const persisted = source
+      ? this.snapshot(params.sessionId, source)
+      : this.requirePersisted(params.sessionId);
+
+    const newSessionId = randomUUID();
+    const forkedTitle =
+      persisted.title === null ? null : `${persisted.title} (fork)`;
+    const forked: SessionState = {
+      cwd: params.cwd,
+      // Deep-clone messages so the fork doesn't share state with the parent.
+      messages: JSON.parse(JSON.stringify(persisted.messages)) as GlmMessage[],
+      abortController: null,
+      promptPromise: null,
+      title: forkedTitle,
+      updatedAt: new Date().toISOString(),
+      model: persisted.model,
+    };
+    this.sessions.set(newSessionId, forked);
+    this.persistSession(newSessionId, forked);
+
+    return {
+      sessionId: newSessionId,
+      models: this.modelsState(forked.model),
+    };
+  }
+
+  async resumeSession(
+    params: import("@agentclientprotocol/sdk").ResumeSessionRequest
+  ): Promise<import("@agentclientprotocol/sdk").ResumeSessionResponse> {
+    const persisted = this.requirePersisted(params.sessionId);
+
+    const restored: SessionState = {
+      cwd: params.cwd,
+      messages: persisted.messages,
+      abortController: null,
+      promptPromise: null,
+      title: persisted.title,
+      updatedAt: persisted.updatedAt,
+      model: persisted.model,
+    };
+    this.sessions.set(params.sessionId, restored);
+
+    // Resume does NOT replay history — the client keeps its own UI state and
+    // just wants the agent to pick up where it left off.
+    return { models: this.modelsState(persisted.model) };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence helpers
+  // ---------------------------------------------------------------------------
+
+  private snapshot(sessionId: string, session: SessionState): PersistedSession {
+    return {
+      sessionId,
+      cwd: session.cwd,
+      messages: session.messages,
+      title: session.title,
+      updatedAt: session.updatedAt,
+      model: session.model,
+    };
+  }
+
+  private persistSession(sessionId: string, session: SessionState): void {
+    if (!this.sessionStore) return;
+    try {
+      this.sessionStore.save(this.snapshot(sessionId, session));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[glm-acp-agent] warning: failed to persist session ${sessionId}: ${msg}\n`
+      );
+    }
+  }
+
+  private requirePersisted(sessionId: string): PersistedSession {
+    if (!this.sessionStore) {
+      throw new Error("Session persistence is disabled");
+    }
+    const persisted = this.sessionStore.load(sessionId);
+    if (!persisted) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    return persisted;
+  }
+
+  private async replayMessages(
+    sessionId: string,
+    messages: GlmMessage[]
+  ): Promise<void> {
+    for (const msg of messages) {
+      if (msg.role === "user") {
+        const text = stringifyUserMessage(msg.content);
+        if (text.length === 0) continue;
+        await this.connection.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "user_message_chunk",
+            content: { type: "text", text },
+          },
+        });
+      } else if (msg.role === "assistant") {
+        const content = msg.content;
+        const text =
+          typeof content === "string"
+            ? content
+            : Array.isArray(content)
+              ? content
+                  .filter(
+                    (p): p is { type: "text"; text: string } =>
+                      typeof p === "object" &&
+                      p !== null &&
+                      (p as { type?: unknown }).type === "text" &&
+                      typeof (p as { text?: unknown }).text === "string"
+                  )
+                  .map((p) => p.text)
+                  .join("")
+              : "";
+        if (text.length === 0) continue;
+        await this.connection.sessionUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text },
+          },
+        });
+      }
+      // system / tool messages are not replayed — they're internal.
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -371,8 +645,11 @@ export class GlmAcpAgent implements Agent {
       let assistantText = "";
       let lastStopReason: string | undefined;
 
-      // Stream the GLM response.
-      for await (const chunk of this.glm.streamChat(session.messages, signal)) {
+      // Stream the GLM response. The session's currently-selected model wins;
+      // it's mutated by `unstable_setSessionModel` between turns.
+      for await (const chunk of this.glm.streamChat(session.messages, signal, {
+        model: session.model,
+      })) {
         if (signal.aborted) return { stopReason: "cancelled" };
 
         if (chunk.thinking) {
@@ -490,37 +767,97 @@ export class GlmAcpAgent implements Agent {
   }
 }
 
-/** Render a list of ACP content blocks into a single user message string. */
-function renderPromptBlocks(blocks: PromptRequest["prompt"]): string {
-  const parts: string[] = [];
+/** OpenAI-shaped content part for multimodal user messages. */
+type UserContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+/**
+ * Render a list of ACP content blocks into a GLM user message.
+ *
+ * When the prompt contains only text/resource blocks we return a plain string
+ * (the broadest-compatible shape). When at least one image block is present
+ * we switch to OpenAI's multimodal array shape so vision-capable GLM models
+ * receive the image as a data URL.
+ *
+ * `plainText` always contains the text-only flattening of the prompt and is
+ * used by the agent to derive a session title.
+ */
+function renderPromptBlocks(blocks: PromptRequest["prompt"]): {
+  content: string | UserContentPart[];
+  plainText: string;
+} {
+  const textParts: string[] = [];
+  const imageParts: UserContentPart[] = [];
+
   for (const block of blocks) {
     switch (block.type) {
       case "text":
-        parts.push(block.text);
+        textParts.push(block.text);
         break;
       case "resource_link":
-        parts.push(`[${block.name}](${block.uri})`);
+        textParts.push(`[${block.name}](${block.uri})`);
         break;
       case "resource": {
         const res = block.resource;
         if ("text" in res && typeof res.text === "string") {
-          parts.push(`<resource uri="${res.uri}">\n${res.text}\n</resource>`);
+          textParts.push(`<resource uri="${res.uri}">\n${res.text}\n</resource>`);
         } else if ("blob" in res) {
           // Binary resources can't be inlined into a chat message; keep a link
           // reference so the model knows it exists.
-          parts.push(`[binary resource](${res.uri})`);
+          textParts.push(`[binary resource](${res.uri})`);
         }
         break;
       }
-      case "image":
+      case "image": {
+        const dataUrl = `data:${block.mimeType};base64,${block.data}`;
+        imageParts.push({ type: "image_url", image_url: { url: dataUrl } });
+        break;
+      }
       case "audio":
-        // We don't advertise image/audio capabilities, but defensively render
-        // a placeholder so a misbehaving client doesn't crash the agent.
-        parts.push(`[unsupported ${block.type} block]`);
+        textParts.push("[unsupported audio block]");
         break;
       default:
-        // Future block types: best-effort placeholder.
-        parts.push(`[unknown block type ${(block as { type: string }).type}]`);
+        textParts.push(`[unknown block type ${(block as { type: string }).type}]`);
+    }
+  }
+
+  const plainText = textParts.join("\n");
+
+  if (imageParts.length === 0) {
+    return { content: plainText, plainText };
+  }
+
+  // Multimodal: combine text + images. OpenAI requires at least one part, so
+  // we always include the text part (even when empty, the array form is valid).
+  const content: UserContentPart[] = [];
+  if (plainText.length > 0) {
+    content.push({ type: "text", text: plainText });
+  }
+  content.push(...imageParts);
+  return { content, plainText };
+}
+
+/**
+ * Flatten the `content` of a user message into a plain string for replay.
+ *
+ * Multimodal user messages (text + image parts) are rendered as their text
+ * portions only; images are noted with a placeholder so the client knows
+ * something visual was there but doesn't try to re-render an opaque
+ * `image_url` part it never produced.
+ */
+function stringifyUserMessage(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    if (typeof part !== "object" || part === null) continue;
+    const type = (part as { type?: unknown }).type;
+    if (type === "text") {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string") parts.push(text);
+    } else if (type === "image_url") {
+      parts.push("[image]");
     }
   }
   return parts.join("\n");

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -17,6 +17,12 @@ import type {
   CloseSessionRequest,
   ListSessionsRequest,
   ListSessionsResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  ForkSessionRequest,
+  ForkSessionResponse,
+  ResumeSessionRequest,
+  ResumeSessionResponse,
   SetSessionModelRequest,
   SetSessionModelResponse,
   ModelInfo,
@@ -186,9 +192,10 @@ export class GlmAcpAgent implements Agent {
   async authenticate(
     _params: AuthenticateRequest
   ): Promise<AuthenticateResponse> {
-    // Authentication is configured via the Z_AI_API_KEY environment variable
-    // (advertised as an `env_var` auth method). The agent has nothing to do
-    // here; failures will surface when the model is first called.
+    // Authentication is configured externally — either via Z_AI_API_KEY in the
+    // environment or via the credentials file written by `glm-acp-agent --setup`.
+    // The agent has nothing to do here; failures will surface when the model
+    // is first called.
     return {};
   }
 
@@ -244,6 +251,15 @@ export class GlmAcpAgent implements Agent {
     }
     session.model = params.modelId;
     session.updatedAt = new Date().toISOString();
+    // Notify clients so any UI that displays the active model refreshes
+    // immediately, instead of waiting for the next prompt to complete.
+    await safeSessionUpdate(this.connection, {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "session_info_update",
+        updatedAt: session.updatedAt,
+      },
+    });
     return {};
   }
 
@@ -409,17 +425,20 @@ export class GlmAcpAgent implements Agent {
     // store is the source of truth for closed/restarted sessions; in-memory
     // state takes precedence when both exist (it has the freshest title /
     // updatedAt before persistence has fired).
+    //
+    // We use the metadata-only store API so we don't load every conversation's
+    // full message history just to render a session picker.
     const merged = new Map<
       string,
       { cwd: string; title: string | null; updatedAt: string }
     >();
 
     if (this.sessionStore) {
-      for (const persisted of this.sessionStore.list()) {
-        merged.set(persisted.sessionId, {
-          cwd: persisted.cwd,
-          title: persisted.title,
-          updatedAt: persisted.updatedAt,
+      for (const meta of this.sessionStore.listMetadata()) {
+        merged.set(meta.sessionId, {
+          cwd: meta.cwd,
+          title: meta.title,
+          updatedAt: meta.updatedAt,
         });
       }
     }
@@ -435,6 +454,10 @@ export class GlmAcpAgent implements Agent {
     const filtered = params.cwd
       ? all.filter(([, s]) => s.cwd === params.cwd)
       : all;
+    // Newest-first so clients can render the picker without re-sorting.
+    filtered.sort(([, a], [, b]) =>
+      a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0
+    );
 
     return {
       sessions: filtered.map(([sessionId, s]) => ({
@@ -450,9 +473,7 @@ export class GlmAcpAgent implements Agent {
   // Session load / fork / resume
   // ---------------------------------------------------------------------------
 
-  async loadSession(
-    params: import("@agentclientprotocol/sdk").LoadSessionRequest
-  ): Promise<import("@agentclientprotocol/sdk").LoadSessionResponse> {
+  async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
     const persisted = this.requirePersisted(params.sessionId);
 
     // Restore in-memory state. We do NOT carry over the abortController /
@@ -477,8 +498,8 @@ export class GlmAcpAgent implements Agent {
   }
 
   async unstable_forkSession(
-    params: import("@agentclientprotocol/sdk").ForkSessionRequest
-  ): Promise<import("@agentclientprotocol/sdk").ForkSessionResponse> {
+    params: ForkSessionRequest
+  ): Promise<ForkSessionResponse> {
     const source = this.sessions.get(params.sessionId);
     const persisted = source
       ? this.snapshot(params.sessionId, source)
@@ -490,7 +511,7 @@ export class GlmAcpAgent implements Agent {
     const forked: SessionState = {
       cwd: params.cwd,
       // Deep-clone messages so the fork doesn't share state with the parent.
-      messages: JSON.parse(JSON.stringify(persisted.messages)) as GlmMessage[],
+      messages: structuredClone(persisted.messages),
       abortController: null,
       promptPromise: null,
       title: forkedTitle,
@@ -507,8 +528,8 @@ export class GlmAcpAgent implements Agent {
   }
 
   async resumeSession(
-    params: import("@agentclientprotocol/sdk").ResumeSessionRequest
-  ): Promise<import("@agentclientprotocol/sdk").ResumeSessionResponse> {
+    params: ResumeSessionRequest
+  ): Promise<ResumeSessionResponse> {
     const persisted = this.requirePersisted(params.sessionId);
 
     const restored: SessionState = {

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -70,9 +70,11 @@ export class SessionStore {
   save(session: PersistedSession): void {
     mkdirSync(this.dir, { recursive: true, mode: 0o700 });
     const path = this.pathFor(session.sessionId);
+    // Write the schema version *after* the spread so the constant always wins,
+    // even if a caller accidentally sets `schemaVersion` on the input.
     const body: PersistedSession = {
-      schemaVersion: SESSION_SCHEMA_VERSION,
       ...session,
+      schemaVersion: SESSION_SCHEMA_VERSION,
     };
     writeFileSync(path, JSON.stringify(body, null, 2) + "\n", { mode: 0o600 });
   }

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -4,14 +4,32 @@ import { join } from "node:path";
 import type { GlmMessage } from "../llm/glm-client.js";
 
 /**
+ * Schema version embedded in every persisted session file. Bump whenever the
+ * shape of `PersistedSession` changes incompatibly so future loaders can
+ * migrate (or reject) old records instead of silently producing garbage.
+ */
+export const SESSION_SCHEMA_VERSION = 1 as const;
+
+/**
  * On-disk representation of a session. Only fields that need to survive a
  * process restart are persisted — `abortController` / `promptPromise` are
  * transient state that has no meaning across processes.
  */
 export interface PersistedSession {
+  /** Schema version of this on-disk record (see SESSION_SCHEMA_VERSION). */
+  schemaVersion?: number;
   sessionId: string;
   cwd: string;
   messages: GlmMessage[];
+  title: string | null;
+  updatedAt: string;
+  model: string;
+}
+
+/** Light-weight summary of a persisted session — used by `listSessions`. */
+export interface PersistedSessionMetadata {
+  sessionId: string;
+  cwd: string;
   title: string | null;
   updatedAt: string;
   model: string;
@@ -52,7 +70,11 @@ export class SessionStore {
   save(session: PersistedSession): void {
     mkdirSync(this.dir, { recursive: true, mode: 0o700 });
     const path = this.pathFor(session.sessionId);
-    writeFileSync(path, JSON.stringify(session, null, 2) + "\n", { mode: 0o600 });
+    const body: PersistedSession = {
+      schemaVersion: SESSION_SCHEMA_VERSION,
+      ...session,
+    };
+    writeFileSync(path, JSON.stringify(body, null, 2) + "\n", { mode: 0o600 });
   }
 
   /** Load a session by id, returning undefined if no such file exists. */
@@ -63,25 +85,49 @@ export class SessionStore {
     } catch {
       return undefined;
     }
-    const parsed = JSON.parse(raw) as PersistedSession;
+    let parsed: PersistedSession;
+    try {
+      parsed = JSON.parse(raw) as PersistedSession;
+    } catch {
+      return undefined;
+    }
+    // Drop records we don't know how to read. Today there's only one schema,
+    // so an unknown version is almost certainly a forward-incompatible record
+    // written by a newer agent build.
+    const version = parsed.schemaVersion ?? SESSION_SCHEMA_VERSION;
+    if (version !== SESSION_SCHEMA_VERSION) return undefined;
     return parsed;
   }
 
-  /** List all persisted sessions (lightweight metadata only). */
-  list(): PersistedSession[] {
+  /**
+   * List metadata for all persisted sessions, sorted newest-first by
+   * `updatedAt`. This is the hot path for `session/list`; we still parse each
+   * file (single-file-per-session has no shared index), but discard the
+   * `messages` array immediately so memory usage scales with the number of
+   * sessions, not their length.
+   */
+  listMetadata(): PersistedSessionMetadata[] {
     let entries: string[];
     try {
       entries = readdirSync(this.dir);
     } catch {
       return [];
     }
-    const out: PersistedSession[] = [];
+    const out: PersistedSessionMetadata[] = [];
     for (const name of entries) {
       if (!name.endsWith(".json")) continue;
       const sessionId = name.slice(0, -".json".length);
       const sess = this.load(sessionId);
-      if (sess) out.push(sess);
+      if (!sess) continue;
+      out.push({
+        sessionId: sess.sessionId,
+        cwd: sess.cwd,
+        title: sess.title,
+        updatedAt: sess.updatedAt,
+        model: sess.model,
+      });
     }
+    out.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0));
     return out;
   }
 }

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { GlmMessage } from "../llm/glm-client.js";
+
+/**
+ * On-disk representation of a session. Only fields that need to survive a
+ * process restart are persisted — `abortController` / `promptPromise` are
+ * transient state that has no meaning across processes.
+ */
+export interface PersistedSession {
+  sessionId: string;
+  cwd: string;
+  messages: GlmMessage[];
+  title: string | null;
+  updatedAt: string;
+  model: string;
+}
+
+/** Resolve the directory we write session files to, honouring overrides. */
+function defaultSessionDir(): string {
+  const explicit = process.env["ACP_GLM_SESSION_DIR"];
+  if (explicit && explicit.length > 0) return explicit;
+  const xdg = process.env["XDG_STATE_HOME"];
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "state");
+  return join(base, "glm-acp-agent", "sessions");
+}
+
+/**
+ * File-backed session store. Each session lives in its own JSON file so we can
+ * grow/shrink linearly with the number of conversations and avoid locking a
+ * single shared file.
+ */
+export class SessionStore {
+  private dir: string;
+
+  constructor(dir: string = defaultSessionDir()) {
+    this.dir = dir;
+  }
+
+  /** Resolve the path for a given sessionId. */
+  private pathFor(sessionId: string): string {
+    // sessionId is generated via randomUUID() so it's path-safe; reject
+    // anything else defensively to avoid path traversal.
+    if (!/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
+      throw new Error(`Invalid sessionId: ${sessionId}`);
+    }
+    return join(this.dir, `${sessionId}.json`);
+  }
+
+  /** Persist a session, creating directories as needed. */
+  save(session: PersistedSession): void {
+    mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    const path = this.pathFor(session.sessionId);
+    writeFileSync(path, JSON.stringify(session, null, 2) + "\n", { mode: 0o600 });
+  }
+
+  /** Load a session by id, returning undefined if no such file exists. */
+  load(sessionId: string): PersistedSession | undefined {
+    let raw: string;
+    try {
+      raw = readFileSync(this.pathFor(sessionId), "utf8");
+    } catch {
+      return undefined;
+    }
+    const parsed = JSON.parse(raw) as PersistedSession;
+    return parsed;
+  }
+
+  /** List all persisted sessions (lightweight metadata only). */
+  list(): PersistedSession[] {
+    let entries: string[];
+    try {
+      entries = readdirSync(this.dir);
+    } catch {
+      return [];
+    }
+    const out: PersistedSession[] = [];
+    for (const name of entries) {
+      if (!name.endsWith(".json")) continue;
+      const sessionId = name.slice(0, -".json".length);
+      const sess = this.load(sessionId);
+      if (sess) out.push(sess);
+    }
+    return out;
+  }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,33 @@
+import { createInterface } from "node:readline/promises";
+import { credentialsPath, writeCredentials } from "./llm/credentials.js";
+
+/**
+ * Interactive setup flow that prompts the user for a Z.AI API key on stdin and
+ * persists it to the credentials file. Invoked when the binary is run with
+ * `--setup` so users can configure the agent without leaking the key into
+ * their shell history.
+ */
+export async function runSetup(input: NodeJS.ReadableStream = process.stdin, output: NodeJS.WritableStream = process.stdout): Promise<void> {
+  const path = credentialsPath();
+
+  output.write("GLM ACP agent setup\n");
+  output.write("===================\n\n");
+  output.write("Get a Z.AI API key from https://z.ai/manage-apikey/apikey-list\n\n");
+
+  const rl = createInterface({ input, output, terminal: false });
+  let apiKey: string;
+  try {
+    const answer = await rl.question("Z_AI_API_KEY: ");
+    apiKey = answer.trim();
+  } finally {
+    rl.close();
+  }
+
+  if (apiKey.length === 0) {
+    throw new Error("No API key entered; aborting setup.");
+  }
+
+  writeCredentials(apiKey);
+  output.write(`\nAPI key saved to ${path}\n`);
+  output.write("You can now run `glm-acp-agent` from your ACP client.\n");
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -59,8 +59,18 @@ async function readSecret(
     let buf = "";
     const cleanup = () => {
       stream.off("data", onData);
+      stream.off("close", onClose);
+      stream.off("error", onError);
       stream.setRawMode(false);
       stream.pause();
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("Input stream closed before a key was entered."));
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
     };
     const onData = (data: Buffer | string) => {
       const chunk = typeof data === "string" ? data : data.toString("utf8");
@@ -92,5 +102,7 @@ async function readSecret(
       }
     };
     stream.on("data", onData);
+    stream.on("close", onClose);
+    stream.on("error", onError);
   });
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -7,21 +7,17 @@ import { credentialsPath, writeCredentials } from "./llm/credentials.js";
  * `--setup` so users can configure the agent without leaking the key into
  * their shell history.
  */
-export async function runSetup(input: NodeJS.ReadableStream = process.stdin, output: NodeJS.WritableStream = process.stdout): Promise<void> {
+export async function runSetup(
+  input: NodeJS.ReadableStream = process.stdin,
+  output: NodeJS.WritableStream = process.stdout
+): Promise<void> {
   const path = credentialsPath();
 
   output.write("GLM ACP agent setup\n");
   output.write("===================\n\n");
   output.write("Get a Z.AI API key from https://z.ai/manage-apikey/apikey-list\n\n");
 
-  const rl = createInterface({ input, output, terminal: false });
-  let apiKey: string;
-  try {
-    const answer = await rl.question("Z_AI_API_KEY: ");
-    apiKey = answer.trim();
-  } finally {
-    rl.close();
-  }
+  const apiKey = (await readSecret(input, output, "Z_AI_API_KEY: ")).trim();
 
   if (apiKey.length === 0) {
     throw new Error("No API key entered; aborting setup.");
@@ -30,4 +26,71 @@ export async function runSetup(input: NodeJS.ReadableStream = process.stdin, out
   writeCredentials(apiKey);
   output.write(`\nAPI key saved to ${path}\n`);
   output.write("You can now run `glm-acp-agent` from your ACP client.\n");
+}
+
+/**
+ * Read a single line from `input`, masking each character with `*` when stdin
+ * is a TTY so the typed key doesn't appear in scrollback. When stdin is piped
+ * (the common test/CI case) we fall back to a plain readline read — the key
+ * isn't on a screen anyway.
+ */
+async function readSecret(
+  input: NodeJS.ReadableStream,
+  output: NodeJS.WritableStream,
+  prompt: string
+): Promise<string> {
+  const stream = input as NodeJS.ReadStream;
+  const isTTY = stream.isTTY === true && typeof stream.setRawMode === "function";
+
+  if (!isTTY) {
+    const rl = createInterface({ input, output, terminal: false });
+    try {
+      return await rl.question(prompt);
+    } finally {
+      rl.close();
+    }
+  }
+
+  output.write(prompt);
+  stream.setRawMode(true);
+  stream.resume();
+
+  return new Promise<string>((resolve, reject) => {
+    let buf = "";
+    const cleanup = () => {
+      stream.off("data", onData);
+      stream.setRawMode(false);
+      stream.pause();
+    };
+    const onData = (data: Buffer | string) => {
+      const chunk = typeof data === "string" ? data : data.toString("utf8");
+      for (const ch of chunk) {
+        if (ch === "\n" || ch === "\r") {
+          output.write("\n");
+          cleanup();
+          resolve(buf);
+          return;
+        }
+        if (ch === "") {
+          // Ctrl-C
+          cleanup();
+          reject(new Error("Setup cancelled by user."));
+          return;
+        }
+        if (ch === "" || ch === "\b") {
+          // Backspace / DEL
+          if (buf.length > 0) {
+            buf = buf.slice(0, -1);
+            output.write("\b \b");
+          }
+          continue;
+        }
+        // Ignore other non-printable control characters silently.
+        if (ch.charCodeAt(0) < 0x20) continue;
+        buf += ch;
+        output.write("*");
+      }
+    };
+    stream.on("data", onData);
+  });
 }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1,8 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 import { GlmAcpAgent } from "../protocol/agent.js";
 import type { GlmStreamChunk } from "../llm/glm-client.js";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+
+// Defence in depth: even though every test below opts out via `sessionStore: null`,
+// redirect the on-disk default path to an isolated tempdir so a future test
+// that forgets the opt-out can't pollute the developer's home directory.
+process.env["ACP_GLM_SESSION_DIR"] = mkdtempSync(
+  pathJoin(osTmpdir(), "glm-acp-test-default-")
+);
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -687,13 +697,11 @@ test("invalid maxTurns falls back to the default", async () => {
 // Session persistence (loadSession / fork / resume)
 // ---------------------------------------------------------------------------
 
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { rmSync } from "node:fs";
 import { SessionStore } from "../protocol/session-store.js";
 
 function makeTempStore(): { store: SessionStore; cleanup: () => void } {
-  const dir = mkdtempSync(join(tmpdir(), "glm-acp-test-"));
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-"));
   const store = new SessionStore(dir);
   return {
     store,
@@ -833,6 +841,82 @@ test("loadSession throws when persistence is disabled", async () => {
     () => agent.loadSession({ sessionId: "x", cwd: "/tmp", mcpServers: [] }),
     /persistence is disabled/
   );
+});
+
+test("closeSession persists final state so a later loadSession can restore it", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const conn = createConnectionStub();
+    const glm = makeStreamingGlm([[{ text: "hi back" }, { done: true, stopReason: "stop" }]]);
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    await agent.closeSession({ sessionId });
+    assert.equal((await agent.listSessions({})).sessions.length, 1, "still listed via store");
+
+    // A fresh agent (simulating a process restart) must be able to load it.
+    const conn2 = createConnectionStub();
+    const agent2 = new GlmAcpAgent(conn2 as never, { sessionStore: store });
+    const loaded = await agent2.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    assert.equal(loaded.models?.currentModelId, store.load(sessionId)?.model);
+  } finally {
+    cleanup();
+  }
+});
+
+test("unstable_forkSession works on a session that exists only on disk", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const sourceId = "22222222-2222-2222-2222-222222222222";
+    store.save({
+      sessionId: sourceId,
+      cwd: "/tmp/orig",
+      messages: [
+        { role: "system", content: "you are a coding assistant" },
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+      ],
+      title: "origin",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-4.5",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    // Note: no newSession, no in-memory record — only the disk file exists.
+    const fork = await agent.unstable_forkSession({
+      sessionId: sourceId,
+      cwd: "/tmp/fork",
+      mcpServers: [],
+    });
+
+    assert.notEqual(fork.sessionId, sourceId);
+    const forked = store.load(fork.sessionId);
+    assert.ok(forked);
+    assert.equal(forked?.cwd, "/tmp/fork");
+    assert.equal(forked?.model, "glm-4.5");
+    assert.equal(forked?.messages.length, 3);
+    assert.equal(forked?.title, "origin (fork)");
+  } finally {
+    cleanup();
+  }
+});
+
+test("unstable_setSessionModel emits a session_info_update notification", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  const before = conn.updates.length;
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.5-air" });
+
+  const emitted = conn.updates.slice(before).filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "session_info_update"
+  );
+  assert.equal(emitted.length, 1);
 });
 
 test("listSessions surfaces persisted-but-not-in-memory sessions", async () => {

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 import { GlmAcpAgent } from "../protocol/agent.js";
 import type { GlmStreamChunk } from "../llm/glm-client.js";
+import { SessionStore } from "../protocol/session-store.js";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 
 // Defence in depth: even though every test below opts out via `sessionStore: null`,
@@ -696,9 +697,6 @@ test("invalid maxTurns falls back to the default", async () => {
 // ---------------------------------------------------------------------------
 // Session persistence (loadSession / fork / resume)
 // ---------------------------------------------------------------------------
-
-import { rmSync } from "node:fs";
-import { SessionStore } from "../protocol/session-store.js";
 
 function makeTempStore(): { store: SessionStore; cleanup: () => void } {
   const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-"));

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -84,7 +84,7 @@ function makeStreamingGlm(steps: Array<GlmStreamChunk[]>) {
 
 test("initialize returns negotiated protocol version, agent info, and auth methods", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
 
   const result = await agent.initialize({
     protocolVersion: PROTOCOL_VERSION,
@@ -96,10 +96,13 @@ test("initialize returns negotiated protocol version, agent info, and auth metho
 
   assert.equal(result.protocolVersion, PROTOCOL_VERSION);
   assert.equal(result.agentInfo?.name, "glm-acp-agent");
-  assert.equal(result.agentCapabilities?.loadSession, false);
+  assert.equal(result.agentCapabilities?.loadSession, true);
   assert.equal(result.agentCapabilities?.promptCapabilities?.embeddedContext, true);
+  assert.equal(result.agentCapabilities?.promptCapabilities?.image, true);
   assert.ok(result.agentCapabilities?.sessionCapabilities?.close);
   assert.ok(result.agentCapabilities?.sessionCapabilities?.list);
+  assert.ok(result.agentCapabilities?.sessionCapabilities?.fork);
+  assert.ok(result.agentCapabilities?.sessionCapabilities?.resume);
   assert.ok(Array.isArray(result.authMethods));
   const envVarMethod = result.authMethods?.find(
     (m) => (m as { type?: string }).type === "env_var"
@@ -117,7 +120,7 @@ test("initialize returns negotiated protocol version, agent info, and auth metho
 
 test("initialize negotiates lower protocol version when client requests one", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
 
   const result = await agent.initialize({
     protocolVersion: 0,
@@ -133,7 +136,7 @@ test("initialize negotiates lower protocol version when client requests one", as
 
 test("newSession returns a unique session id and seeds a system prompt", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: true },
@@ -161,7 +164,7 @@ test("system prompt advertises only the tools matching client capabilities", asy
       yield { done: true, stopReason: "stop" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   // Explicitly empty capabilities: the client has no fs, no terminal.
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
@@ -189,7 +192,7 @@ test("system prompt falls back to all tools when client never sent capabilities"
       yield { done: true, stopReason: "stop" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   // Skip initialize on purpose so clientCapabilities stays null.
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
   await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
@@ -208,7 +211,7 @@ test("system prompt falls back to all tools when client never sent capabilities"
 
 test("listSessions can filter by cwd", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
 
   await agent.newSession({ cwd: "/tmp/a", mcpServers: [] });
@@ -222,7 +225,7 @@ test("listSessions can filter by cwd", async () => {
 
 test("closeSession removes the session and a subsequent prompt fails", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -242,14 +245,14 @@ test("closeSession removes the session and a subsequent prompt fails", async () 
 
 test("authenticate is a no-op", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   const result = await agent.authenticate({ methodId: "z_ai_api_key" });
   assert.deepEqual(result, {});
 });
 
 test("setSessionMode is a no-op", async () => {
   const conn = createConnectionStub();
-  const agent = new GlmAcpAgent(conn as never);
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
   const result = await agent.setSessionMode({ sessionId, modeId: "ask" });
@@ -263,7 +266,7 @@ test("setSessionMode is a no-op", async () => {
 test("prompt streams agent_message_chunk and returns end_turn", async () => {
   const conn = createConnectionStub();
   const glm = makeStreamingGlm([[{ text: "Hello, world!" }, { done: true, stopReason: "stop" }]]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -294,7 +297,7 @@ test("prompt forwards reasoning_content as agent_thought_chunk", async () => {
       { done: true, stopReason: "stop" },
     ],
   ]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -311,7 +314,7 @@ test("prompt maps content_filter stop reason to refusal", async () => {
   const glm = makeStreamingGlm([
     [{ text: "I can't help." }, { done: true, stopReason: "content_filter" }],
   ]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -327,7 +330,7 @@ test("prompt maps length stop reason to max_tokens", async () => {
   const glm = makeStreamingGlm([
     [{ text: "..." }, { done: true, stopReason: "length" }],
   ]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -347,7 +350,7 @@ test("prompt loop returns max_turn_requests after exhausting tool turns", async 
       yield { done: true, stopReason: "tool_calls" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm, maxTurns: 2 });
+  const agent = new GlmAcpAgent(conn as never, { glm, maxTurns: 2, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -378,7 +381,7 @@ test("prompt cancellation returns cancelled stop reason", async () => {
       yield { done: true, stopReason: "stop" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -403,7 +406,7 @@ test("prompt echoes userMessageId and reports usage", async () => {
       { done: true, stopReason: "stop" },
     ],
   ]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -429,7 +432,7 @@ test("prompt converts resource_link and embedded resource blocks", async () => {
       yield { done: true, stopReason: "stop" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -477,7 +480,7 @@ test("tool call result is fed back into the next streamChat call", async () => {
       }
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
@@ -498,7 +501,7 @@ test("prompt without title sets title from first user message", async () => {
   const glm = makeStreamingGlm([
     [{ text: "ok" }, { done: true, stopReason: "stop" }],
   ]);
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -544,7 +547,7 @@ test("a follow-up prompt waits for the previous loop to fully unwind", async () 
     },
   };
 
-  const agent = new GlmAcpAgent(conn as never, { glm });
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -558,12 +561,299 @@ test("a follow-up prompt waits for the previous loop to fully unwind", async () 
   assert.equal(secondStartedBeforeFirstReturned, false);
 });
 
+// ---------------------------------------------------------------------------
+// Per-session model + unstable_setSessionModel
+// ---------------------------------------------------------------------------
+
+test("newSession returns a SessionModelState with availableModels and currentModelId", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+  const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  assert.ok(result.models, "expected models field on NewSessionResponse");
+  assert.ok(Array.isArray(result.models?.availableModels));
+  assert.ok((result.models?.availableModels.length ?? 0) >= 2);
+  assert.equal(typeof result.models?.currentModelId, "string");
+});
+
+test("unstable_setSessionModel updates the model used on the next prompt", async () => {
+  const conn = createConnectionStub();
+  const seenModels: Array<string | undefined> = [];
+  const glm = {
+    async *streamChat(
+      _msgs: unknown,
+      _signal?: AbortSignal,
+      options?: { model?: string }
+    ): AsyncGenerator<GlmStreamChunk> {
+      seenModels.push(options?.model);
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId, models } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await agent.prompt({ sessionId, prompt: [{ type: "text", text: "first" }] });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.5-air" });
+  await agent.prompt({ sessionId, prompt: [{ type: "text", text: "second" }] });
+
+  assert.equal(seenModels[0], models?.currentModelId);
+  assert.equal(seenModels[1], "glm-4.5-air");
+});
+
+test("unstable_setSessionModel rejects unknown sessions", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await assert.rejects(
+    () => agent.unstable_setSessionModel({ sessionId: "missing", modelId: "glm-5.1" }),
+    /Session not found/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Image content
+// ---------------------------------------------------------------------------
+
+test("prompt with image block forwards a multimodal user message", async () => {
+  const conn = createConnectionStub();
+  let captured: unknown;
+  const glm = {
+    async *streamChat(
+      messages: ReadonlyArray<{ role: string; content?: unknown }>
+    ): AsyncGenerator<GlmStreamChunk> {
+      const userMsg = messages.find((m) => m.role === "user");
+      captured = userMsg?.content;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await agent.prompt({
+    sessionId,
+    prompt: [
+      { type: "text", text: "What is in this image?" },
+      { type: "image", data: "AAAA", mimeType: "image/png" },
+    ],
+  });
+
+  assert.ok(Array.isArray(captured), "expected multimodal content array");
+  const arr = captured as Array<{ type: string; image_url?: { url: string }; text?: string }>;
+  const textPart = arr.find((p) => p.type === "text");
+  const imagePart = arr.find((p) => p.type === "image_url");
+  assert.equal(textPart?.text, "What is in this image?");
+  assert.equal(imagePart?.image_url?.url, "data:image/png;base64,AAAA");
+});
+
+test("prompt without image blocks keeps content as a plain string", async () => {
+  const conn = createConnectionStub();
+  let captured: unknown;
+  const glm = {
+    async *streamChat(
+      messages: ReadonlyArray<{ role: string; content?: unknown }>
+    ): AsyncGenerator<GlmStreamChunk> {
+      const userMsg = messages.find((m) => m.role === "user");
+      captured = userMsg?.content;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hello" }] });
+
+  assert.equal(typeof captured, "string");
+  assert.equal(captured, "hello");
+});
+
 test("invalid maxTurns falls back to the default", async () => {
   const conn = createConnectionStub();
   const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
 
   for (const bad of [0, -1, NaN, Number.POSITIVE_INFINITY]) {
-    const agent = new GlmAcpAgent(conn as never, { glm: { ...glm }, maxTurns: bad });
+    const agent = new GlmAcpAgent(conn as never, { glm: { ...glm }, maxTurns: bad, sessionStore: null });
     assert.equal((agent as unknown as { maxTurns: number }).maxTurns, 20);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Session persistence (loadSession / fork / resume)
+// ---------------------------------------------------------------------------
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore } from "../protocol/session-store.js";
+
+function makeTempStore(): { store: SessionStore; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "glm-acp-test-"));
+  const store = new SessionStore(dir);
+  return {
+    store,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+test("prompt persists session state to the SessionStore", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const conn = createConnectionStub();
+    const glm = makeStreamingGlm([[{ text: "hi back" }, { done: true, stopReason: "stop" }]]);
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    const persisted = store.load(sessionId);
+    assert.ok(persisted, "expected session to be persisted");
+    assert.equal(persisted?.cwd, "/tmp");
+    // system + user + assistant
+    assert.ok((persisted?.messages.length ?? 0) >= 3);
+    assert.ok(persisted?.title);
+  } finally {
+    cleanup();
+  }
+});
+
+test("loadSession restores messages and replays them as session updates", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    store.save({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd: "/tmp",
+      messages: [
+        { role: "system", content: "you are a coding assistant" },
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+      ],
+      title: "ping pong",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    const result = await agent.loadSession({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    assert.ok(result.models, "expected models in load response");
+    assert.equal(result.models?.currentModelId, "glm-5.1");
+
+    const userChunks = conn.updates.filter(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "user_message_chunk"
+    );
+    const assistantChunks = conn.updates.filter(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "agent_message_chunk"
+    );
+    assert.equal(userChunks.length, 1);
+    assert.equal(assistantChunks.length, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("unstable_forkSession creates a new sessionId with a deep-copied history", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const conn = createConnectionStub();
+    const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "first" }] });
+
+    const fork = await agent.unstable_forkSession({
+      sessionId,
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    assert.notEqual(fork.sessionId, sessionId);
+    assert.ok(fork.models);
+
+    // Mutating the fork shouldn't affect the original.
+    const original = store.load(sessionId);
+    const forked = store.load(fork.sessionId);
+    assert.ok(original);
+    assert.ok(forked);
+    assert.notEqual(original?.messages, forked?.messages);
+    assert.equal(original?.messages.length, forked?.messages.length);
+  } finally {
+    cleanup();
+  }
+});
+
+test("resumeSession restores in-memory state without replaying messages", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    store.save({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd: "/tmp",
+      messages: [
+        { role: "system", content: "you are a coding assistant" },
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+      ],
+      title: "ping pong",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    const result = await agent.resumeSession({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd: "/tmp",
+      mcpServers: [],
+    });
+
+    assert.equal(result.models?.currentModelId, "glm-5.1");
+    // No replay updates expected.
+    assert.equal(conn.updates.length, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("loadSession throws when persistence is disabled", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await assert.rejects(
+    () => agent.loadSession({ sessionId: "x", cwd: "/tmp", mcpServers: [] }),
+    /persistence is disabled/
+  );
+});
+
+test("listSessions surfaces persisted-but-not-in-memory sessions", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    store.save({
+      sessionId: "11111111-1111-1111-1111-111111111111",
+      cwd: "/tmp",
+      messages: [{ role: "system", content: "" }],
+      title: "Saved earlier",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    const list = await agent.listSessions({});
+    assert.equal(list.sessions.length, 1);
+    assert.equal(list.sessions[0]?.sessionId, "11111111-1111-1111-1111-111111111111");
+    assert.equal(list.sessions[0]?.title, "Saved earlier");
+  } finally {
+    cleanup();
   }
 });

--- a/src/tests/credentials.test.ts
+++ b/src/tests/credentials.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  credentialsPath,
+  readCredentialsKey,
+  resolveApiKey,
+  writeCredentials,
+} from "../llm/credentials.js";
+
+function withTmp<T>(fn: (dir: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), "glm-creds-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("credentialsPath honours XDG_CONFIG_HOME", () => {
+  const old = process.env["XDG_CONFIG_HOME"];
+  try {
+    process.env["XDG_CONFIG_HOME"] = "/custom/xdg";
+    assert.equal(
+      credentialsPath(),
+      "/custom/xdg/glm-acp-agent/credentials.json"
+    );
+  } finally {
+    if (old === undefined) delete process.env["XDG_CONFIG_HOME"];
+    else process.env["XDG_CONFIG_HOME"] = old;
+  }
+});
+
+test("readCredentialsKey returns undefined for a missing file", () => {
+  withTmp((dir) => {
+    const path = join(dir, "credentials.json");
+    assert.equal(readCredentialsKey(path), undefined);
+  });
+});
+
+test("readCredentialsKey returns undefined for malformed JSON", () => {
+  withTmp((dir) => {
+    const path = join(dir, "credentials.json");
+    writeFileSync(path, "not json");
+    assert.equal(readCredentialsKey(path), undefined);
+  });
+});
+
+test("writeCredentials and readCredentialsKey round-trip", () => {
+  withTmp((dir) => {
+    const path = join(dir, "nested", "credentials.json");
+    writeCredentials("test-key", path);
+    assert.equal(readCredentialsKey(path), "test-key");
+  });
+});
+
+test("writeCredentials writes a 0600-permission file", () => {
+  if (process.platform === "win32") return; // POSIX-only
+  withTmp((dir) => {
+    const path = join(dir, "credentials.json");
+    writeCredentials("k", path);
+    const mode = statSync(path).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+});
+
+test("writeCredentials refuses an empty key", () => {
+  withTmp((dir) => {
+    const path = join(dir, "credentials.json");
+    assert.throws(() => writeCredentials("", path), /empty/);
+  });
+});
+
+test("resolveApiKey prefers Z_AI_API_KEY over the credentials file", () => {
+  withTmp((dir) => {
+    const path = join(dir, "credentials.json");
+    writeCredentials("from-disk", path);
+    const oldEnv = process.env["Z_AI_API_KEY"];
+    const oldXdg = process.env["XDG_CONFIG_HOME"];
+    try {
+      process.env["Z_AI_API_KEY"] = "from-env";
+      process.env["XDG_CONFIG_HOME"] = dir; // makes credentialsPath() point here
+      // Path doesn't actually need to match; readCredentialsKey() falls through
+      // anyway when env wins.
+      assert.equal(resolveApiKey(), "from-env");
+    } finally {
+      if (oldEnv === undefined) delete process.env["Z_AI_API_KEY"];
+      else process.env["Z_AI_API_KEY"] = oldEnv;
+      if (oldXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+      else process.env["XDG_CONFIG_HOME"] = oldXdg;
+    }
+  });
+});
+
+test("resolveApiKey falls back to the credentials file when env is unset", () => {
+  withTmp((dir) => {
+    const xdg = join(dir, "xdg");
+    const credPath = join(xdg, "glm-acp-agent", "credentials.json");
+    writeCredentials("from-disk", credPath);
+    const oldEnv = process.env["Z_AI_API_KEY"];
+    const oldXdg = process.env["XDG_CONFIG_HOME"];
+    try {
+      delete process.env["Z_AI_API_KEY"];
+      process.env["XDG_CONFIG_HOME"] = xdg;
+      assert.equal(resolveApiKey(), "from-disk");
+    } finally {
+      if (oldEnv !== undefined) process.env["Z_AI_API_KEY"] = oldEnv;
+      if (oldXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+      else process.env["XDG_CONFIG_HOME"] = oldXdg;
+    }
+  });
+});

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,5 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
+
+// Defence in depth: redirect the default session-persistence directory to an
+// isolated tempdir so any forgotten `sessionStore: null` opt-out can't write
+// to the developer's home.
+process.env["ACP_GLM_SESSION_DIR"] = mkdtempSync(
+  pathJoin(osTmpdir(), "glm-acp-integration-test-")
+);
 import {
   AgentSideConnection,
   ClientSideConnection,

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -71,7 +71,7 @@ test("end-to-end initialize / new session / prompt round-trip via real SDK trans
   ]);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _agentConn = new AgentSideConnection(
-    (conn) => new GlmAcpAgent(conn, { glm }),
+    (conn) => new GlmAcpAgent(conn, { glm, sessionStore: null }),
     a
   );
 
@@ -134,7 +134,7 @@ test("end-to-end tool call: agent reads a file via the stub client", async () =>
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _agentConn = new AgentSideConnection(
-    (conn) => new GlmAcpAgent(conn, { glm }),
+    (conn) => new GlmAcpAgent(conn, { glm, sessionStore: null }),
     a
   );
   const clientConn = new ClientSideConnection(() => stub, b);
@@ -184,7 +184,7 @@ test("end-to-end cancellation via session/cancel notification", async () => {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _agentConn = new AgentSideConnection(
-    (conn) => new GlmAcpAgent(conn, { glm }),
+    (conn) => new GlmAcpAgent(conn, { glm, sessionStore: null }),
     a
   );
   const clientConn = new ClientSideConnection(() => stub, b);
@@ -208,7 +208,7 @@ test("end-to-end session/list and session/close advertised on initialize and rou
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _agentConn = new AgentSideConnection(
-    (conn) => new GlmAcpAgent(conn, { glm: makeStreamingGlm([]) }),
+    (conn) => new GlmAcpAgent(conn, { glm: makeStreamingGlm([]), sessionStore: null }),
     a
   );
   const clientConn = new ClientSideConnection(() => stub, b);


### PR DESCRIPTION
## Purpose

This feature closes the registry-parity gaps surfaced by the audit against `agentclientprotocol/registry` (April 2026 nightly matrix). The agent now ships the four ACP capabilities most peers already advertise — mid-session model switching, image content, terminal-friendly auth setup, and session load/fork/resume — so it can sit alongside `claude-acp`, `codex-acp`, `kimi`, and `qwen-code` in the registry without being the outlier on any axis.

## Key Changes

- **Per-session model + `unstable_setSessionModel`** — model lives on `SessionState` instead of the `GlmClient` constructor; `newSession` returns a curated `availableModels` list (overridable via `ACP_GLM_AVAILABLE_MODELS`); `set_model` emits a `session_info_update` notification so client UIs refresh immediately.
- **`promptCapabilities.image`** — image blocks are forwarded to GLM as OpenAI-shaped `image_url` data-URL parts; text-only prompts keep the broad-compat string shape.
- **Terminal Auth via `--setup`** — `glm-acp-agent --setup` writes `~/.config/glm-acp-agent/credentials.json` (mode 0600); raw-mode TTY input masks the typed key with `*` and supports backspace/Ctrl-C; `GlmClient` resolves env > file.
- **Session persistence** — new `SessionStore` writes `~/.local/state/glm-acp-agent/sessions/<id>.json` after every prompt and on `closeSession`; `loadSession` replays user/assistant text as session updates, `unstable_forkSession` deep-clones (incl. from disk-only sources), `resumeSession` restores in-memory without replay.
- **Capability advertisement** — `loadSession: true`, `sessionCapabilities.fork/resume: {}`, `promptCapabilities.image: true`.
- **Registry metadata** — `registry/glm-acp-agent/agent.json` description refreshed; `--help` documents every env var.
- **Robustness** — `PersistedSession` carries a `schemaVersion`; `SessionStore.listMetadata()` returns slim summaries sorted newest-first so `session/list` doesn't deserialise every conversation's full history.

## Checks

- [x] Code compiles without errors (`tsc` clean)
- [x] All tests pass (`npm test` — 72/72)
- [x] `--setup` and `--help` smoke-tested end-to-end
- [x] No regressions in pre-existing tests (auth methods, prompt loop, tool calls, capability gating)

## Task

[#5](https://github.com/stefandevo/glm-acp-agent/issues/5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive setup mode for API key configuration
  * Session persistence with load, fork, and resume operations
  * Mid-conversation model switching capability
  * Image input support for vision-capable models
  * Credentials file configuration support

* **Documentation**
  * Updated with session lifecycle operations, image input handling, authentication methods, and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->