### PR TITLE
#15 - Switch default to Coding endpoint + add debug logging

### DIFF
--- a/src/llm/credentials.ts
+++ b/src/llm/credentials.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
+import { debug, maskSecret } from "./logger.js";
 
 /**
  * Credential management for the Z.AI API key.
@@ -45,8 +46,17 @@ export function readCredentialsKey(path: string = credentialsPath()): string | u
  */
 export function resolveApiKey(): string | undefined {
   const fromEnv = process.env["Z_AI_API_KEY"];
-  if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv;
-  return readCredentialsKey();
+  if (typeof fromEnv === "string" && fromEnv.length > 0) {
+    debug(`resolveApiKey: source=env key=${maskSecret(fromEnv)}`);
+    return fromEnv;
+  }
+  const fromFile = readCredentialsKey();
+  if (fromFile) {
+    debug(`resolveApiKey: source=file key=${maskSecret(fromFile)}`);
+  } else {
+    debug("resolveApiKey: no key found");
+  }
+  return fromFile;
 }
 
 /**

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/reso
 import type { ModelInfo, Usage } from "@agentclientprotocol/sdk";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
 import { resolveApiKey } from "./credentials.js";
+import { debug, error } from "./logger.js";
 
 /**
  * A single message in the GLM conversation history.
@@ -37,8 +38,8 @@ export interface StreamChatOptions {
   model: string;
 }
 
-/** Default base URL for the Z.AI / Zhipu OpenAI-compatible API. */
-const DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4";
+/** Default base URL for the Z.AI / Zhipu OpenAI-compatible API (Coding endpoint). */
+const DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 /** Default GLM model when neither client nor user has chosen one. */
 export const DEFAULT_MODEL = "glm-5.1";
@@ -151,6 +152,10 @@ export class GlmClient {
       },
     }));
 
+    debug(
+      `streamChat: model=${model} baseURL=${this.client.baseURL} messages=${messages.length} tools=${tools.length} thinking=${thinkingEnabled}`
+    );
+
     // The OpenAI SDK forwards unknown extra body fields verbatim, so we use
     // that to pass GLM-specific fields like `thinking`.
     const extraBody: Record<string, unknown> = {};
@@ -158,20 +163,28 @@ export class GlmClient {
       extraBody["thinking"] = { type: "enabled" };
     }
 
-    const stream = await this.client.chat.completions.create(
-      {
-        model,
-        messages,
-        tools,
-        tool_choice: "auto",
-        stream: true,
-        // Always ask the API to include final usage in the streaming response.
-        stream_options: { include_usage: true },
-        max_tokens: this.maxTokens,
-        ...extraBody,
-      },
-      { signal }
-    );
+    let stream: Awaited<ReturnType<typeof this.client.chat.completions.create>>;
+    try {
+      stream = await this.client.chat.completions.create(
+        {
+          model,
+          messages,
+          tools,
+          tool_choice: "auto",
+          stream: true,
+          // Always ask the API to include final usage in the streaming response.
+          stream_options: { include_usage: true },
+          max_tokens: this.maxTokens,
+          ...extraBody,
+        },
+        { signal }
+      );
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      const body = (err as { error?: unknown })?.error;
+      error(`streamChat request failed: status=${status}`, JSON.stringify(body) ?? String(err));
+      throw err;
+    }
 
     // Tool call deltas arrive interleaved across chunks; assemble by index.
     const pendingToolCalls: Map<
@@ -253,6 +266,7 @@ export class GlmClient {
         ) {
           usage.thoughtTokens = rawUsage.completion_tokens_details.reasoning_tokens;
         }
+        debug(`streamChat usage: input=${usage.inputTokens} output=${usage.outputTokens} total=${usage.totalTokens}`);
         yield { usage };
       }
     }

