### PR TITLE
#28 - Fix MCP naming: web_search arg name + Vision MCP tool discovery

### DIFF
--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -359,7 +359,7 @@ test("web_search uses stored credentials and calls the Coding Plan MCP search to
         jsonResponse({
           jsonrpc: "2.0",
           id: 2,
-          result: { tools: [{ name: "webSearchPrime" }] },
+          result: { tools: [{ name: "webSearchPrime", inputSchema: { properties: { search_query: { type: "string" } } } }] },
         }),
         jsonResponse({
           jsonrpc: "2.0",
@@ -402,7 +402,7 @@ test("web_search uses stored credentials and calls the Coding Plan MCP search to
         assert.equal(calls[3]?.headers.get("Mcp-Name"), "webSearchPrime");
         assert.deepEqual(calls[3]?.body.params, {
           name: "webSearchPrime",
-          arguments: { query: "glm coding plan", count: 1 },
+          arguments: { search_query: "glm coding plan", count: 1 },
         });
         const last = conn.updates.at(-1) as { update: { status?: string } };
         assert.equal(last.update.status, "completed");

--- a/src/tests/mcp-arg-remap.test.ts
+++ b/src/tests/mcp-arg-remap.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { remapArguments, resolveToolName } from "../tools/mcp-arg-remap.js";
+
+// ---------------------------------------------------------------------------
+// remapArguments
+// ---------------------------------------------------------------------------
+
+test("remapArguments: passes through unchanged when targetProperties is empty (no schema)", () => {
+  const args = { query: "hello", count: 5 };
+  const result = remapArguments(args, []);
+  assert.deepEqual(result, { query: "hello", count: 5 });
+});
+
+test("remapArguments: passes through when key already matches a target property", () => {
+  const result = remapArguments({ search_query: "hello" }, ["search_query", "count"]);
+  assert.deepEqual(result, { search_query: "hello" });
+});
+
+test("remapArguments: remaps query → search_query when search_query is in targetProperties", () => {
+  const result = remapArguments({ query: "hello", count: 3 }, ["search_query", "count"]);
+  assert.deepEqual(result, { search_query: "hello", count: 3 });
+});
+
+test("remapArguments: passes through unrecognised key that has no alias", () => {
+  const result = remapArguments({ unknown_key: "val" }, ["search_query"]);
+  assert.deepEqual(result, { unknown_key: "val" });
+});
+
+test("remapArguments: passes through alias key when alias not in targetProperties", () => {
+  // query → search_query alias exists, but target schema doesn't have search_query
+  const result = remapArguments({ query: "hello" }, ["q"]);
+  assert.deepEqual(result, { query: "hello" });
+});
+
+test("remapArguments: canonical key wins over alias (key already in targetProperties)", () => {
+  // If caller somehow passes search_query directly and it matches, no remapping occurs
+  const result = remapArguments({ search_query: "direct" }, ["search_query"]);
+  assert.deepEqual(result, { search_query: "direct" });
+});
+
+// ---------------------------------------------------------------------------
+// resolveToolName
+// ---------------------------------------------------------------------------
+
+test("resolveToolName: exact match takes priority", () => {
+  const result = resolveToolName("webSearchPrime", ["webSearchPrime", "webReader"], "test-endpoint");
+  assert.equal(result, "webSearchPrime");
+});
+
+test("resolveToolName: returns requestedName unchanged when availableTools is empty (fail-open)", () => {
+  const result = resolveToolName("image_analysis", [], "test-endpoint");
+  assert.equal(result, "image_analysis");
+});
+
+test("resolveToolName: keyword fallback matches search tool with different name", () => {
+  const result = resolveToolName("webSearch", ["SearchToolV2", "readerTool"], "test-endpoint");
+  assert.equal(result, "SearchToolV2");
+});
+
+test("resolveToolName: keyword fallback matches reader tool with different name", () => {
+  const result = resolveToolName("webReader", ["searchTool", "ContentReaderV2"], "test-endpoint");
+  assert.equal(result, "ContentReaderV2");
+});
+
+test("resolveToolName: keyword fallback matches vision/image tool with different name", () => {
+  const result = resolveToolName("image_analysis", ["analyzeImage", "otherTool"], "test-endpoint");
+  assert.equal(result, "analyzeImage");
+});
+
+test("resolveToolName: throws descriptive error when no match found", () => {
+  assert.throws(
+    () => resolveToolName("unknownTool", ["webSearch", "webReader"], "https://api.example.com"),
+    (err: Error) => {
+      assert.ok(err.message.includes('"unknownTool"'));
+      assert.ok(err.message.includes("webSearch"));
+      assert.ok(err.message.includes("webReader"));
+      return true;
+    }
+  );
+});

--- a/src/tests/vision-mcp-client.test.ts
+++ b/src/tests/vision-mcp-client.test.ts
@@ -53,11 +53,19 @@ test("StdioVisionMcpClient initializes once and forwards tools/call", async () =
 
   pushStdout(JSON.stringify({ jsonrpc: "2.0", id: initBody.id, result: { protocolVersion: "2025-06-18" } }) + "\n");
 
-  // Initialized notification + tools/call should follow.
+  // notifications/initialized and tools/list should follow.
   await new Promise((r) => setImmediate(r));
   const initialized = JSON.parse(written[1]?.trim() ?? "{}") as { method: string };
   assert.equal(initialized.method, "notifications/initialized");
-  const callBody = JSON.parse(written[2]?.trim() ?? "{}") as { id: number; method: string; params: { name: string; arguments: Record<string, unknown> } };
+
+  const toolsListBody = JSON.parse(written[2]?.trim() ?? "{}") as { id: number; method: string };
+  assert.equal(toolsListBody.method, "tools/list");
+
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: toolsListBody.id, result: { tools: [{ name: "image_analysis" }] } }) + "\n");
+
+  // tools/call should follow after tools/list completes.
+  await new Promise((r) => setImmediate(r));
+  const callBody = JSON.parse(written[3]?.trim() ?? "{}") as { id: number; method: string; params: { name: string; arguments: Record<string, unknown> } };
   assert.equal(callBody.method, "tools/call");
   assert.equal(callBody.params.name, "image_analysis");
   assert.equal(callBody.params.arguments["image_source"], "/tmp/x.png");
@@ -77,9 +85,11 @@ test("StdioVisionMcpClient surfaces JSON-RPC errors with method context", async 
   const callPromise = client.callTool("image_analysis", { image_source: "x" });
 
   await new Promise((r) => setImmediate(r));
-  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }) + "\n");
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }) + "\n"); // init response
   await new Promise((r) => setImmediate(r));
