### PR TITLE
#24 - Align Coding Plan models and add Vision MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 - **Tool calling** – agentic loop with up to 20 turns of GLM function calling
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
-- **Image input** – `promptCapabilities.image` is advertised; image content blocks are forwarded as data-URL parts so vision-capable models (e.g. `glm-4v-plus`) can ingest them
+- **Image input via Coding Plan Vision MCP** – `promptCapabilities.image` is advertised; pasted ACP image blocks are routed through Z.AI Vision MCP (`@z_ai/mcp-server`) and the resulting analysis is fed into the main coding model. Direct chat-image (e.g. `glm-4v-plus`) calls are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Six built-in tools** (see below)
 - **Capability-aware** – every tool is gated on the client capabilities advertised at `initialize` time; tools the client can't run return a clear error to the model instead of crashing
@@ -48,17 +48,18 @@ ACP Client (IDE plugin, CLI, …)
         ▼
   GlmAcpAgent          ← ACP protocol layer  (src/protocol/)
         │
-        ├─ GlmClient   ← Z.AI / Zhipu AI Chat Completions  (src/llm/)
-        │    └─ streams chat completions with tool schemas
+        ├─ GlmClient   ← Z.AI / Zhipu AI Coding Plan Chat Completions  (src/llm/)
         │
-        └─ ToolExecutor ← executes tool calls  (src/tools/)
-             ├─ read_file / write_file       → ACP client (fs.*)
-             ├─ list_files / run_command     → ACP client (terminal)
-             ├─ web_search                   → Z.AI Coding Plan Web Search MCP
-             └─ web_reader                   → Z.AI Coding Plan Web Reader MCP
+        ├─ ToolExecutor ← executes tool calls  (src/tools/)
+        │    ├─ read_file / write_file       → ACP client (fs.*)
+        │    ├─ list_files / run_command     → ACP client (terminal)
+        │    ├─ web_search / web_reader      → Z.AI Coding Plan Web MCP (HTTP)
+        │    └─ image_analysis               → Z.AI Coding Plan Vision MCP (stdio)
+        │
+        └─ VisionMcpClient ← spawns `npx @z_ai/mcp-server` on demand
 ```
 
-The agent process itself only needs network access to `api.z.ai`. All file-system and shell operations are **delegated to the ACP client** — the agent never touches the local disk directly. `web_search` and `web_reader` run **inside the agent process** and call Z.AI's Coding Plan-compatible MCP servers with the same resolved API key used for model calls.
+The agent process needs network access to `api.z.ai` for chat completions and Web MCP, plus `npx` available on `PATH` so it can launch `@z_ai/mcp-server` for vision. Filesystem and shell operations remain delegated to the ACP client; the agent itself only writes to the OS temp directory when it needs to materialize a pasted image for Vision MCP, and those temp files are removed once the prompt completes.
 
 ---
 
@@ -72,6 +73,7 @@ The agent process itself only needs network access to `api.z.ai`. All file-syste
 | `run_command` | ACP client | `terminal` | Run an arbitrary shell command via `sh -c` (asks for permission) |
 | `web_search` | Agent (Z.AI Coding Plan MCP) | – | Search the web — returns titles, URLs, and summaries |
 | `web_reader` | Agent (Z.AI Coding Plan MCP) | – | Fetch and parse a web page (markdown or plain text) |
+| `image_analysis` | Agent (Z.AI Vision MCP, stdio) | – | Analyze a local image path or remote URL using `@z_ai/mcp-server` |
 
 ---
 
@@ -125,17 +127,31 @@ The key is written to `$XDG_CONFIG_HOME/glm-acp-agent/credentials.json` (default
 
 ### Supported models
 
-Any model exposed by the Z.AI Chat Completions API can be used. Recommended choices:
+The agent advertises only the models on the current Z.AI Coding Plan allowlist:
 
 | Model | Notes |
 |-------|-------|
 | `glm-5.1` | **Default.** Long-horizon coding model; thinking mode auto-enabled |
-| `glm-4.7` | Strong reasoning, 200K context |
-| `glm-4.6` | Faster, slightly cheaper |
-| `glm-4.5` | Cost-efficient general-purpose |
-| `glm-4-long` | Extended-context variant |
+| `glm-5-turbo` | Faster Coding Plan reasoning model |
+| `glm-4.7` | 200K-context reasoning model |
+| `glm-4.5-air` | Lightweight, lower-latency model |
+
+`ACP_GLM_AVAILABLE_MODELS` still lets you advertise custom IDs, but custom IDs sit outside the supported Coding Plan list — the Coding Plan endpoint will reject any model code Z.AI hasn't whitelisted (business code `1211`).
+
+Vision (`glm-4v-plus` etc.) is **not** advertised as a chat model: vision on the Coding Plan flows through the [Vision MCP](#vision-mcp) section below instead.
 
 When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or `glm-5.x`, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. Override with `ACP_GLM_THINKING=false` if you want plain completions only.
+
+### Vision MCP
+
+Pasted ACP image blocks are not sent to the chat-completions endpoint. Instead, the agent boots `@z_ai/mcp-server` over stdio (via `npx -y @z_ai/mcp-server@latest`) and calls its `image_analysis` tool. The text result is spliced into the user message as `<image_analysis index="N">…</image_analysis>` so the regular Coding Plan model can reason about it.
+
+Prerequisites:
+
+- `npx` on `PATH` (Node 18+ / npm 9+).
+- The same `Z_AI_API_KEY` used for chat completions; the agent forwards it to the MCP server as `Z_AI_API_KEY` plus `Z_AI_MODE=ZAI`.
+
+The model can also call `image_analysis` explicitly with `{ image_source: "/path/or/url", prompt?: "…" }`. Vision failures (missing `npx`, MCP startup, quota) are surfaced as actionable errors but never abort the prompt; an inline `<image_analysis_error>` annotation is used so the conversation can continue.
 
 ---
 
@@ -330,6 +346,7 @@ The test suite covers:
 - Permission flows for `write_file` and `run_command` (allow / reject / cancel)
 - Shell-quoted argument handling for `list_files` and `run_command`
 - GLM streaming: text deltas, `reasoning_content` deltas, multi-chunk tool-call assembly, and trailing usage
+- Image preprocessing through a mocked Vision MCP client and graceful degradation on Vision MCP failures
 
 ---
 

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM model family. Supports streaming, tool calls, mid-session model switching (session/set_model), image input on vision-capable models, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -59,24 +59,19 @@ const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
     description: "Latest GLM reasoning model with thinking mode",
   },
   {
-    modelId: "glm-4.6",
-    name: "GLM-4.6",
-    description: "General-purpose reasoning model",
+    modelId: "glm-5-turbo",
+    name: "GLM-5 Turbo",
+    description: "Faster Coding Plan reasoning model",
   },
   {
-    modelId: "glm-4.5",
-    name: "GLM-4.5",
-    description: "Stable production model",
+    modelId: "glm-4.7",
+    name: "GLM-4.7",
+    description: "200K-context reasoning model",
   },
   {
     modelId: "glm-4.5-air",
     name: "GLM-4.5 Air",
     description: "Lightweight, lower-latency model",
-  },
-  {
-    modelId: "glm-4v-plus",
-    name: "GLM-4V Plus",
-    description: "Vision-capable multimodal model",
   },
 ];
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -44,6 +44,9 @@ import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
+import { preprocessImageBlocks, type PreprocessedPrompt } from "./image-preprocessor.js";
+import { StdioVisionMcpClient, type VisionMcpClient } from "../tools/vision-mcp-client.js";
+import { resolveApiKey } from "../llm/credentials.js";
 import { debug, error } from "../llm/logger.js";
 
 /**
@@ -96,6 +99,13 @@ export interface GlmAcpAgentOptions {
    * Pass `null` to disable persistence entirely.
    */
   sessionStore?: SessionStore | null;
+  /**
+   * Vision MCP client used to analyze ACP image blocks via @z_ai/mcp-server.
+   * Pass `null` to disable vision entirely (image blocks degrade to a text
+   * placeholder). When undefined the agent lazy-creates a StdioVisionMcpClient
+   * on first use.
+   */
+  visionClient?: VisionMcpClient | null;
 }
 
 /**
@@ -111,6 +121,8 @@ export class GlmAcpAgent implements Agent {
   private maxTurns: number;
   private clientCapabilities: ClientCapabilities | null = null;
   private sessionStore: SessionStore | null;
+  private _visionClient: VisionMcpClient | null;
+  private visionClientExplicit: boolean;
 
   constructor(
     private connection: AgentSideConnection,
@@ -126,6 +138,8 @@ export class GlmAcpAgent implements Agent {
       options.sessionStore === null
         ? null
         : (options.sessionStore ?? new SessionStore());
+    this.visionClientExplicit = "visionClient" in options;
+    this._visionClient = options.visionClient ?? null;
   }
 
   private get glm(): NonNullable<GlmAcpAgentOptions["glm"]> {
@@ -133,6 +147,16 @@ export class GlmAcpAgent implements Agent {
       this._glm = new GlmClient();
     }
     return this._glm;
+  }
+
+  private get visionClient(): VisionMcpClient | null {
+    if (this.visionClientExplicit) return this._visionClient;
+    if (!this._visionClient) {
+      const apiKey = resolveApiKey();
+      if (!apiKey) return null;
+      this._visionClient = new StdioVisionMcpClient({ apiKey });
+    }
+    return this._visionClient;
   }
 
   // ---------------------------------------------------------------------------
@@ -331,11 +355,17 @@ export class GlmAcpAgent implements Agent {
     }
 
     // Convert ACP content blocks into a GLM user message. Baseline: text +
-    // resource_link. Optional: embedded resources, plus image blocks (forwarded
-    // as OpenAI-shaped data-URL parts so vision-capable GLM models like
-    // glm-4v-plus can ingest them).
+    // resource_link. Optional: embedded resources. Image blocks are routed
+    // through Z.AI Coding Plan Vision MCP (see image-preprocessor) so the
+    // result is always a plain string for the chat-completions endpoint.
+    let preprocessed: PreprocessedPrompt | undefined;
+    preprocessed = await preprocessImageBlocks(
+      params.prompt,
+      this.visionClient,
+      abortController.signal
+    );
     const { content: userContent, plainText: userText } = renderPromptBlocks(
-      params.prompt
+      preprocessed.blocks
     );
     session.messages.push({ role: "user", content: userContent });
 
@@ -411,6 +441,9 @@ export class GlmAcpAgent implements Agent {
       // Always resolve the promptPromise so a subsequent prompt can proceed.
       session.promptPromise = null;
       resolvePromptPromise();
+      for (const cleanup of preprocessed?.cleanups ?? []) {
+        try { await cleanup(); } catch { /* best effort */ }
+      }
     }
   }
 
@@ -660,7 +693,8 @@ export class GlmAcpAgent implements Agent {
       this.connection,
       sessionId,
       this.clientCapabilities,
-      signal
+      signal,
+      this.visionClient
     );
 
     let lastUsage: Usage | undefined;
@@ -797,35 +831,28 @@ export class GlmAcpAgent implements Agent {
     if (fs.readTextFile) names.push("read_file");
     if (fs.writeTextFile) names.push("write_file");
     if (terminal) names.push("list_files", "run_command");
-    // Web tools always run inside the agent process, so they are unconditional.
+    // Web tools and image_analysis run inside the agent process, so they are
+    // unconditional except when vision is explicitly disabled.
     names.push("web_search", "web_reader");
+    if (this.visionClientExplicit ? this._visionClient !== null : true) {
+      names.push("image_analysis");
+    }
     return names;
   }
 }
 
-/** OpenAI-shaped content part for multimodal user messages. */
-type UserContentPart =
-  | { type: "text"; text: string }
-  | { type: "image_url"; image_url: { url: string } };
-
 /**
- * Render a list of ACP content blocks into a GLM user message.
+ * Render a list of ACP content blocks (after image preprocessing) into the
+ * plain-string user message we send to the chat-completions endpoint.
  *
- * When the prompt contains only text/resource blocks we return a plain string
- * (the broadest-compatible shape). When at least one image block is present
- * we switch to OpenAI's multimodal array shape so vision-capable GLM models
- * receive the image as a data URL.
- *
- * `plainText` always contains the text-only flattening of the prompt and is
- * used by the agent to derive a session title.
+ * `plainText` mirrors `content` and is used by the agent to derive a session
+ * title.
  */
-function renderPromptBlocks(blocks: PromptRequest["prompt"]): {
-  content: string | UserContentPart[];
+function renderPromptBlocks(blocks: ReadonlyArray<PromptRequest["prompt"][number]>): {
+  content: string;
   plainText: string;
 } {
   const textParts: string[] = [];
-  const imageParts: UserContentPart[] = [];
-
   for (const block of blocks) {
     switch (block.type) {
       case "text":
@@ -839,15 +866,13 @@ function renderPromptBlocks(blocks: PromptRequest["prompt"]): {
         if ("text" in res && typeof res.text === "string") {
           textParts.push(`<resource uri="${res.uri}">\n${res.text}\n</resource>`);
         } else if ("blob" in res) {
-          // Binary resources can't be inlined into a chat message; keep a link
-          // reference so the model knows it exists.
           textParts.push(`[binary resource](${res.uri})`);
         }
         break;
       }
       case "image": {
-        const dataUrl = `data:${block.mimeType};base64,${block.data}`;
-        imageParts.push({ type: "image_url", image_url: { url: dataUrl } });
+        // Defensive: image blocks should have been preprocessed away upstream.
+        textParts.push(`[image: ${block.mimeType}]`);
         break;
       }
       case "audio":
@@ -857,46 +882,13 @@ function renderPromptBlocks(blocks: PromptRequest["prompt"]): {
         textParts.push(`[unknown block type ${(block as { type: string }).type}]`);
     }
   }
-
   const plainText = textParts.join("\n");
-
-  if (imageParts.length === 0) {
-    return { content: plainText, plainText };
-  }
-
-  // Multimodal: combine text + images. OpenAI requires at least one part, so
-  // we always include the text part (even when empty, the array form is valid).
-  const content: UserContentPart[] = [];
-  if (plainText.length > 0) {
-    content.push({ type: "text", text: plainText });
-  }
-  content.push(...imageParts);
-  return { content, plainText };
+  return { content: plainText, plainText };
 }
 
-/**
- * Flatten the `content` of a user message into a plain string for replay.
- *
- * Multimodal user messages (text + image parts) are rendered as their text
- * portions only; images are noted with a placeholder so the client knows
- * something visual was there but doesn't try to re-render an opaque
- * `image_url` part it never produced.
- */
+/** Flatten the `content` of a user message into a plain string for replay. */
 function stringifyUserMessage(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  const parts: string[] = [];
-  for (const part of content) {
-    if (typeof part !== "object" || part === null) continue;
-    const type = (part as { type?: unknown }).type;
-    if (type === "text") {
-      const text = (part as { text?: unknown }).text;
-      if (typeof text === "string") parts.push(text);
-    } else if (type === "image_url") {
-      parts.push("[image]");
-    }
-  }
-  return parts.join("\n");
+  return typeof content === "string" ? content : "";
 }
 
 /**

--- a/src/protocol/image-preprocessor.ts
+++ b/src/protocol/image-preprocessor.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
+import type { PromptRequest } from "@agentclientprotocol/sdk";
+import type { VisionMcpClient } from "../tools/vision-mcp-client.js";
+
+type Block = PromptRequest["prompt"][number];
+type TextBlock = { type: "text"; text: string };
+
+export interface PreprocessedPrompt {
+  blocks: Block[];
+  cleanups: Array<() => Promise<void>>;
+}
+
+/**
+ * Replace every ACP image block with a text annotation containing the result
+ * of a Vision MCP `image_analysis` call. ACP image blocks may carry a usable
+ * URI (passed through as-is) or only inline base64 `data` (we materialize that
+ * to an OS temp file and pass the path; cleanup callbacks remove it later).
+ *
+ * Failures from the vision client are degraded into `<image_analysis_error>`
+ * annotations so a vision outage cannot crash a prompt that happens to
+ * include an image.
+ */
+export async function preprocessImageBlocks(
+  blocks: ReadonlyArray<Block>,
+  visionClient: VisionMcpClient | null,
+  signal?: AbortSignal
+): Promise<PreprocessedPrompt> {
+  if (!blocks.some((b) => b.type === "image")) {
+    return { blocks: [...blocks], cleanups: [] };
+  }
+
+  const out: Block[] = [];
+  const cleanups: Array<() => Promise<void>> = [];
+  let imageIndex = 0;
+
+  for (const block of blocks) {
+    if (block.type !== "image") {
+      out.push(block);
+      continue;
+    }
+    imageIndex += 1;
+
+    if (!visionClient) {
+      out.push(textBlock(`<image_attached index="${imageIndex}" mime="${block.mimeType}">image attached (not analyzed; Vision MCP unavailable)</image_attached>`));
+      continue;
+    }
+
+    let imageSource = "";
+    if (typeof block.uri === "string" && block.uri.length > 0) {
+      imageSource = block.uri;
+    } else if (typeof block.data === "string" && block.data.length > 0) {
+      const dir = await mkdtemp(pathJoin(tmpdir(), "glm-acp-image-"));
+      const ext = guessExtension(block.mimeType);
+      const path = pathJoin(dir, `image-${imageIndex}${ext}`);
+      await writeFile(path, Buffer.from(block.data, "base64"));
+      imageSource = path;
+      cleanups.push(async () => {
+        try { await rm(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+      });
+    } else {
+      out.push(textBlock(`<image_analysis_error index="${imageIndex}">image block has neither a uri nor base64 data</image_analysis_error>`));
+      continue;
+    }
+
+    try {
+      const result = await visionClient.callTool("image_analysis", { image_source: imageSource }, signal);
+      const text = extractText(result);
+      out.push(textBlock(`<image_analysis index="${imageIndex}">\n${text}\n</image_analysis>`));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      out.push(textBlock(`<image_analysis_error index="${imageIndex}">${message}</image_analysis_error>`));
+    }
+  }
+
+  return { blocks: out, cleanups };
+}
+
+function textBlock(text: string): TextBlock {
+  return { type: "text", text };
+}
+
+function guessExtension(mime: string): string {
+  switch (mime.toLowerCase()) {
+    case "image/png": return ".png";
+    case "image/jpeg":
+    case "image/jpg": return ".jpg";
+    case "image/gif": return ".gif";
+    case "image/webp": return ".webp";
+    default: return ".bin";
+  }
+}
+
+function extractText(result: unknown): string {
+  if (typeof result === "string") return result;
+  if (typeof result !== "object" || result === null) return "";
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((entry) => (typeof entry === "object" && entry !== null && typeof (entry as { text?: unknown }).text === "string" ? (entry as { text: string }).text : ""))
+    .filter((s) => s.length > 0)
+    .join("\n");
+}

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -875,20 +875,28 @@ test("unstable_setSessionModel rejects unknown sessions", async () => {
 // Image content
 // ---------------------------------------------------------------------------
 
-test("prompt with image block forwards a multimodal user message", async () => {
+test("prompt with image block runs Vision MCP preprocessing and feeds text into the model", async () => {
   const conn = createConnectionStub();
-  let captured: unknown;
+  let capturedUser: unknown;
   const glm = {
     async *streamChat(
       messages: ReadonlyArray<{ role: string; content?: unknown }>
     ): AsyncGenerator<GlmStreamChunk> {
       const userMsg = messages.find((m) => m.role === "user");
-      captured = userMsg?.content;
+      capturedUser = userMsg?.content;
       yield { text: "ok" };
       yield { done: true, stopReason: "stop" };
     },
   };
-  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  const visionCalls: Array<Record<string, unknown>> = [];
+  const visionClient = {
+    async callTool(_name: string, args: Record<string, unknown>) {
+      visionCalls.push(args);
+      return { content: [{ type: "text", text: "It is a kitten." }] };
+    },
+    async dispose() {},
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, visionClient, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
@@ -896,16 +904,77 @@ test("prompt with image block forwards a multimodal user message", async () => {
     sessionId,
     prompt: [
       { type: "text", text: "What is in this image?" },
-      { type: "image", data: "AAAA", mimeType: "image/png" },
+      { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
     ],
   });
 
-  assert.ok(Array.isArray(captured), "expected multimodal content array");
-  const arr = captured as Array<{ type: string; image_url?: { url: string }; text?: string }>;
-  const textPart = arr.find((p) => p.type === "text");
-  const imagePart = arr.find((p) => p.type === "image_url");
-  assert.equal(textPart?.text, "What is in this image?");
-  assert.equal(imagePart?.image_url?.url, "data:image/png;base64,AAAA");
+  assert.equal(visionCalls.length, 1);
+  assert.equal(visionCalls[0]?.["image_source"], "https://example.com/cat.png");
+  // Resulting user content must be a plain string with image annotation embedded.
+  assert.equal(typeof capturedUser, "string");
+  assert.match(capturedUser as string, /What is in this image\?/);
+  assert.match(capturedUser as string, /<image_analysis index="1">[\s\S]*It is a kitten\.[\s\S]*<\/image_analysis>/);
+});
+
+test("prompt with image block but no vision client falls back to a text annotation", async () => {
+  const conn = createConnectionStub();
+  let capturedUser: unknown;
+  const glm = {
+    async *streamChat(
+      messages: ReadonlyArray<{ role: string; content?: unknown }>
+    ): AsyncGenerator<GlmStreamChunk> {
+      const userMsg = messages.find((m) => m.role === "user");
+      capturedUser = userMsg?.content;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, visionClient: null, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await agent.prompt({
+    sessionId,
+    prompt: [
+      { type: "text", text: "Describe" },
+      { type: "image", data: "AAAA", mimeType: "image/png" },
+    ],
+  });
+  assert.equal(typeof capturedUser, "string");
+  assert.match(capturedUser as string, /image_attached/);
+});
+
+test("Vision MCP failures degrade gracefully without aborting the prompt", async () => {
+  const conn = createConnectionStub();
+  let capturedUser: unknown;
+  const glm = {
+    async *streamChat(
+      messages: ReadonlyArray<{ role: string; content?: unknown }>
+    ): AsyncGenerator<GlmStreamChunk> {
+      const userMsg = messages.find((m) => m.role === "user");
+      capturedUser = userMsg?.content;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const visionClient = {
+    async callTool() { throw new Error("Vision MCP image_analysis failed: quota exceeded"); },
+    async dispose() {},
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, visionClient, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  const result = await agent.prompt({
+    sessionId,
+    prompt: [
+      { type: "text", text: "look" },
+      { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/x.png" },
+    ],
+  });
+  assert.equal(result.stopReason, "end_turn");
+  assert.match(capturedUser as string, /image_analysis_error/);
+  assert.match(capturedUser as string, /quota exceeded/);
 });
 
 test("prompt without image blocks keeps content as a plain string", async () => {

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeCredentials } from "../llm/credentials.js";
 import { ToolExecutor } from "../tools/executor.js";
+import type { VisionMcpClient } from "../tools/vision-mcp-client.js";
 
 interface StubTerminal {
   id: string;
@@ -567,4 +568,60 @@ test("write_file rejects whitespace-only paths", async () => {
     JSON.stringify({ path: " \t\n", content: "x" })
   );
   assert.match(result.content, /path.*required/);
+});
+
+// ---------------------------------------------------------------------------
+// image_analysis (Vision MCP)
+// ---------------------------------------------------------------------------
+
+function fakeVisionClient(impl: VisionMcpClient["callTool"]): VisionMcpClient {
+  return {
+    callTool: impl,
+    async dispose() { /* noop */ },
+  };
+}
+
+test("image_analysis routes through the injected vision client and returns the text", async () => {
+  const conn = createConnectionStub();
+  const vision = fakeVisionClient(async (toolName, args) => {
+    assert.equal(toolName, "image_analysis");
+    assert.equal(args["image_source"], "/tmp/cat.png");
+    return { content: [{ type: "text", text: "A tabby cat." }] };
+  });
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS, undefined, vision);
+  const result = await exec.execute(
+    "tc1",
+    "image_analysis",
+    JSON.stringify({ image_source: "/tmp/cat.png", prompt: "describe" })
+  );
+  assert.equal(result.content, "A tabby cat.");
+  const last = conn.updates.at(-1) as { update: { status?: string } };
+  assert.equal(last.update.status, "completed");
+});
+
+test("image_analysis surfaces vision errors as a failed tool result", async () => {
+  const conn = createConnectionStub();
+  const vision = fakeVisionClient(async () => {
+    throw new Error("Vision MCP image_analysis failed: quota exceeded");
+  });
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS, undefined, vision);
+  const result = await exec.execute(
+    "tc1",
+    "image_analysis",
+    JSON.stringify({ image_source: "/tmp/x.png" })
+  );
+  assert.match(result.content, /quota exceeded/);
+  const last = conn.updates.at(-1) as { update: { status?: string } };
+  assert.equal(last.update.status, "failed");
+});
+
+test("image_analysis is unavailable when no vision client is configured", async () => {
+  const conn = createConnectionStub();
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+  const result = await exec.execute(
+    "tc1",
+    "image_analysis",
+    JSON.stringify({ image_source: "/tmp/x.png" })
+  );
+  assert.match(result.content, /vision[^.]*not configured/i);
 });

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GlmClient } from "../llm/glm-client.js";
+import { GlmClient, getAvailableModels } from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
   process.env["Z_AI_API_KEY"] = "test-key";
@@ -150,6 +150,32 @@ test("constructor throws if Z_AI_API_KEY is missing", () => {
     assert.throws(() => new GlmClient(), /Z_AI_API_KEY/);
   } finally {
     if (old !== undefined) process.env["Z_AI_API_KEY"] = old;
+  }
+});
+
+test("getAvailableModels returns the Coding Plan allowlist by default", () => {
+  const old = process.env["ACP_GLM_AVAILABLE_MODELS"];
+  delete process.env["ACP_GLM_AVAILABLE_MODELS"];
+  try {
+    const ids = getAvailableModels().map((m) => m.modelId);
+    assert.deepEqual(ids, ["glm-5.1", "glm-5-turbo", "glm-4.7", "glm-4.5-air"]);
+    assert.ok(!ids.includes("glm-4v-plus"), "glm-4v-plus must not be advertised");
+    assert.ok(!ids.includes("glm-4.6"), "glm-4.6 must not be advertised");
+    assert.ok(!ids.includes("glm-4.5"), "glm-4.5 must not be advertised");
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_AVAILABLE_MODELS"] = old;
+  }
+});
+
+test("ACP_GLM_AVAILABLE_MODELS env override still wins over the built-in list", () => {
+  const old = process.env["ACP_GLM_AVAILABLE_MODELS"];
+  process.env["ACP_GLM_AVAILABLE_MODELS"] = "custom-a, custom-b";
+  try {
+    const ids = getAvailableModels().map((m) => m.modelId);
+    assert.deepEqual(ids, ["custom-a", "custom-b"]);
+  } finally {
+    if (old === undefined) delete process.env["ACP_GLM_AVAILABLE_MODELS"];
+    else process.env["ACP_GLM_AVAILABLE_MODELS"] = old;
   }
 });
 

--- a/src/tests/image-preprocessor.test.ts
+++ b/src/tests/image-preprocessor.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { preprocessImageBlocks } from "../protocol/image-preprocessor.js";
+import type { VisionMcpClient } from "../tools/vision-mcp-client.js";
+
+function makeClient(impl: VisionMcpClient["callTool"]): VisionMcpClient {
+  return { callTool: impl, async dispose() {} };
+}
+
+test("preprocessImageBlocks returns the input unchanged when no images are present", async () => {
+  const result = await preprocessImageBlocks(
+    [{ type: "text", text: "hi" }],
+    makeClient(async () => { throw new Error("should not be called"); })
+  );
+  assert.deepEqual(result.blocks, [{ type: "text", text: "hi" }]);
+  assert.equal(result.cleanups.length, 0);
+});
+
+test("preprocessImageBlocks forwards a remote URI directly to the vision client", async () => {
+  let seen: Record<string, unknown> | null = null;
+  const result = await preprocessImageBlocks(
+    [
+      { type: "text", text: "What is this?" },
+      { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
+    ],
+    makeClient(async (_name, args) => {
+      seen = args;
+      return { content: [{ type: "text", text: "A cat." }] };
+    })
+  );
+  assert.equal(seen?.["image_source"], "https://example.com/cat.png");
+  // Image block must have been replaced with a text annotation.
+  assert.equal(result.blocks.length, 2);
+  const last = result.blocks[1] as { type: string; text?: string };
+  assert.equal(last.type, "text");
+  assert.match(last.text ?? "", /<image_analysis index="1">[\s\S]*A cat\.[\s\S]*<\/image_analysis>/);
+});
+
+test("preprocessImageBlocks materializes inline data to a temp file and cleans it up", async () => {
+  let seenPath = "";
+  const result = await preprocessImageBlocks(
+    [{ type: "image", data: "AAAA", mimeType: "image/png" }],
+    makeClient(async (_name, args) => {
+      seenPath = String(args["image_source"]);
+      assert.ok(existsSync(seenPath), "temp file must exist while vision MCP is invoked");
+      const bytes = readFileSync(seenPath);
+      assert.equal(bytes.length, 3); // base64 "AAAA" = 3 bytes
+      return { content: [{ type: "text", text: "blank" }] };
+    })
+  );
+  // Run cleanups after the call returns and verify the file is gone.
+  for (const c of result.cleanups) await c();
+  assert.equal(existsSync(seenPath), false);
+});
+
+test("preprocessImageBlocks degrades gracefully when the vision client fails", async () => {
+  const result = await preprocessImageBlocks(
+    [
+      { type: "text", text: "Look:" },
+      { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/x.png" },
+    ],
+    makeClient(async () => { throw new Error("quota exceeded"); })
+  );
+  const annotation = result.blocks.at(-1) as { type: string; text?: string };
+  assert.equal(annotation.type, "text");
+  assert.match(annotation.text ?? "", /image_analysis_error/);
+  assert.match(annotation.text ?? "", /quota exceeded/);
+});
+
+test("preprocessImageBlocks skips vision when no client is given and notes the image", async () => {
+  const result = await preprocessImageBlocks(
+    [{ type: "image", data: "AAAA", mimeType: "image/png" }],
+    null
+  );
+  const block = result.blocks[0] as { type: string; text?: string };
+  assert.equal(block.type, "text");
+  assert.match(block.text ?? "", /image attached \(not analyzed/i);
+  assert.equal(result.cleanups.length, 0);
+});

--- a/src/tests/vision-mcp-client.test.ts
+++ b/src/tests/vision-mcp-client.test.ts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+import { StdioVisionMcpClient } from "../tools/vision-mcp-client.js";
+
+interface FakeChild extends EventEmitter {
+  stdin: Writable;
+  stdout: Readable;
+  stderr: Readable;
+  pid: number;
+  kill: (signal?: string) => boolean;
+}
+
+function makeFakeChild(): { child: FakeChild; written: string[]; pushStdout: (line: string) => void } {
+  const written: string[] = [];
+  const stdin = new Writable({
+    write(chunk, _enc, cb) {
+      written.push(chunk.toString("utf8"));
+      cb();
+    },
+  });
+  const stdout = new Readable({ read() { /* push manually */ } });
+  const stderr = new Readable({ read() { /* noop */ } });
+  const child = Object.assign(new EventEmitter(), {
+    stdin,
+    stdout,
+    stderr,
+    pid: 4242,
+    kill: () => true,
+  }) as FakeChild;
+  const pushStdout = (line: string) => stdout.push(line);
+  return { child, written, pushStdout };
+}
+
+test("StdioVisionMcpClient initializes once and forwards tools/call", async () => {
+  const { child, written, pushStdout } = makeFakeChild();
+  const client = new StdioVisionMcpClient({
+    apiKey: "key-1",
+    spawn: () => child as never,
+  });
+
+  const callPromise = client.callTool("image_analysis", {
+    image_source: "/tmp/x.png",
+    prompt: "describe",
+  });
+
+  // Wait a tick so the client has written initialize.
+  await new Promise((r) => setImmediate(r));
+  const initLine = written[0] ?? "";
+  const initBody = JSON.parse(initLine.trim()) as { id: number; method: string };
+  assert.equal(initBody.method, "initialize");
+
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: initBody.id, result: { protocolVersion: "2025-06-18" } }) + "\n");
+
+  // Initialized notification + tools/call should follow.
+  await new Promise((r) => setImmediate(r));
+  const initialized = JSON.parse(written[1]?.trim() ?? "{}") as { method: string };
+  assert.equal(initialized.method, "notifications/initialized");
+  const callBody = JSON.parse(written[2]?.trim() ?? "{}") as { id: number; method: string; params: { name: string; arguments: Record<string, unknown> } };
+  assert.equal(callBody.method, "tools/call");
+  assert.equal(callBody.params.name, "image_analysis");
+  assert.equal(callBody.params.arguments["image_source"], "/tmp/x.png");
+
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: callBody.id, result: { content: [{ type: "text", text: "a cat" }] } }) + "\n");
+
+  const result = await callPromise;
+  assert.deepEqual(result, { content: [{ type: "text", text: "a cat" }] });
+
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient surfaces JSON-RPC errors with method context", async () => {
+  const { child, pushStdout } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+
+  const callPromise = client.callTool("image_analysis", { image_source: "x" });
+
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, error: { code: -32000, message: "quota exceeded" } }) + "\n");
+
+  await assert.rejects(callPromise, /Vision MCP image_analysis failed.*quota exceeded/);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient explains a missing npx as an actionable error", async () => {
+  const client = new StdioVisionMcpClient({
+    apiKey: "k",
+    spawn: () => {
+      const err = Object.assign(new Error("spawn npx ENOENT"), { code: "ENOENT" });
+      throw err;
+    },
+  });
+  await assert.rejects(
+    () => client.callTool("image_analysis", { image_source: "x" }),
+    /npx.*not found/i
+  );
+});

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -141,4 +141,26 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "image_analysis",
+      description:
+        "Analyze an image (local file path or remote URL) using Z.AI Coding Plan Vision MCP. Returns a textual description / answer. Use this to extract text from screenshots, describe diagrams, or answer questions about images the user has referenced.",
+      parameters: {
+        type: "object",
+        properties: {
+          image_source: {
+            type: "string",
+            description: "Local file path or remote URL of the image to analyze.",
+          },
+          prompt: {
+            type: "string",
+            description: "Optional question or instruction guiding the analysis. Defaults to a general description.",
+          },
+        },
+        required: ["image_source"],
+      },
+    },
+  },
 ];

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -8,6 +8,7 @@ import {
   ZAI_WEB_READER_MCP_ENDPOINT,
   ZAI_WEB_SEARCH_MCP_ENDPOINT,
 } from "./zai-mcp-client.js";
+import type { VisionMcpClient } from "./vision-mcp-client.js";
 
 /**
  * Result returned after executing a tool call against the ACP client.
@@ -29,7 +30,8 @@ export class ToolExecutor {
     private connection: AgentSideConnection,
     private sessionId: string,
     private clientCapabilities: ClientCapabilities | null = null,
-    private signal?: AbortSignal
+    private signal?: AbortSignal,
+    private visionClient: VisionMcpClient | null = null
   ) {}
 
   /**
@@ -67,6 +69,8 @@ export class ToolExecutor {
         return this.webSearch(toolCallId, args);
       case "web_reader":
         return this.webReader(toolCallId, args);
+      case "image_analysis":
+        return this.imageAnalysis(toolCallId, args);
       default: {
         const message = `Error: unknown tool "${toolName}"`;
         await this.failedToolCall(toolCallId, toolName, args, message);
@@ -585,6 +589,66 @@ export class ToolExecutor {
     }
   }
 
+  private async imageAnalysis(
+    toolCallId: string,
+    args: Record<string, unknown>
+  ): Promise<ToolResult> {
+    const imageSource = String(args["image_source"] ?? "").trim();
+    const prompt = typeof args["prompt"] === "string" ? args["prompt"] : undefined;
+    if (!imageSource) {
+      return this.failAndReturn(
+        toolCallId,
+        "image_analysis",
+        args,
+        "Error: `image_source` is required."
+      );
+    }
+    if (!this.visionClient) {
+      return this.failAndReturn(
+        toolCallId,
+        "image_analysis",
+        args,
+        "Error: vision is not configured on this agent process. Vision MCP requires `npx` and the Z.AI Coding Plan."
+      );
+    }
+
+    await this.connection.sessionUpdate({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title: `Analyze image: ${imageSource}`,
+        kind: "fetch",
+        status: "in_progress",
+        locations: [{ path: imageSource }],
+        rawInput: args,
+      },
+    });
+
+    try {
+      const visionArgs: Record<string, unknown> = { image_source: imageSource };
+      if (prompt) visionArgs["prompt"] = prompt;
+      const mcpResult = await this.visionClient.callTool("image_analysis", visionArgs, this.signal);
+      const text = unwrapVisionText(mcpResult);
+
+      await this.connection.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text } }],
+          rawOutput: { text },
+        },
+      });
+      return { content: text };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.markFailed(toolCallId, message);
+      return { content: `Error analyzing image: ${message}` };
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Notification helpers
   // ---------------------------------------------------------------------------
@@ -750,4 +814,16 @@ function stringValue(value: unknown): string | undefined {
  */
 function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function unwrapVisionText(mcpResult: unknown): string {
+  if (!isRecord(mcpResult)) return typeof mcpResult === "string" ? mcpResult : "";
+  const content = mcpResult["content"];
+  if (Array.isArray(content)) {
+    const texts = content
+      .map((entry) => (isRecord(entry) && typeof entry["text"] === "string" ? (entry["text"] as string) : ""))
+      .filter((s) => s.length > 0);
+    if (texts.length > 0) return texts.join("\n");
+  }
+  return JSON.stringify(mcpResult);
 }

--- a/src/tools/vision-mcp-client.ts
+++ b/src/tools/vision-mcp-client.ts
@@ -1,0 +1,163 @@
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+export interface VisionMcpClient {
+  callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown>;
+  dispose(): Promise<void>;
+}
+
+interface StdioVisionMcpClientOptions {
+  apiKey: string;
+  /** Override the package spec for tests/pinning. Defaults to `@z_ai/mcp-server@latest`. */
+  packageSpec?: string;
+  /** Override the spawn function for tests. */
+  spawn?: (command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => ChildProcessWithoutNullStreams;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  method: string;
+}
+
+export class StdioVisionMcpClient implements VisionMcpClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private initialized: Promise<void> | null = null;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private buffer = "";
+  private exited = false;
+  private exitReason: string | null = null;
+
+  constructor(private opts: StdioVisionMcpClientOptions) {}
+
+  async callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    if (signal?.aborted) throw new Error("Vision MCP call cancelled");
+    await this.ensureInitialized();
+    return this.request("tools/call", { name: toolName, arguments: args }, `Vision MCP ${toolName}`, signal);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.child && !this.exited) {
+      try {
+        this.child.kill();
+      } catch {
+        // ignore
+      }
+    }
+    this.child = null;
+    this.initialized = null;
+    for (const [, p] of this.pending) {
+      p.reject(new Error(`cancelled (client disposed)`));
+    }
+    this.pending.clear();
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return this.initialized;
+    this.initialized = this.startAndInitialize();
+    try {
+      await this.initialized;
+    } catch (err) {
+      this.initialized = null;
+      throw err;
+    }
+  }
+
+  private async startAndInitialize(): Promise<void> {
+    const packageSpec = this.opts.packageSpec ?? "@z_ai/mcp-server@latest";
+    const spawnFn = this.opts.spawn ?? nodeSpawn;
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnFn("npx", ["-y", packageSpec], {
+        env: { ...process.env, Z_AI_API_KEY: this.opts.apiKey, Z_AI_MODE: "ZAI" },
+      });
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      if (code === "ENOENT") {
+        throw new Error("Vision MCP startup failed: `npx` not found on PATH. Install Node.js / npm 9+ and ensure `npx` is available.");
+      }
+      throw new Error(`Vision MCP startup failed: ${(err as Error).message}`);
+    }
+    this.child = child;
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
+    child.on("exit", (code, sig) => {
+      this.exited = true;
+      this.exitReason = `exit code=${code} signal=${sig ?? "(none)"}`;
+      for (const [, p] of this.pending) {
+        p.reject(new Error(`server exited (${this.exitReason}).`));
+      }
+      this.pending.clear();
+    });
+    child.on("error", (err) => {
+      this.exited = true;
+      this.exitReason = err.message;
+    });
+
+    await this.request("initialize", {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
+    }, "Vision MCP initialize");
+    this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  }
+
+  private request(method: string, params: Record<string, unknown>, label: string, signal?: AbortSignal): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      this.pending.set(id, {
+        method: label,
+        resolve,
+        reject: (err) => reject(new Error(`${label} failed: ${err.message}`)),
+      });
+      const onAbort = () => {
+        const pending = this.pending.get(id);
+        if (pending) {
+          this.pending.delete(id);
+          pending.reject(new Error("aborted"));
+        }
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        this.send({ jsonrpc: "2.0", id, method, params });
+      } catch (err) {
+        this.pending.delete(id);
+        reject(new Error(`${label} failed: ${(err as Error).message}`));
+      }
+    });
+  }
+
+  private send(message: Record<string, unknown>): void {
+    if (!this.child || this.exited) {
+      throw new Error(`Vision MCP server is not running${this.exitReason ? ` (${this.exitReason})` : ""}.`);
+    }
+    this.child.stdin.write(JSON.stringify(message) + "\n");
+  }
+
+  private handleStdout(chunk: string): void {
+    this.buffer += chunk;
+    let idx: number;
+    while ((idx = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (!line) continue;
+      let parsed: { id?: number; result?: unknown; error?: { code?: number; message?: string } };
+      try {
+        parsed = JSON.parse(line) as typeof parsed;
+      } catch {
+        continue;
+      }
+      if (typeof parsed.id !== "number") continue;
+      const pending = this.pending.get(parsed.id);
+      if (!pending) continue;
+      this.pending.delete(parsed.id);
+      if (parsed.error) {
+        pending.reject(new Error(parsed.error.message ?? `code ${parsed.error.code ?? "?"}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose
Type: feature. Implement #24 - Align Coding Plan models and add Vision MCP support.

Task: [#24](https://github.com/stefandevo/glm-acp-agent/issues/24)

## Key Changes
- README.md
- registry/glm-acp-agent/agent.json
- src/llm/glm-client.ts
- src/protocol/agent.ts
- src/protocol/image-preprocessor.ts
- src/tests/agent.test.ts
- src/tests/executor.test.ts
- src/tests/glm-client.test.ts
- src/tests/image-preprocessor.test.ts
- src/tests/vision-mcp-client.test.ts
- src/tools/definitions.ts
- src/tools/executor.ts
- src/tools/vision-mcp-client.ts

## Checks
- [ ] Validate behavior locally