### PR TITLE
#23 - Harden MCP web search discovery and retry

### DIFF
--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -358,6 +358,11 @@ test("web_search uses stored credentials and calls the Coding Plan MCP search to
         jsonResponse({
           jsonrpc: "2.0",
           id: 2,
+          result: { tools: [{ name: "webSearchPrime" }] },
+        }),
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
           result: {
             content: [
               {
@@ -389,12 +394,12 @@ test("web_search uses stored credentials and calls the Coding Plan MCP search to
 
         assert.match(result.content, /\[1\] GLM Coding Plan/);
         assert.match(result.content, /URL: https:\/\/z\.ai\//);
-        assert.equal(calls.length, 3);
+        assert.equal(calls.length, 4);
         assert.ok(calls.every((call) => call.url === "https://api.z.ai/api/mcp/web_search_prime/mcp"));
         assert.equal(calls[0]?.headers.get("Authorization"), "Bearer from-disk");
-        assert.equal(calls[2]?.headers.get("Mcp-Method"), "tools/call");
-        assert.equal(calls[2]?.headers.get("Mcp-Name"), "webSearchPrime");
-        assert.deepEqual(calls[2]?.body.params, {
+        assert.equal(calls[3]?.headers.get("Mcp-Method"), "tools/call");
+        assert.equal(calls[3]?.headers.get("Mcp-Name"), "webSearchPrime");
+        assert.deepEqual(calls[3]?.body.params, {
           name: "webSearchPrime",
           arguments: { query: "glm coding plan", count: 1 },
         });
@@ -420,6 +425,11 @@ test("web_reader calls the Coding Plan MCP reader tool and formats reader_result
         jsonResponse({
           jsonrpc: "2.0",
           id: 2,
+          result: { tools: [{ name: "webReader" }] },
+        }),
+        jsonResponse({
+          jsonrpc: "2.0",
+          id: 3,
           result: {
             content: [
               {
@@ -450,8 +460,8 @@ test("web_reader calls the Coding Plan MCP reader tool and formats reader_result
         assert.match(result.content, /URL: https:\/\/example\.com\//);
         assert.match(result.content, /Main body/);
         assert.ok(calls.every((call) => call.url === "https://api.z.ai/api/mcp/web_reader/mcp"));
-        assert.equal(calls[2]?.headers.get("Mcp-Name"), "webReader");
-        assert.deepEqual(calls[2]?.body.params, {
+        assert.equal(calls[3]?.headers.get("Mcp-Name"), "webReader");
+        assert.deepEqual(calls[3]?.body.params, {
           name: "webReader",
           arguments: { url: "https://example.com/", return_format: "markdown" },
         });

--- a/src/tests/zai-mcp-client.test.ts
+++ b/src/tests/zai-mcp-client.test.ts
@@ -271,3 +271,109 @@ test("ZaiMcpClient explains Coding Plan eligibility when Z.AI returns 1113", asy
     /Coding Plan quota\/base URL\/tool eligibility.*1113/
   );
 });
+
+test("ZaiMcpClient retries once on tool-not-found error with re-initialization", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    // First attempt: init
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {} },
+      },
+      { sessionId: "session-old" }
+    ),
+    new Response(null, { status: 202 }),
+    // First attempt: tools/list returns stale list
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "staleSearchTool" }] },
+    }),
+    // First attempt: tools/call fails with tool-not-found
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      error: { code: -32601, message: "Tool not found: staleSearchTool" },
+    }),
+    // Retry: re-initialize
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        result: { protocolVersion: "2025-06-18", capabilities: {} },
+      },
+      { sessionId: "session-new" }
+    ),
+    new Response(null, { status: 202 }),
+    // Retry: tools/list returns updated list
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 5,
+      result: { tools: [{ name: "webSearchV2" }] },
+    }),
+    // Retry: tools/call succeeds
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 6,
+      result: { content: [{ type: "text", text: "retry success" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  const result = await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { query: "test" },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(result, { content: [{ type: "text", text: "retry success" }] });
+  assert.equal(calls.length, 8);
+  assert.equal(calls[4]?.body.method, "initialize");
+  assert.equal(calls[6]?.body.method, "tools/list");
+  assert.equal(calls[7]?.body.method, "tools/call");
+  assert.deepEqual(calls[7]?.body.params, {
+    name: "webSearchV2",
+    arguments: { query: "test" },
+  });
+});
+
+test("ZaiMcpClient does not retry on non-tool-not-found errors", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {} },
+      },
+      { sessionId: "session-no-retry" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "webSearchPrime" }] },
+    }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      error: { code: -32000, message: "Internal server error" },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  await assert.rejects(
+    () =>
+      client.callTool({
+        endpoint,
+        toolName: "webSearchPrime",
+        arguments: { query: "test" },
+        apiKey: "test-key",
+      }),
+    /Internal server error/
+  );
+  assert.equal(calls.length, 4);
+});

--- a/src/tests/zai-mcp-client.test.ts
+++ b/src/tests/zai-mcp-client.test.ts
@@ -40,7 +40,7 @@ function createFetchStub(responses: Response[]) {
   return { calls, fetchStub };
 }
 