-  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, error: { code: -32000, message: "quota exceeded" } }) + "\n");
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { tools: [{ name: "image_analysis" }] } }) + "\n"); // tools/list
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 3, error: { code: -32000, message: "quota exceeded" } }) + "\n"); // tools/call error
 
   await assert.rejects(callPromise, /Vision MCP image_analysis failed.*quota exceeded/);
   await client.dispose();
@@ -98,3 +108,58 @@ test("StdioVisionMcpClient explains a missing npx as an actionable error", async
     /npx.*not found/i
   );
 });
+
+test("StdioVisionMcpClient resolves tool name via keyword fallback when server uses a different name", async () => {
+  const { child, written, pushStdout } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+
+  const callPromise = client.callTool("image_analysis", { image_source: "/img.png" });
+
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18" } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  // Server uses "analyzeImage" instead of "image_analysis"
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { tools: [{ name: "analyzeImage" }] } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  const callBody = JSON.parse(written[3]?.trim() ?? "{}") as { id: number; params: { name: string } };
+  assert.equal(callBody.params.name, "analyzeImage");
+
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: callBody.id, result: { content: [{ type: "text", text: "dog" }] } }) + "\n");
+  const result = await callPromise;
+  assert.deepEqual(result, { content: [{ type: "text", text: "dog" }] });
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient retries once on tool-not-found after re-discovering tools", async () => {
+  const { child, written, pushStdout } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+
+  const callPromise = client.callTool("image_analysis", { image_source: "/img.png" });
+
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18" } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  // Initial discovery: tool name contains "image" so keyword matches
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { tools: [{ name: "old_image_tool" }] } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  // written[3] = first tools/call (name resolved to "old_image_tool" via keyword)
+  const firstCall = JSON.parse(written[3]?.trim() ?? "{}") as { id: number; params: { name: string } };
+  assert.equal(firstCall.params.name, "old_image_tool");
+  // tools/call fails with tool-not-found
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: firstCall.id, error: { code: -32601, message: "Tool old_image_tool not found" } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  // written[4] = re-discovery tools/list
+  const rediscoverBody = JSON.parse(written[4]?.trim() ?? "{}") as { id: number; method: string };
+  assert.equal(rediscoverBody.method, "tools/list");
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: rediscoverBody.id, result: { tools: [{ name: "analyzeImage" }] } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  // written[5] = retry tools/call with updated name
+  const retryCallBody = JSON.parse(written[5]?.trim() ?? "{}") as { id: number; params: { name: string } };
+  assert.equal(retryCallBody.params.name, "analyzeImage");
+
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: retryCallBody.id, result: { content: [{ type: "text", text: "cat" }] } }) + "\n");
+  const result = await callPromise;
+  assert.deepEqual(result, { content: [{ type: "text", text: "cat" }] });
+  await client.dispose();
+});
+

