### PR TITLE
#22 - Document ACP_GLM_DEBUG in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
 | `ACP_GLM_THINKING` | No | auto-detected | Force thinking mode `true` / `false` |
 | `ACP_GLM_SESSION_DIR` | No | `$XDG_STATE_HOME/glm-acp-agent/sessions` | Where session JSON files are persisted |
+| `ACP_GLM_DEBUG` | No | — | Set to `true` or `1` to enable verbose debug logging to stderr (shows model selection, API key resolution, tool calls, and usage stats) |
 | `XDG_CONFIG_HOME` | No | `~/.config` | Where the credentials file is read/written |
 
 ### One-time setup

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ if (args.includes("--setup")) {
       "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",
       "  ACP_GLM_THINKING               Force thinking mode (true / false)",
       "  ACP_GLM_SESSION_DIR            Where to persist sessions (default: ~/.local/state/glm-acp-agent/sessions)",
+      "  ACP_GLM_DEBUG                  Enable verbose stderr logging (true or 1)",
       "  XDG_CONFIG_HOME                Where to read/write credentials.json (default: ~/.config)",
       "",
     ].join("\n")


### PR DESCRIPTION
## Purpose
Type: feature. Implement #22 - Document ACP_GLM_DEBUG in help and README.

Task: [#22](https://github.com/stefandevo/glm-acp-agent/issues/22)

## Key Changes
- README.md
- src/index.ts

## Checks
- [ ] Validate behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new debug environment variable that enables verbose logging with details about model selection, API key resolution, tool calls, and usage statistics to stderr.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->