### PR TITLE
#20 - Route web tools through Coding Plan MCP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ The agent connects to any ACP-compatible IDE or client over **stdio**, streams r
 
 ---
 
+## Coding Plan Only
+
+`glm-acp-agent` is intentionally built for the **Z.AI GLM Coding Plan**. It is not a general-purpose Z.AI Open Platform API client.
+
+By default, model calls use the Coding Plan endpoint:
+
+```text
+https://api.z.ai/api/coding/paas/v4
+```
+
+The same Coding Plan API key is used for the agent's GLM model calls and supported Coding Plan tools. General Z.AI API/resource-package billing surfaces, such as direct `/api/paas/v4` Tool API calls, are intentionally out of scope for this ACP agent.
+
+Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/api/paas/v4` Tool API. If you need general Z.AI API billing, separate resource packages, or non-Coding Plan endpoints, use a different provider configuration or fork this agent for that purpose.
+
+---
+
 ## Features
 
 - **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, `session/list`, `session/load`, `session/fork`, `session/resume`, and `session/set_model`
@@ -38,11 +54,11 @@ ACP Client (IDE plugin, CLI, …)
         └─ ToolExecutor ← executes tool calls  (src/tools/)
              ├─ read_file / write_file       → ACP client (fs.*)
              ├─ list_files / run_command     → ACP client (terminal)
-             ├─ web_search                   → Z.AI /paas/v4/web_search
-             └─ web_reader                   → Z.AI /paas/v4/reader
+             ├─ web_search                   → Z.AI Coding Plan Web Search MCP
+             └─ web_reader                   → Z.AI Coding Plan Web Reader MCP
 ```
 
-The agent process itself only needs network access to `api.z.ai`. All file-system and shell operations are **delegated to the ACP client** — the agent never touches the local disk directly. `web_search` and `web_reader` are different: they run **inside the agent process** and call the Z.AI Tools API directly.
+The agent process itself only needs network access to `api.z.ai`. All file-system and shell operations are **delegated to the ACP client** — the agent never touches the local disk directly. `web_search` and `web_reader` run **inside the agent process** and call Z.AI's Coding Plan-compatible MCP servers with the same resolved API key used for model calls.
 
 ---
 
@@ -54,8 +70,8 @@ The agent process itself only needs network access to `api.z.ai`. All file-syste
 | `write_file` | ACP client | `fs.writeTextFile` | Write or overwrite a text file (asks for permission) |
 | `list_files` | ACP client | `terminal` | List a directory via `ls -la` (POSIX shell required) |
 | `run_command` | ACP client | `terminal` | Run an arbitrary shell command via `sh -c` (asks for permission) |
-| `web_search` | Agent (Z.AI) | – | Search the web — returns titles, URLs, and summaries |
-| `web_reader` | Agent (Z.AI) | – | Fetch and parse a web page (markdown or plain text) |
+| `web_search` | Agent (Z.AI Coding Plan MCP) | – | Search the web — returns titles, URLs, and summaries |
+| `web_reader` | Agent (Z.AI Coding Plan MCP) | – | Fetch and parse a web page (markdown or plain text) |
 
 ---
 