--- a/src/tests/zai-mcp-client.test.ts
+++ b/src/tests/zai-mcp-client.test.ts
@@ -55,7 +55,7 @@ test("ZaiMcpClient initializes, sends initialized, discovers tools, and calls a 
     jsonResponse({
       jsonrpc: "2.0",
       id: 2,
-      result: { tools: [{ name: "webSearchPrime" }] },
+      result: { tools: [{ name: "webSearchPrime", inputSchema: { properties: { search_query: { type: "string" }, result_count: { type: "number" } } } }] },
     }),
     jsonResponse({
       jsonrpc: "2.0",
@@ -90,7 +90,7 @@ test("ZaiMcpClient initializes, sends initialized, discovers tools, and calls a 
   assert.equal(calls[3]?.body.method, "tools/call");
   assert.deepEqual(calls[3]?.body.params, {
     name: "webSearchPrime",
-    arguments: { query: "glm coding plan", count: 3 },
+    arguments: { search_query: "glm coding plan", count: 3 },
   });
   assert.equal(calls[3]?.headers.get("MCP-Session-Id"), "session-123");
   assert.equal(calls[3]?.headers.get("Mcp-Method"), "tools/call");
@@ -376,4 +376,98 @@ test("ZaiMcpClient does not retry on non-tool-not-found errors", async () => {
     /Internal server error/
   );
   assert.equal(calls.length, 4);
+});
+
+test("ZaiMcpClient passes args through unchanged when arg names already match schema properties", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    jsonResponse(
+      { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {} } },
+      { sessionId: "session-passthrough" }
+    ),
+    new Response(null, { status: 202 }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "webSearchPrime", inputSchema: { properties: { search_query: { type: "string" } } } }] },
+    }),
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      result: { content: [{ type: "text", text: "ok" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { search_query: "already correct" },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(calls[3]?.body.params, {
+    name: "webSearchPrime",
+    arguments: { search_query: "already correct" },
+  });
+});
+
+test("ZaiMcpClient retries once on -32602 arg-validation error and re-discovers schema", async () => {
+  const endpoint = "https://api.z.ai/api/mcp/web_search_prime/mcp";
+  const { calls, fetchStub } = createFetchStub([
+    // First attempt: init
+    jsonResponse(
+      { jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {} } },
+      { sessionId: "session-stale" }
+    ),
+    new Response(null, { status: 202 }),
+    // First attempt: tools/list returns stale schema (wrong arg name)
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { tools: [{ name: "webSearchPrime", inputSchema: { properties: { q: { type: "string" } } } }] },
+    }),
+    // First attempt: tools/call fails with -32602
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 3,
+      error: { code: -32602, message: "search_query cannot be empty" },
+    }),
+    // Retry: re-initialize
+    jsonResponse(
+      { jsonrpc: "2.0", id: 4, result: { protocolVersion: "2025-06-18", capabilities: {} } },
+      { sessionId: "session-fresh" }
+    ),
+    new Response(null, { status: 202 }),
+    // Retry: tools/list returns updated schema
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 5,
+      result: { tools: [{ name: "webSearchPrime", inputSchema: { properties: { search_query: { type: "string" } } } }] },
+    }),
+    // Retry: tools/call succeeds with remapped args
+    jsonResponse({
+      jsonrpc: "2.0",
+      id: 6,
+      result: { content: [{ type: "text", text: "retry success" }] },
+    }),
+  ]);
+
+  const client = new ZaiMcpClient(fetchStub as typeof fetch);
+  const result = await client.callTool({
+    endpoint,
+    toolName: "webSearchPrime",
+    arguments: { query: "test" },
+    apiKey: "test-key",
+  });
+
+  assert.deepEqual(result, { content: [{ type: "text", text: "retry success" }] });
+  assert.equal(calls.length, 8);
+  assert.equal(calls[4]?.body.method, "initialize");
+  assert.equal(calls[6]?.body.method, "tools/list");
+  // After re-discovery the alias maps query → search_query
+  assert.deepEqual(calls[7]?.body.params, {
+    name: "webSearchPrime",
+    arguments: { search_query: "test" },
+  });
 });