-test("ZaiMcpClient initializes, sends initialized, caches session id, and calls a tool", async () => {
+test("ZaiMcpClient initializes, sends initialized, discovers tools, and calls a tool", async () => {
   const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
   const { calls, fetchStub } = createFetchStub([
     jsonResponse(
@@ -55,6 +55,11 @@ test("ZaiMcpClient initializes, sends initialized, caches session id, and calls 
     jsonResponse({
       jsonrpc: "2.0",
       id: 2,
+      result: { tools: [{ name: "webSearchPrime" }] },
+    }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
       result: { content: [{ type: "text", text: "Search result text" }] },
     }),
   ]);
@@ -68,7 +73,7 @@ test("ZaiMcpClient initializes, sends initialized, caches session id, and calls 
   });
 
   assert.deepEqual(result, { content: [{ type: "text", text: "Search result text" }] });
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 4);
   assert.equal(calls[0]?.body.method, "initialize");
   assert.equal(calls[0]?.headers.get("Authorization"), "Bearer test-key");
   assert.equal(calls[0]?.headers.get("Accept"), "application/json, text/event-stream");
@@ -79,14 +84,60 @@ test("ZaiMcpClient initializes, sends initialized, caches session id, and calls 
   assert.equal(calls[1]?.headers.get("MCP-Session-Id"), "session-123");
   assert.equal(calls[1]?.headers.get("Mcp-Method"), "notifications/initialized");
 
-  assert.equal(calls[2]?.body.method, "tools/call");
-  assert.deepEqual(calls[2]?.body.params, {
+  assert.equal(calls[2]?.body.method, "tools/list");
+  assert.equal(calls[2]?.headers.get("MCP-Session-Id"), "session-123");
+
+  assert.equal(calls[3]?.body.method, "tools/call");
+  assert.deepEqual(calls[3]?.body.params, {
     name: "webSearchPrime",
     arguments: { query: "glm coding plan", count: 3 },
   });
-  assert.equal(calls[2]?.headers.get("MCP-Session-Id"), "session-123");
-  assert.equal(calls[2]?.headers.get("Mcp-Method"), "tools/call");
-  assert.equal(calls[2]?.headers.get("Mcp-Name"), "webSearchPrime");
+  assert.equal(calls[3]?.headers.get("MCP-Session-Id"), "session-123");
+  assert.equal(calls[3]?.headers.get("Mcp-Method"), "tools/call");
+  assert.equal(calls[3]?.headers.get("Mcp-Name"), "webSearchPrime");
+});
+
+test("ZaiMcpClient discovers tools after initialization and caches them", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "zai" } },
+      },
+      { sessionId: "session-discover" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        tools: [
+          { name: "webSearchPrime", description: "Search the web" },
+          { name: "otherTool", description: "Something else" },
+        ],
+      },
+    }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      result: { content: [{ type: "text", text: "ok" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { query: "test" },
+    apiKey: "test-key",
+  });
+
+  assert.equal(calls.length, 4);
+  assert.equal(calls[2]?.body.method, "tools/list");
+  assert.equal(calls[2]?.headers.get("MCP-Session-Id"), "session-discover");
+  assert.equal(calls[2]?.headers.get("Mcp-Method"), "tools/list");
 });
 
 test("ZaiMcpClient parses SSE wrapped JSON-RPC responses", async () => {
@@ -101,6 +152,11 @@ test("ZaiMcpClient parses SSE wrapped JSON-RPC responses", async () => {
     sseResponse({
       jsonrpc: "2.0",
       id: 2,
+      result: { tools: [{ name: "webReader" }] },
+    }),
+    sseResponse({
+      jsonrpc: "2.0",
+      id: 3,
       result: { content: [{ type: "text", text: "# Title\nBody" }] },
     }),
   ]);

--- a/src/tests/zai-mcp-client.test.ts
+++ b/src/tests/zai-mcp-client.test.ts
@@ -172,6 +172,79 @@ test("ZaiMcpClient parses SSE wrapped JSON-RPC responses", async () => {
   assert.deepEqual(result, { content: [{ type: "text", text: "# Title\nBody" }] });
 });
 
+test("ZaiMcpClient resolves tool name via keyword fallback when exact name is unavailable", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {} },
+      },
+      { sessionId: "session-fallback" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "webSearchV2" }, { name: "otherTool" }] },
+    }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      result: { content: [{ type: "text", text: "fallback result" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  const result = await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { query: "test" },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(result, { content: [{ type: "text", text: "fallback result" }] });
+  assert.equal(calls[3]?.body.method, "tools/call");
+  assert.deepEqual(calls[3]?.body.params, {
+    name: "webSearchV2",
+    arguments: { query: "test" },
+  });
+  assert.equal(calls[3]?.headers.get("Mcp-Name"), "webSearchV2");
+});
+
+test("ZaiMcpClient throws with diagnostics when no matching tool is found", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { fetchStub } = createFetchStub([
+    jsonResponse(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { protocolVersion: "2025-06-18", capabilities: {} },
+      },
+      { sessionId: "session-no-match" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "totallyUnrelated" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  await assert.rejects(
+    () =>
+      client.callTool({
+        endpoint,
+        toolName: "webSearchPrime",
+        arguments: { query: "test" },
+        apiKey: "test-key",
+      }),
+    /Tool "webSearchPrime" not available/
+  );
+});
+
 test("ZaiMcpClient explains Coding Plan eligibility when Z.AI returns 1113", async () => {
   const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
   const { fetchStub } = createFetchStub([

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -41,6 +41,17 @@ export class ZaiMcpClient {
   ) {}
 
   async callTool(call: ZaiMcpToolCall): Promise<unknown> {
+    try {
+      return await this.callToolInternal(call);
+    } catch (err) {
+      if (!isToolNotFoundError(err)) throw err;
+      const cacheKey = `${call.endpoint}\n${call.apiKey}`;
+      this.sessions.delete(cacheKey);
+      return this.callToolInternal(call);
+    }
+  }
+
+  private async callToolInternal(call: ZaiMcpToolCall): Promise<unknown> {
     const session = await this.ensureInitialized(call);
     const resolvedName = resolveToolName(call.toolName, session.toolNames, call.endpoint);
     const result = await this.sendRequest(
@@ -304,4 +315,12 @@ function extractToolKeyword(name: string): string | undefined {
   if (lower.includes("search")) return "search";
   if (lower.includes("reader")) return "reader";
   return undefined;
+}
+
+function isToolNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  if (/-32601/.test(msg)) return true;
+  if (/tool.*not.*found|not.*found.*tool|unknown.*tool/.test(msg)) return true;
+  return false;
 }

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -42,6 +42,7 @@ export class ZaiMcpClient {
 
   async callTool(call: ZaiMcpToolCall): Promise<unknown> {
     const session = await this.ensureInitialized(call);
+    const resolvedName = resolveToolName(call.toolName, session.toolNames, call.endpoint);
     const result = await this.sendRequest(
       call.endpoint,
       call.apiKey,
@@ -51,14 +52,14 @@ export class ZaiMcpClient {
         id: this.nextId++,
         method: "tools/call",
         params: {
-          name: call.toolName,
+          name: resolvedName,
           arguments: call.arguments,
         },
       },
       "tools/call",
       call.signal,
       session.sessionId,
-      call.toolName
+      resolvedName
     );
     return result;
   }
@@ -278,4 +279,29 @@ function formatJsonRpcError(stage: string, error: NonNullable<JsonRpcResponse["e
 
 function isCodingPlanEligibilityError(body: string): boolean {
   return /(^|["\s:])1113($|["\s,}])/.test(body);
+}
+
+function resolveToolName(
+  requestedName: string,
+  availableTools: string[],
+  endpoint: string
+): string {
+  if (availableTools.includes(requestedName)) return requestedName;
+
+  const keyword = extractToolKeyword(requestedName);
+  if (keyword) {
+    const match = availableTools.find((t) => t.toLowerCase().includes(keyword));
+    if (match) return match;
+  }
+
+  throw new Error(
+    `Tool "${requestedName}" not available on ${endpoint}. Available tools: [${availableTools.join(", ")}]`
+  );
+}
+
+function extractToolKeyword(name: string): string | undefined {
+  const lower = name.toLowerCase();
+  if (lower.includes("search")) return "search";
+  if (lower.includes("reader")) return "reader";
+  return undefined;
 }

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -32,7 +32,7 @@ export interface ZaiMcpToolCall {
 }
 
 export class ZaiMcpClient {
-  private sessions = new Map<string, { sessionId?: string; initialized: boolean }>();
+  private sessions = new Map<string, { sessionId?: string; initialized: boolean; toolNames: string[] }>();
   private nextId = 1;
 
   constructor(
@@ -102,9 +102,38 @@ export class ZaiMcpClient {
       sessionId
     );
 
-    const session = { sessionId, initialized: true };
+    const toolNames = await this.discoverTools(
+      call.endpoint,
+      call.apiKey,
+      sessionId,
+      call.signal
+    );
+    const session = { sessionId, initialized: true, toolNames };
     this.sessions.set(cacheKey, session);
     return session;
+  }
+
+  private async discoverTools(
+    endpoint: string,
+    apiKey: string,
+    sessionId: string | undefined,
+    signal?: AbortSignal
+  ): Promise<string[]> {
+    const response = await this.fetchJsonRpc(
+      endpoint,
+      apiKey,
+      "tools/list",
+      {
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method: "tools/list",
+      },
+      "tools/list",
+      signal,
+      sessionId
+    );
+    const result = response.body.result as { tools?: { name: string }[] } | undefined;
+    return result?.tools?.map((t) => t.name) ?? [];
   }
 
   private async sendRequest(


### PR DESCRIPTION
## Purpose
Type: feature. Implement #23 - Harden MCP web search discovery and retry.

Task: [#23](https://github.com/stefandevo/glm-acp-agent/issues/23)

## Key Changes
- src/tests/executor.test.ts
- src/tests/zai-mcp-client.test.ts
- src/tools/zai-mcp-client.ts

## Checks
- [ ] Validate behavior locally