--- a/src/llm/logger.ts
+++ b/src/llm/logger.ts
@@ -1,0 +1,46 @@
+/**
+ * Debug logging for the GLM ACP agent.
+ *
+ * Set `ACP_GLM_DEBUG=true` to enable verbose logging to stderr.
+ * `warn()` and `error()` always write to stderr regardless of the debug flag.
+ */
+
+const DEBUG_ENABLED =
+  typeof process === "object" &&
+  typeof process.env === "object" &&
+  (process.env["ACP_GLM_DEBUG"] === "true" || process.env["ACP_GLM_DEBUG"] === "1");
+
+function timestamp(): string {
+  return new Date().toISOString().slice(11, 23);
+}
+
+function write(level: string, ...args: unknown[]): void {
+  const prefix = `[glm-acp-agent] ${timestamp()} [${level}]`;
+  process.stderr.write(`${prefix} ${args.join(" ")}\n`);
+}
+
+/** Log a debug message. Only writes when `ACP_GLM_DEBUG=true`. */
+export function debug(...args: unknown[]): void {
+  if (DEBUG_ENABLED) write("DEBUG", ...args);
+}
+
+/** Log a warning. Always written to stderr. */
+export function warn(...args: unknown[]): void {
+  write("WARN", ...args);
+}
+
+/** Log an error. Always written to stderr. */
+export function error(...args: unknown[]): void {
+  write("ERROR", ...args);
+}
+
+/** Mask all but the last 4 characters of a string (e.g. API key). */
+export function maskSecret(s: string): string {
+  if (s.length <= 4) return "****";
+  return "****" + s.slice(-4);
+}
+
+/** Reset the DEBUG_ENABLED flag (used in tests). */
+export function _resetDebugEnabled(): void {
+  // no-op in production; tests monkey-patch this module's internals.
+}

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -44,6 +44,7 @@ import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
+import { debug, error } from "../llm/logger.js";
 
 /**
  * Maximum bytes of AGENTS.md / CLAUDE.md to embed in the system prompt.
@@ -213,6 +214,7 @@ export class GlmAcpAgent implements Agent {
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     const sessionId = randomUUID();
+    debug(`newSession: id=${sessionId} cwd=${params.cwd} model=${getDefaultModel()}`);
 
     const systemPrompt: GlmMessage = {
       role: "system",
@@ -383,6 +385,7 @@ export class GlmAcpAgent implements Agent {
       if (userMessageId) response.userMessageId = userMessageId;
       return response;
     } catch (err) {
+      error(`prompt error: session=${params.sessionId}`, err instanceof Error ? err.message : String(err));
       // If the abort happened concurrently with another error, prefer the
       // cancelled stop reason – that's what the spec asks for.
       if (abortController.signal.aborted) {
@@ -665,6 +668,8 @@ export class GlmAcpAgent implements Agent {
     for (let turn = 0; turn < this.maxTurns; turn++) {
       if (signal.aborted) return { stopReason: "cancelled" };
 
+      debug(`promptLoop: turn=${turn} session=${sessionId} model=${session.model} messages=${session.messages.length}`);
+
       const toolCalls: Array<{
         id: string;
         name: string;
@@ -703,6 +708,7 @@ export class GlmAcpAgent implements Agent {
         }
 
         if (chunk.toolCall) {
+          debug(`promptLoop: toolCall id=${chunk.toolCall.id} name=${chunk.toolCall.name}`);
           toolCalls.push(chunk.toolCall);
         }
 
@@ -741,6 +747,7 @@ export class GlmAcpAgent implements Agent {
         if (signal.aborted) return { stopReason: "cancelled", usage: lastUsage };
 
         const result = await executor.execute(tc.id, tc.name, tc.arguments);
+        debug(`promptLoop: toolResult id=${tc.id} name=${tc.name} contentLength=${result.content.length}`);
 
         session.messages.push({
           role: "tool",

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -2,6 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { GlmClient } from "../llm/glm-client.js";
 
+test("constructor uses the coding endpoint by default", () => {
+  process.env["Z_AI_API_KEY"] = "test-key";
+  delete process.env["ACP_GLM_BASE_URL"];
+  try {
+    const c = new GlmClient();
+    const url = (c as unknown as { client: { baseURL: string } }).client.baseURL;
+    assert.equal(url, "https://api.z.ai/api/coding/paas/v4");
+  } finally {
+    delete process.env["Z_AI_API_KEY"];
+  }
+});
+
 // We don't want to actually hit the network, but the OpenAI SDK still
 // constructs a client when we instantiate GlmClient. We stub the
 // `client.chat.completions.create` method on the underlying OpenAI client.

--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { maskSecret } from "../llm/logger.js";
+
+test("maskSecret masks all but last 4 chars", () => {
+  assert.equal(maskSecret("abcdefgh"), "****efgh");
+});
+
+test("maskSecret returns **** for short strings", () => {
+  assert.equal(maskSecret("ab"), "****");
+  assert.equal(maskSecret("abcd"), "****");
+});
+
+test("maskSecret handles exactly 5 chars", () => {
+  assert.equal(maskSecret("abcde"), "****bcde");
+});


### PR DESCRIPTION
## Purpose
Type: feature. Implement #15 - Switch default to Coding endpoint + add debug logging.

Task: [#15](https://github.com/stefandevo/glm-acp-agent/issues/15)

## Key Changes
- src/llm/credentials.ts
- src/llm/glm-client.ts
- src/llm/logger.ts
- src/protocol/agent.ts
- src/tests/glm-client.test.ts
- src/tests/logger.test.ts

## Checks
- [ ] Validate behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug logging capability for troubleshooting, enabled via environment variable.
  * Improved error visibility with structured logging throughout the agent lifecycle.

* **Tests**
  * Added test coverage for API endpoint configuration and logging utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->