--- a/src/tools/mcp-arg-remap.ts
+++ b/src/tools/mcp-arg-remap.ts
@@ -1,5 +1,11 @@
 import { debug } from "../llm/logger.js";
 
+/** Represents a tool discovered via `tools/list`, including its schema property names. */
+export interface DiscoveredTool {
+  name: string;
+  properties: string[];
+}
+
 /** Maps agent-side argument names to upstream MCP property names. */
 const ARG_ALIASES: Record<string, string> = {
   query: "search_query",
@@ -51,7 +57,10 @@ export function resolveToolName(
   const keywords = extractToolKeywords(requestedName);
   for (const keyword of keywords) {
     const match = availableTools.find((t) => t.toLowerCase().includes(keyword));
-    if (match) return match;
+    if (match) {
+      debug(`mcp-arg-remap: resolved tool name "${requestedName}" → "${match}" via keyword "${keyword}"`);
+      return match;
+    }
   }
 
   throw new Error(

--- a/src/tools/mcp-arg-remap.ts
+++ b/src/tools/mcp-arg-remap.ts
@@ -1,0 +1,76 @@
+import { debug } from "../llm/logger.js";
+
+/** Maps agent-side argument names to upstream MCP property names. */
+const ARG_ALIASES: Record<string, string> = {
+  query: "search_query",
+};
+
+/**
+ * Remaps argument keys to match the upstream MCP tool's `inputSchema.properties`.
+ * - If a key already matches a target property, it is passed through unchanged.
+ * - Otherwise, the alias table is consulted; if the alias exists in the target properties, the key is remapped.
+ * - If no schema is available (empty `targetProperties`), all arguments are passed through unchanged.
+ */
+export function remapArguments(
+  requestedArgs: Record<string, unknown>,
+  targetProperties: string[]
+): Record<string, unknown> {
+  if (!targetProperties.length) return requestedArgs;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(requestedArgs)) {
+    if (targetProperties.includes(key)) {
+      result[key] = value;
+    } else {
+      const alias = ARG_ALIASES[key];
+      if (alias && targetProperties.includes(alias)) {
+        debug(`mcp-arg-remap: remapped arg "${key}" → "${alias}"`);
+        result[alias] = value;
+      } else {
+        result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Resolves a requested tool name against the list of available tools discovered via `tools/list`.
+ * - Exact match takes priority.
+ * - Falls back to keyword-based search (e.g. "search", "reader", "image").
+ * - If `availableTools` is empty (discovery not available), returns `requestedName` unchanged.
+ * - Throws a descriptive error if no match is found.
+ */
+export function resolveToolName(
+  requestedName: string,
+  availableTools: string[],
+  context: string
+): string {
+  if (!availableTools.length) return requestedName;
+  if (availableTools.includes(requestedName)) return requestedName;
+
+  const keywords = extractToolKeywords(requestedName);
+  for (const keyword of keywords) {
+    const match = availableTools.find((t) => t.toLowerCase().includes(keyword));
+    if (match) return match;
+  }
+
+  throw new Error(
+    `Tool "${requestedName}" not available on ${context}. Available tools: [${availableTools.join(", ")}]`
+  );
+}
+
+function extractToolKeywords(name: string): string[] {
+  const lower = name.toLowerCase();
+  const keywords: string[] = [];
+  if (lower.includes("search")) keywords.push("search");
+  if (lower.includes("reader")) keywords.push("reader");
+  if (
+    lower.includes("image") ||
+    lower.includes("vision") ||
+    lower.includes("analysis") ||
+    lower.includes("recognition")
+  ) {
+    keywords.push("image", "vision", "analysis", "recognition");
+  }
+  return keywords;
+}

--- a/src/tools/vision-mcp-client.ts
+++ b/src/tools/vision-mcp-client.ts
@@ -1,5 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { remapArguments, resolveToolName } from "./mcp-arg-remap.js";
+import { remapArguments, resolveToolName, type DiscoveredTool } from "./mcp-arg-remap.js";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -14,11 +14,6 @@ interface StdioVisionMcpClientOptions {
   packageSpec?: string;
   /** Override the spawn function for tests. */
   spawn?: (command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => ChildProcessWithoutNullStreams;
-}
-
-interface DiscoveredTool {
-  name: string;
-  properties: string[];
 }
 
 interface PendingRequest {
@@ -46,24 +41,26 @@ export class StdioVisionMcpClient implements VisionMcpClient {
   }
 
   private async callToolInternal(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
-    const toolNames = this.discoveredTools.map((t) => t.name);
-    const resolvedName = resolveToolName(toolName, toolNames, "@z_ai/mcp-server");
-    const toolSchema = this.discoveredTools.find((t) => t.name === resolvedName);
-    const remappedArgs = remapArguments(args, toolSchema?.properties ?? []);
+    const { name: resolvedName, args: remappedArgs } = this.resolveAndRemap(toolName, args);
     try {
       return await this.request("tools/call", { name: resolvedName, arguments: remappedArgs }, `Vision MCP ${toolName}`, signal);
     } catch (err) {
       if (!isVisionRetryableError(err)) throw err;
-      await this.rediscoverTools();
-      const resolvedName2 = resolveToolName(toolName, this.discoveredTools.map((t) => t.name), "@z_ai/mcp-server");
-      const toolSchema2 = this.discoveredTools.find((t) => t.name === resolvedName2);
-      const remappedArgs2 = remapArguments(args, toolSchema2?.properties ?? []);
+      await this.rediscoverTools(signal);
+      const { name: resolvedName2, args: remappedArgs2 } = this.resolveAndRemap(toolName, args);
       return this.request("tools/call", { name: resolvedName2, arguments: remappedArgs2 }, `Vision MCP ${toolName}`, signal);
     }
   }
 
-  private async rediscoverTools(): Promise<void> {
-    const result = await this.request("tools/list", {}, "Vision MCP tools/list") as
+  private resolveAndRemap(toolName: string, args: Record<string, unknown>): { name: string; args: Record<string, unknown> } {
+    const toolNames = this.discoveredTools.map((t) => t.name);
+    const resolvedName = resolveToolName(toolName, toolNames, "@z_ai/mcp-server");
+    const toolSchema = this.discoveredTools.find((t) => t.name === resolvedName);
+    return { name: resolvedName, args: remapArguments(args, toolSchema?.properties ?? []) };
+  }
+
+  private async rediscoverTools(signal?: AbortSignal): Promise<void> {
+    const result = await this.request("tools/list", {}, "Vision MCP tools/list", signal) as
       | { tools?: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[] }
       | undefined;
     const tools = result?.tools ?? [];

--- a/src/tools/vision-mcp-client.ts
+++ b/src/tools/vision-mcp-client.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { remapArguments, resolveToolName } from "./mcp-arg-remap.js";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -15,6 +16,11 @@ interface StdioVisionMcpClientOptions {
   spawn?: (command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => ChildProcessWithoutNullStreams;
 }
 
+interface DiscoveredTool {
+  name: string;
+  properties: string[];
+}
+
 interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: Error) => void;
@@ -29,13 +35,44 @@ export class StdioVisionMcpClient implements VisionMcpClient {
   private buffer = "";
   private exited = false;
   private exitReason: string | null = null;
+  private discoveredTools: DiscoveredTool[] = [];
 
   constructor(private opts: StdioVisionMcpClientOptions) {}
 
   async callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
     if (signal?.aborted) throw new Error("Vision MCP call cancelled");
     await this.ensureInitialized();
-    return this.request("tools/call", { name: toolName, arguments: args }, `Vision MCP ${toolName}`, signal);
+    return this.callToolInternal(toolName, args, signal);
+  }
+
+  private async callToolInternal(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    const toolNames = this.discoveredTools.map((t) => t.name);
+    const resolvedName = resolveToolName(toolName, toolNames, "@z_ai/mcp-server");
+    const toolSchema = this.discoveredTools.find((t) => t.name === resolvedName);
+    const remappedArgs = remapArguments(args, toolSchema?.properties ?? []);
+    try {
+      return await this.request("tools/call", { name: resolvedName, arguments: remappedArgs }, `Vision MCP ${toolName}`, signal);
+    } catch (err) {
+      if (!isVisionRetryableError(err)) throw err;
+      await this.rediscoverTools();
+      const resolvedName2 = resolveToolName(toolName, this.discoveredTools.map((t) => t.name), "@z_ai/mcp-server");
+      const toolSchema2 = this.discoveredTools.find((t) => t.name === resolvedName2);
+      const remappedArgs2 = remapArguments(args, toolSchema2?.properties ?? []);
+      return this.request("tools/call", { name: resolvedName2, arguments: remappedArgs2 }, `Vision MCP ${toolName}`, signal);
+    }
+  }
+
+  private async rediscoverTools(): Promise<void> {
+    const result = await this.request("tools/list", {}, "Vision MCP tools/list") as
+      | { tools?: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[] }
+      | undefined;
+    const tools = result?.tools ?? [];
+    if (tools.length > 0) {
+      this.discoveredTools = tools.map((t) => ({
+        name: t.name,
+        properties: t.inputSchema?.properties ? Object.keys(t.inputSchema.properties) : [],
+      }));
+    }
   }
 
   async dispose(): Promise<void> {
@@ -48,6 +85,7 @@ export class StdioVisionMcpClient implements VisionMcpClient {
     }
     this.child = null;
     this.initialized = null;
+    this.discoveredTools = [];
     for (const [, p] of this.pending) {
       p.reject(new Error(`cancelled (client disposed)`));
     }
@@ -102,6 +140,7 @@ export class StdioVisionMcpClient implements VisionMcpClient {
       clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
     }, "Vision MCP initialize");
     this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    await this.rediscoverTools();
   }
 
   private request(method: string, params: Record<string, unknown>, label: string, signal?: AbortSignal): Promise<unknown> {
@@ -160,4 +199,12 @@ export class StdioVisionMcpClient implements VisionMcpClient {
       }
     }
   }
+}
+
+function isVisionRetryableError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  if (/-32601/.test(msg)) return true;
+  if (/tool.*not.*found|not.*found.*tool|unknown.*tool/.test(msg)) return true;
+  return false;
 }

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -1,3 +1,5 @@
+import { remapArguments, resolveToolName } from "./mcp-arg-remap.js";
+
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 
 export const ZAI_WEB_SEARCH_MCP_ENDPOINT =
@@ -31,8 +33,13 @@ export interface ZaiMcpToolCall {
   signal?: AbortSignal;
 }
 
+interface DiscoveredTool {
+  name: string;
+  properties: string[];
+}
+
 export class ZaiMcpClient {
-  private sessions = new Map<string, { sessionId?: string; initialized: boolean; toolNames: string[] }>();
+  private sessions = new Map<string, { sessionId?: string; initialized: boolean; tools: DiscoveredTool[] }>();
   private nextId = 1;
 
   constructor(
@@ -44,7 +51,7 @@ export class ZaiMcpClient {
     try {
       return await this.callToolInternal(call);
     } catch (err) {
-      if (!isToolNotFoundError(err)) throw err;
+      if (!isRetryableError(err)) throw err;
       const cacheKey = `${call.endpoint}\n${call.apiKey}`;
       this.sessions.delete(cacheKey);
       return this.callToolInternal(call);
@@ -53,7 +60,10 @@ export class ZaiMcpClient {
 
   private async callToolInternal(call: ZaiMcpToolCall): Promise<unknown> {
     const session = await this.ensureInitialized(call);
-    const resolvedName = resolveToolName(call.toolName, session.toolNames, call.endpoint);
+    const toolNames = session.tools.map((t) => t.name);
+    const resolvedName = resolveToolName(call.toolName, toolNames, call.endpoint);
+    const toolSchema = session.tools.find((t) => t.name === resolvedName);
+    const remappedArgs = remapArguments(call.arguments, toolSchema?.properties ?? []);
     const result = await this.sendRequest(
       call.endpoint,
       call.apiKey,
@@ -64,7 +74,7 @@ export class ZaiMcpClient {
         method: "tools/call",
         params: {
           name: resolvedName,
-          arguments: call.arguments,
+          arguments: remappedArgs,
         },
       },
       "tools/call",
@@ -114,13 +124,13 @@ export class ZaiMcpClient {
       sessionId
     );
 
-    const toolNames = await this.discoverTools(
+    const tools = await this.discoverTools(
       call.endpoint,
       call.apiKey,
       sessionId,
       call.signal
     );
-    const session = { sessionId, initialized: true, toolNames };
+    const session = { sessionId, initialized: true, tools };
     this.sessions.set(cacheKey, session);
     return session;
   }
@@ -130,7 +140,7 @@ export class ZaiMcpClient {
     apiKey: string,
     sessionId: string | undefined,
     signal?: AbortSignal
-  ): Promise<string[]> {
+  ): Promise<DiscoveredTool[]> {
     const response = await this.fetchJsonRpc(
       endpoint,
       apiKey,
@@ -144,8 +154,15 @@ export class ZaiMcpClient {
       signal,
       sessionId
     );
-    const result = response.body.result as { tools?: { name: string }[] } | undefined;
-    return result?.tools?.map((t) => t.name) ?? [];
+    const result = response.body.result as
+      | { tools?: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[] }
+      | undefined;
+    return (
+      result?.tools?.map((t) => ({
+        name: t.name,
+        properties: t.inputSchema?.properties ? Object.keys(t.inputSchema.properties) : [],
+      })) ?? []
+    );
   }
 
   private async sendRequest(
@@ -292,35 +309,11 @@ function isCodingPlanEligibilityError(body: string): boolean {
   return /(^|["\s:])1113($|["\s,}])/.test(body);
 }
 
-function resolveToolName(
-  requestedName: string,
-  availableTools: string[],
-  endpoint: string
-): string {
-  if (availableTools.includes(requestedName)) return requestedName;
-
-  const keyword = extractToolKeyword(requestedName);
-  if (keyword) {
-    const match = availableTools.find((t) => t.toLowerCase().includes(keyword));
-    if (match) return match;
-  }
-
-  throw new Error(
-    `Tool "${requestedName}" not available on ${endpoint}. Available tools: [${availableTools.join(", ")}]`
-  );
-}
-
-function extractToolKeyword(name: string): string | undefined {
-  const lower = name.toLowerCase();
-  if (lower.includes("search")) return "search";
-  if (lower.includes("reader")) return "reader";
-  return undefined;
-}
-
-function isToolNotFoundError(error: unknown): boolean {
+function isRetryableError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const msg = error.message.toLowerCase();
   if (/-32601/.test(msg)) return true;
+  if (/-32602/.test(msg)) return true;
   if (/tool.*not.*found|not.*found.*tool|unknown.*tool/.test(msg)) return true;
   return false;
 }

--- a/src/tools/zai-mcp-client.ts
+++ b/src/tools/zai-mcp-client.ts
@@ -1,4 +1,4 @@
-import { remapArguments, resolveToolName } from "./mcp-arg-remap.js";
+import { remapArguments, resolveToolName, type DiscoveredTool } from "./mcp-arg-remap.js";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -31,11 +31,6 @@ export interface ZaiMcpToolCall {
   arguments: Record<string, unknown>;
   apiKey: string;
   signal?: AbortSignal;
-}
-
-interface DiscoveredTool {
-  name: string;
-  properties: string[];
 }
 
 export class ZaiMcpClient {


### PR DESCRIPTION
## Purpose
Type: feature. Implement #28 - Fix MCP naming: web_search arg name + Vision MCP tool discovery.

Task: [#28](https://github.com/stefandevo/glm-acp-agent/issues/28)

## Key Changes
- src/tests/executor.test.ts
- src/tests/mcp-arg-remap.test.ts
- src/tests/vision-mcp-client.test.ts
- src/tests/zai-mcp-client.test.ts
- src/tools/mcp-arg-remap.ts
- src/tools/vision-mcp-client.ts
- src/tools/zai-mcp-client.ts

## Checks
- [ ] Validate behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent tool argument remapping to automatically adapt requests to tool input schemas.
  * Implemented keyword-based tool name resolution for improved compatibility when tool names differ.

* **Bug Fixes**
  * Enhanced error handling and retry logic for failed tool calls with cached tool discovery.

* **Tests**
  * Added comprehensive test coverage for argument remapping, tool resolution, and retry behavior across MCP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->