@@ -87,7 +103,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | `Z_AI_API_KEY` | One of env / `--setup` | — | API key for the Z.AI / Zhipu AI service. If unset, the credentials file is consulted. |
 | `ACP_GLM_MODEL` | No | `glm-5.1` | Default GLM model for new sessions |
 | `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
-| `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/paas/v4` | Override the API base URL |
+| `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
 | `ACP_GLM_THINKING` | No | auto-detected | Force thinking mode `true` / `false` |
 | `ACP_GLM_SESSION_DIR` | No | `$XDG_STATE_HOME/glm-acp-agent/sessions` | Where session JSON files are persisted |

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -1,5 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeCredentials } from "../llm/credentials.js";
 import { ToolExecutor } from "../tools/executor.js";
 
 interface StubTerminal {
@@ -66,6 +70,70 @@ const FULL_CAPS = {
   fs: { readTextFile: true, writeTextFile: true },
   terminal: true,
 };
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+  body: Record<string, unknown>;
+  headers: Headers;
+};
+
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit & { sessionId?: string } = {}
+): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+  if (init.sessionId) headers.set("MCP-Session-Id", init.sessionId);
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function createFetchStub(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  const fetchStub = async (url: string | URL | Request, init?: RequestInit) => {
+    assert.ok(init, "fetch init is required");
+    const body =
+      typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    const headers = new Headers(init.headers);
+    calls.push({ url: String(url), init, body, headers });
+    const response = responses.shift();
+    assert.ok(response, "unexpected fetch call");
+    return response;
+  };
+  return { calls, fetchStub };
+}
+
+async function withStoredApiKey<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-creds-"));
+  const oldEnv = process.env["Z_AI_API_KEY"];
+  const oldXdg = process.env["XDG_CONFIG_HOME"];
+  try {
+    delete process.env["Z_AI_API_KEY"];
+    process.env["XDG_CONFIG_HOME"] = dir;
+    writeCredentials("from-disk", join(dir, "glm-acp-agent", "credentials.json"));
+    return await fn();
+  } finally {
+    if (oldEnv === undefined) delete process.env["Z_AI_API_KEY"];
+    else process.env["Z_AI_API_KEY"] = oldEnv;
+    if (oldXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+    else process.env["XDG_CONFIG_HOME"] = oldXdg;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function withMockedFetch<T>(
+  responses: Response[],
+  fn: (calls: FetchCall[]) => Promise<T>
+): Promise<T> {
+  const oldFetch = globalThis.fetch;
+  const { calls, fetchStub } = createFetchStub(responses);
+  try {
+    globalThis.fetch = fetchStub as typeof fetch;
+    return await fn(calls);
+  } finally {
+    globalThis.fetch = oldFetch;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Argument parsing
@@ -268,6 +336,163 @@ test("list_files rejects empty path", async () => {
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
   const result = await exec.execute("tc1", "list_files", JSON.stringify({ path: "" }));
   assert.match(result.content, /non-empty string/);
+});
+
+// ---------------------------------------------------------------------------
+// web_search / web_reader via Z.AI Coding Plan MCP
+// ---------------------------------------------------------------------------
+
+test("web_search uses stored credentials and calls the Coding Plan MCP search tool", async () => {
+  await withStoredApiKey(async () => {
+    await withMockedFetch(
+      [
+        jsonResponse(
+          {
+            jsonrpc: "2.0",
+            id: 1,
+            result: { protocolVersion: "2025-06-18", capabilities: {} },
+          },
+          { sessionId: "search-session" }
+        ),
+        new Response(null, { status: 202 }),
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  search_result: [
+                    {
+                      title: "GLM Coding Plan",
+                      link: "https://z.ai/",
+                      media: "Z.AI",
+                      publish_date: "2026-04-29",
+                      content: "MCP quota path",
+                    },
+                  ],
+                }),
+              },
+            ],
+          },
+        }),
+      ],
+      async (calls) => {
+        const conn = createConnectionStub();
+        const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+        const result = await exec.execute(
+          "tc-web-search",
+          "web_search",
+          JSON.stringify({ query: "glm coding plan", count: 1 })
+        );
+
+        assert.match(result.content, /\[1\] GLM Coding Plan/);
+        assert.match(result.content, /URL: https:\/\/z\.ai\//);
+        assert.equal(calls.length, 3);
+        assert.ok(calls.every((call) => call.url === "https://api.z.ai/api/mcp/web_search_prime/mcp"));
+        assert.equal(calls[0]?.headers.get("Authorization"), "Bearer from-disk");
+        assert.equal(calls[2]?.headers.get("Mcp-Method"), "tools/call");
+        assert.equal(calls[2]?.headers.get("Mcp-Name"), "webSearchPrime");
+        assert.deepEqual(calls[2]?.body.params, {
+          name: "webSearchPrime",
+          arguments: { query: "glm coding plan", count: 1 },
+        });
+        const last = conn.updates.at(-1) as { update: { status?: string } };
+        assert.equal(last.update.status, "completed");
+      }
+    );
+  });
+});
+
+test("web_reader calls the Coding Plan MCP reader tool and formats reader_result", async () => {
+  const oldEnv = process.env["Z_AI_API_KEY"];
+  try {
+    process.env["Z_AI_API_KEY"] = "from-env";
+    await withMockedFetch(
+      [
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { protocolVersion: "2025-06-18", capabilities: {} },
+        }),
+        new Response(null, { status: 202 }),
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  reader_result: {
+                    title: "Example",
+                    url: "https://example.com/",
+                    description: "Short description",
+                    content: "Main body",
+                  },
+                }),
+              },
+            ],
+          },
+        }),
+      ],
+      async (calls) => {
+        const conn = createConnectionStub();
+        const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+        const result = await exec.execute(
+          "tc-web-reader",
+          "web_reader",
+          JSON.stringify({ url: "https://example.com/", return_format: "markdown" })
+        );
+
+        assert.match(result.content, /^# Example/);
+        assert.match(result.content, /URL: https:\/\/example\.com\//);
+        assert.match(result.content, /Main body/);
+        assert.ok(calls.every((call) => call.url === "https://api.z.ai/api/mcp/web_reader/mcp"));
+        assert.equal(calls[2]?.headers.get("Mcp-Name"), "webReader");
+        assert.deepEqual(calls[2]?.body.params, {
+          name: "webReader",
+          arguments: { url: "https://example.com/", return_format: "markdown" },
+        });
+      }
+    );
+  } finally {
+    if (oldEnv === undefined) delete process.env["Z_AI_API_KEY"];
+    else process.env["Z_AI_API_KEY"] = oldEnv;
+  }
+});
+
+test("web_search reports Coding Plan 1113 MCP errors as actionable failed tool results", async () => {
+  const oldEnv = process.env["Z_AI_API_KEY"];
+  try {
+    process.env["Z_AI_API_KEY"] = "from-env";
+    await withMockedFetch(
+      [
+        jsonResponse(
+          { error: { code: "1113", message: "No permission for current API key" } },
+          { status: 429 }
+        ),
+      ],
+      async () => {
+        const conn = createConnectionStub();
+        const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+        const result = await exec.execute(
+          "tc-web-search-error",
+          "web_search",
+          JSON.stringify({ query: "glm" })
+        );
+
+        assert.match(result.content, /Coding Plan quota\/base URL\/tool eligibility/);
+        assert.match(result.content, /1113/);
+        const last = conn.updates.at(-1) as { update: { status?: string } };
+        assert.equal(last.update.status, "failed");
+      }
+    );
+  } finally {
+    if (oldEnv === undefined) delete process.env["Z_AI_API_KEY"];
+    else process.env["Z_AI_API_KEY"] = oldEnv;
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/zai-mcp-client.test.ts
+++ b/src/tests/zai-mcp-client.test.ts
@@ -1,0 +1,144 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ZaiMcpClient } from "../tools/zai-mcp-client.js";
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+  body: Record<string, unknown>;
+  headers: Headers;
+};
+
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit & { sessionId?: string } = {}
+): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+  if (init.sessionId) headers.set("MCP-Session-Id", init.sessionId);
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function sseResponse(body: unknown): Response {
+  return new Response(`event: message\ndata: ${JSON.stringify(body)}\n\n`, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function createFetchStub(responses: Response[]) {
+  const calls: FetchCall[] = [];
+  const fetchStub = async (url: string | URL | Request, init?: RequestInit) => {
+    assert.ok(init, "fetch init is required");
+    const body =
+      typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    const headers = new Headers(init.headers);
+    calls.push({ url: String(url), init, body, headers });
+    const response = responses.shift();
+    assert.ok(response, "unexpected fetch call");
+    return response;
+  };
+  return { calls, fetchStub };
+}
+
+test("ZaiMcpClient initializes, sends initialized, caches session id, and calls a tool", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "zai" } },
+      },
+      { sessionId: "session-123" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { content: [{ type: "text", text: "Search result text" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  const result = await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { query: "glm coding plan", count: 3 },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(result, { content: [{ type: "text", text: "Search result text" }] });
+  assert.equal(calls.length, 3);
+  assert.equal(calls[0]?.body.method, "initialize");
+  assert.equal(calls[0]?.headers.get("Authorization"), "Bearer test-key");
+  assert.equal(calls[0]?.headers.get("Accept"), "application/json, text/event-stream");
+  assert.equal(calls[0]?.headers.get("Mcp-Method"), "initialize");
+  assert.equal(calls[0]?.headers.get("MCP-Protocol-Version"), "2025-06-18");
+
+  assert.equal(calls[1]?.body.method, "notifications/initialized");
+  assert.equal(calls[1]?.headers.get("MCP-Session-Id"), "session-123");
+  assert.equal(calls[1]?.headers.get("Mcp-Method"), "notifications/initialized");
+
+  assert.equal(calls[2]?.body.method, "tools/call");
+  assert.deepEqual(calls[2]?.body.params, {
+    name: "webSearchPrime",
+    arguments: { query: "glm coding plan", count: 3 },
+  });
+  assert.equal(calls[2]?.headers.get("MCP-Session-Id"), "session-123");
+  assert.equal(calls[2]?.headers.get("Mcp-Method"), "tools/call");
+  assert.equal(calls[2]?.headers.get("Mcp-Name"), "webSearchPrime");
+});
+
+test("ZaiMcpClient parses SSE wrapped JSON-RPC responses", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_reader/mcp";
+  const { fetchStub } = createFetchStub([
+    sseResponse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { protocolVersion: "2025-06-18", capabilities: {} },
+    }),
+    new Response(null, { status: 202 }),
+    sseResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { content: [{ type: "text", text: "# Title\nBody" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  const result = await client.callTool({
+    endpoint,
+    toolName: "webReader",
+    arguments: { url: "https://example.com" },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(result, { content: [{ type: "text", text: "# Title\nBody" }] });
+});
+
+test("ZaiMcpClient explains Coding Plan eligibility when Z.AI returns 1113", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        error: {
+          code: "1113",
+          message: "No permission for current API key",
+        },
+      },
+      { status: 429 }
+    ),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  await assert.rejects(
+    () =>
+      client.callTool({
+        endpoint,
+        toolName: "webSearchPrime",
+        arguments: { query: "glm" },
+        apiKey: "test-key",
+      }),
+    /Coding Plan quota\/base URL\/tool eligibility.*1113/
+  );
+});

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -2,6 +2,12 @@ import type {
   AgentSideConnection,
   ClientCapabilities,
 } from "@agentclientprotocol/sdk";
+import { resolveApiKey } from "../llm/credentials.js";
+import {
+  callZaiMcpTool,
+  ZAI_WEB_READER_MCP_ENDPOINT,
+  ZAI_WEB_SEARCH_MCP_ENDPOINT,
+} from "./zai-mcp-client.js";
 
 /**
  * Result returned after executing a tool call against the ACP client.
@@ -486,51 +492,19 @@ export class ToolExecutor {
     });
 
     try {
-      const apiKey = requireApiKey();
-      const body: Record<string, unknown> = {
-        search_engine: "search-prime",
-        search_query: query,
-      };
-      if (count !== undefined) body["count"] = count;
+      const apiKey = requireResolvedApiKey();
+      const toolArgs: Record<string, unknown> = { query };
+      if (count !== undefined) toolArgs["count"] = count;
 
-      const response = await fetch("https://api.z.ai/api/paas/v4/web_search", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(body),
+      const mcpResult = await callZaiMcpTool({
+        endpoint: ZAI_WEB_SEARCH_MCP_ENDPOINT,
+        toolName: "webSearchPrime",
+        arguments: toolArgs,
+        apiKey,
         signal: this.signal,
       });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`HTTP ${response.status}: ${errorText}`);
-      }
-
-      const data = (await response.json()) as {
-        search_result?: Array<{
-          title?: string;
-          link?: string;
-          content?: string;
-          media?: string;
-          publish_date?: string;
-        }>;
-      };
-
-      const results = data.search_result ?? [];
-      const formatted = results
-        .map((r, i) => {
-          const lines = [`[${i + 1}] ${r.title ?? "(no title)"}`];
-          if (r.link) lines.push(`URL: ${r.link}`);
-          if (r.media) lines.push(`Source: ${r.media}`);
-          if (r.publish_date) lines.push(`Date: ${r.publish_date}`);
-          if (r.content) lines.push(`Summary: ${r.content}`);
-          return lines.join("\n");
-        })
-        .join("\n\n");
-
-      const output = formatted || "No results found.";
+      const { output, resultCount } = formatSearchOutput(mcpResult);
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -539,7 +513,7 @@ export class ToolExecutor {
           toolCallId,
           status: "completed",
           content: [{ type: "content", content: { type: "text", text: output } }],
-          rawOutput: { resultCount: results.length },
+          rawOutput: { resultCount },
         },
       });
 
@@ -580,39 +554,17 @@ export class ToolExecutor {
     });
 
     try {
-      const apiKey = requireApiKey();
+      const apiKey = requireResolvedApiKey();
 
-      const response = await fetch("https://api.z.ai/api/paas/v4/reader", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({ url, return_format: returnFormat }),
+      const mcpResult = await callZaiMcpTool({
+        endpoint: ZAI_WEB_READER_MCP_ENDPOINT,
+        toolName: "webReader",
+        arguments: { url, return_format: returnFormat },
+        apiKey,
         signal: this.signal,
       });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`HTTP ${response.status}: ${errorText}`);
-      }
-
-      const data = (await response.json()) as {
-        reader_result?: {
-          title?: string;
-          description?: string;
-          url?: string;
-          content?: string;
-        };
-      };
-
-      const result = data.reader_result;
-      const lines: string[] = [];
-      if (result?.title) lines.push(`# ${result.title}`);
-      if (result?.url) lines.push(`URL: ${result.url}`);
-      if (result?.description) lines.push(`\n${result.description}`);
-      if (result?.content) lines.push(`\n${result.content}`);
-      const output = lines.join("\n") || "No content returned.";
+      const { output, title, resultUrl } = formatReaderOutput(mcpResult);
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -621,7 +573,7 @@ export class ToolExecutor {
           toolCallId,
           status: "completed",
           content: [{ type: "content", content: { type: "text", text: output } }],
-          rawOutput: { title: result?.title, url: result?.url },
+          rawOutput: { title, url: resultUrl },
         },
       });
 
@@ -686,13 +638,110 @@ export class ToolExecutor {
   }
 }
 
-/** Read the API key from env, throwing a clear error if it's missing. */
-function requireApiKey(): string {
-  const apiKey = process.env["Z_AI_API_KEY"];
+/** Resolve the API key from env or stored credentials, throwing a clear error if missing. */
+function requireResolvedApiKey(): string {
+  const apiKey = resolveApiKey();
   if (!apiKey) {
-    throw new Error("Z_AI_API_KEY environment variable is required but not set.");
+    throw new Error(
+      "No API key found. Set Z_AI_API_KEY, or run `glm-acp-agent --setup` to store one."
+    );
   }
   return apiKey;
+}
+
+function formatSearchOutput(mcpResult: unknown): { output: string; resultCount: number } {
+  const payload = unwrapMcpPayload(mcpResult);
+  const results = isRecord(payload) && Array.isArray(payload["search_result"])
+    ? payload["search_result"]
+    : [];
+
+  if (results.length === 0) {
+    return {
+      output: typeof payload === "string" && payload.length > 0 ? payload : "No results found.",
+      resultCount: 0,
+    };
+  }
+
+  const output = results
+    .map((raw, i) => {
+      const r = isRecord(raw) ? raw : {};
+      const lines = [`[${i + 1}] ${stringValue(r["title"]) ?? "(no title)"}`];
+      const link = stringValue(r["link"]);
+      const media = stringValue(r["media"]);
+      const publishDate = stringValue(r["publish_date"]);
+      const content = stringValue(r["content"]);
+      if (link) lines.push(`URL: ${link}`);
+      if (media) lines.push(`Source: ${media}`);
+      if (publishDate) lines.push(`Date: ${publishDate}`);
+      if (content) lines.push(`Summary: ${content}`);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+
+  return { output, resultCount: results.length };
+}
+
+function formatReaderOutput(mcpResult: unknown): {
+  output: string;
+  title?: string;
+  resultUrl?: string;
+} {
+  const payload = unwrapMcpPayload(mcpResult);
+  const result = isRecord(payload) && isRecord(payload["reader_result"])
+    ? payload["reader_result"]
+    : undefined;
+
+  if (!result) {
+    return {
+      output: typeof payload === "string" && payload.length > 0 ? payload : "No content returned.",
+    };
+  }
+
+  const title = stringValue(result["title"]);
+  const resultUrl = stringValue(result["url"]);
+  const description = stringValue(result["description"]);
+  const content = stringValue(result["content"]);
+  const lines: string[] = [];
+  if (title) lines.push(`# ${title}`);
+  if (resultUrl) lines.push(`URL: ${resultUrl}`);
+  if (description) lines.push(`\n${description}`);
+  if (content) lines.push(`\n${content}`);
+
+  return { output: lines.join("\n") || "No content returned.", title, resultUrl };
+}
+
+function unwrapMcpPayload(mcpResult: unknown): unknown {
+  if (!isRecord(mcpResult)) return mcpResult;
+  const content = mcpResult["content"];
+  if (!Array.isArray(content)) return mcpResult;
+
+  const texts = content
+    .map((entry) => {
+      if (!isRecord(entry)) return undefined;
+      const text = entry["text"];
+      return typeof text === "string" ? text : undefined;
+    })
+    .filter((text): text is string => typeof text === "string");
+
+  if (texts.length === 0) return mcpResult;
+  if (texts.length === 1) return parseJsonIfPossible(texts[0]);
+  return texts.join("\n");
+}
+
+function parseJsonIfPossible(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 /**

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -1,0 +1,252 @@
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+export const ZAI_WEB_SEARCH_MCP_ENDPOINT =
+  "https://api.z.ai/api/mcp/web_search_prime/mcp";
+export const ZAI_WEB_READER_MCP_ENDPOINT =
+  "https://api.z.ai/api/mcp/web_reader/mcp";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc?: string;
+  id?: number;
+  result?: unknown;
+  error?: {
+    code?: string | number;
+    message?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface ZaiMcpToolCall {
+  endpoint: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  apiKey: string;
+  signal?: AbortSignal;
+}
+
+export class ZaiMcpClient {
+  private sessions = new Map<string, { sessionId?: string; initialized: boolean }>();
+  private nextId = 1;
+
+  constructor(
+    private fetchImpl: typeof fetch = ((...args: Parameters<typeof fetch>) =>
+      fetch(...args)) as typeof fetch
+  ) {}
+
+  async callTool(call: ZaiMcpToolCall): Promise<unknown> {
+    const session = await this.ensureInitialized(call);
+    const result = await this.sendRequest(
+      call.endpoint,
+      call.apiKey,
+      "tools/call",
+      {
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method: "tools/call",
+        params: {
+          name: call.toolName,
+          arguments: call.arguments,
+        },
+      },
+      "tools/call",
+      call.signal,
+      session.sessionId,
+      call.toolName
+    );
+    return result;
+  }
+
+  private async ensureInitialized(call: ZaiMcpToolCall) {
+    const cacheKey = `${call.endpoint}\n${call.apiKey}`;
+    const cached = this.sessions.get(cacheKey);
+    if (cached?.initialized) return cached;
+
+    const initializeResponse = await this.fetchJsonRpc(
+      call.endpoint,
+      call.apiKey,
+      "initialize",
+      {
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method: "initialize",
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: {
+            name: "glm-acp-agent",
+            version: "1.0.0",
+          },
+        },
+      },
+      "initialize",
+      call.signal
+    );
+
+    const sessionId = initializeResponse.sessionId;
+    await this.sendNotification(
+      call.endpoint,
+      call.apiKey,
+      {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      },
+      "notifications/initialized",
+      call.signal,
+      sessionId
+    );
+
+    const session = { sessionId, initialized: true };
+    this.sessions.set(cacheKey, session);
+    return session;
+  }
+
+  private async sendRequest(
+    endpoint: string,
+    apiKey: string,
+    mcpMethod: string,
+    body: JsonRpcRequest,
+    stage: string,
+    signal?: AbortSignal,
+    sessionId?: string,
+    mcpName?: string
+  ): Promise<unknown> {
+    const response = await this.fetchJsonRpc(
+      endpoint,
+      apiKey,
+      mcpMethod,
+      body,
+      stage,
+      signal,
+      sessionId,
+      mcpName
+    );
+    return response.body.result;
+  }
+
+  private async sendNotification(
+    endpoint: string,
+    apiKey: string,
+    body: JsonRpcRequest,
+    mcpMethod: string,
+    signal?: AbortSignal,
+    sessionId?: string
+  ): Promise<void> {
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: buildHeaders(apiKey, mcpMethod, sessionId),
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(formatMcpError(mcpMethod, response.status, text));
+    }
+  }
+
+  private async fetchJsonRpc(
+    endpoint: string,
+    apiKey: string,
+    mcpMethod: string,
+    body: JsonRpcRequest,
+    stage: string,
+    signal?: AbortSignal,
+    sessionId?: string,
+    mcpName?: string
+  ): Promise<{ body: JsonRpcResponse; sessionId?: string }> {
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: buildHeaders(apiKey, mcpMethod, sessionId, mcpName),
+      body: JSON.stringify(body),
+      signal,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(formatMcpError(stage, response.status, text));
+    }
+
+    const parsed = parseMcpResponse(text, response.headers.get("Content-Type") ?? "");
+    if (parsed.error) {
+      throw new Error(formatJsonRpcError(stage, parsed.error));
+    }
+
+    return {
+      body: parsed,
+      sessionId: response.headers.get("MCP-Session-Id") ?? undefined,
+    };
+  }
+}
+
+const defaultClient = new ZaiMcpClient();
+
+export function callZaiMcpTool(call: ZaiMcpToolCall): Promise<unknown> {
+  return defaultClient.callTool(call);
+}
+
+function buildHeaders(
+  apiKey: string,
+  mcpMethod: string,
+  sessionId?: string,
+  mcpName?: string
+): Headers {
+  const headers = new Headers({
+    Authorization: `Bearer ${apiKey}`,
+    Accept: "application/json, text/event-stream",
+    "Content-Type": "application/json",
+    "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+    "Mcp-Method": mcpMethod,
+  });
+  if (sessionId) headers.set("MCP-Session-Id", sessionId);
+  if (mcpName) headers.set("Mcp-Name", mcpName);
+  return headers;
+}
+
+function parseMcpResponse(text: string, contentType: string): JsonRpcResponse {
+  if (!text.trim()) {
+    throw new Error("MCP response was empty.");
+  }
+  if (contentType.toLowerCase().includes("text/event-stream")) {
+    return parseSseJsonRpc(text);
+  }
+  return JSON.parse(text) as JsonRpcResponse;
+}
+
+function parseSseJsonRpc(text: string): JsonRpcResponse {
+  const dataLines: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+  for (const data of dataLines) {
+    if (!data || data === "[DONE]") continue;
+    const parsed = JSON.parse(data) as JsonRpcResponse;
+    if (parsed.result !== undefined || parsed.error !== undefined) return parsed;
+  }
+  throw new Error("MCP SSE response did not contain a JSON-RPC result.");
+}
+
+function formatMcpError(stage: string, status: number, body: string): string {
+  if (isCodingPlanEligibilityError(body)) {
+    return `MCP ${stage} failed: HTTP ${status}. Coding Plan quota/base URL/tool eligibility likely is not being met (business code 1113). ${body}`;
+  }
+  return `MCP ${stage} failed: HTTP ${status}: ${body}`;
+}
+
+function formatJsonRpcError(stage: string, error: NonNullable<JsonRpcResponse["error"]>): string {
+  const details = JSON.stringify(error);
+  if (isCodingPlanEligibilityError(details)) {
+    return `MCP ${stage} failed: Coding Plan quota/base URL/tool eligibility likely is not being met (business code 1113). ${details}`;
+  }
+  return `MCP ${stage} failed: ${details}`;
+}
+
+function isCodingPlanEligibilityError(body: string): boolean {
+  return /(^|["\s:])1113($|["\s,}])/.test(body);
+}


### PR DESCRIPTION
## Purpose
Type: feature. Implement #20 - Route web tools through Coding Plan MCP endpoints.

Task: [#20](https://github.com/stefandevo/glm-acp-agent/issues/20)

## Key Changes
- README.md
- src/tests/executor.test.ts
- src/tests/zai-mcp-client.test.ts
- src/tools/executor.ts
- src/tools/zai-mcp-client.ts

## Checks
- [ ] Validate behavior locally