### PR TITLE
#30 - Harden Zed image attachment handling

### DIFF
--- a/src/llm/logger.ts
+++ b/src/llm/logger.ts
@@ -40,6 +40,11 @@ export function maskSecret(s: string): string {
   return "****" + s.slice(-4);
 }
 
+/** Returns true when debug logging is active (`ACP_GLM_DEBUG=true`). */
+export function isDebugEnabled(): boolean {
+  return DEBUG_ENABLED;
+}
+
 /** Reset the DEBUG_ENABLED flag (used in tests). */
 export function _resetDebugEnabled(): void {
   // no-op in production; tests monkey-patch this module's internals.

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -44,10 +44,10 @@ import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS } from "../tools/definitions.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
-import { preprocessImageBlocks, type PreprocessedPrompt } from "./image-preprocessor.js";
+import { preprocessImageBlocks, buildPromptBlockDiagnosticLines, type PreprocessedPrompt } from "./image-preprocessor.js";
 import { StdioVisionMcpClient, type VisionMcpClient } from "../tools/vision-mcp-client.js";
 import { resolveApiKey } from "../llm/credentials.js";
-import { debug, error } from "../llm/logger.js";
+import { debug, error, isDebugEnabled } from "../llm/logger.js";
 
 /**
  * Maximum bytes of AGENTS.md / CLAUDE.md to embed in the system prompt.
@@ -213,8 +213,11 @@ export class GlmAcpAgent implements Agent {
           // Baseline (text + resource_link) is implicit; we additionally accept
           // embedded resources for inline file context, plus images for
           // vision-capable GLM models (e.g. glm-4v-plus).
+          // Set ACP_GLM_PROMPT_IMAGES=false (or =0) to stop advertising image
+          // support so clients like Zed won't offer the image-attachment UI.
           embeddedContext: true,
-          image: true,
+          image: process.env["ACP_GLM_PROMPT_IMAGES"] !== "false" &&
+                 process.env["ACP_GLM_PROMPT_IMAGES"] !== "0",
         },
         sessionCapabilities: {
           close: {},
@@ -358,6 +361,11 @@ export class GlmAcpAgent implements Agent {
     // resource_link. Optional: embedded resources. Image blocks are routed
     // through Z.AI Coding Plan Vision MCP (see image-preprocessor) so the
     // result is always a plain string for the chat-completions endpoint.
+    if (isDebugEnabled()) {
+      for (const line of buildPromptBlockDiagnosticLines(params.prompt)) {
+        debug(line);
+      }
+    }
     let preprocessed: PreprocessedPrompt | undefined;
     preprocessed = await preprocessImageBlocks(
       params.prompt,

--- a/src/protocol/image-preprocessor.ts
+++ b/src/protocol/image-preprocessor.ts
@@ -77,8 +77,64 @@ export async function preprocessImageBlocks(
   return { blocks: out, cleanups };
 }
 
+/**
+ * Build a list of safe, redacted diagnostic lines describing the inbound ACP
+ * prompt blocks. Intended for debug logging — callers must guard with
+ * `isDebugEnabled()` before calling so the string work is skipped in prod.
+ *
+ * Safety rules:
+ * - Image blocks: log MIME, URI presence, and approximate decoded byte length.
+ *   Never log the base64 payload.
+ * - Resource/resource-link blocks: log the URI scheme + path basename only
+ *   (no full paths, no query strings, no data: payloads).
+ */
+export function buildPromptBlockDiagnosticLines(blocks: ReadonlyArray<Block>): string[] {
+  const counts = new Map<string, number>();
+  for (const b of blocks) counts.set(b.type, (counts.get(b.type) ?? 0) + 1);
+
+  const lines: string[] = [
+    `prompt blocks: ${[...counts.entries()].map(([t, n]) => `${t}×${n}`).join(", ")}`,
+  ];
+
+  for (const b of blocks) {
+    if (b.type === "image") {
+      const hasUri = typeof b.uri === "string" && b.uri.length > 0;
+      // Approximate decoded byte length from base64 length to avoid overstating size.
+      const dataBytes = typeof b.data === "string" ? Math.floor(b.data.length * 0.75) : 0;
+      lines.push(`  image block: mime=${b.mimeType} uri=${hasUri} data_bytes≈${dataBytes}`);
+    } else if (b.type === "resource_link") {
+      const uriSafe = safeUriSummary(b.uri);
+      const mimePart = b.mimeType ? ` mime=${b.mimeType}` : "";
+      lines.push(`  resource_link block: name=${b.name} uri=${uriSafe}${mimePart}`);
+    } else if (b.type === "resource") {
+      const res = b.resource;
+      const uriSafe = safeUriSummary(res.uri);
+      const mimePart = res.mimeType ? ` mime=${res.mimeType}` : "";
+      lines.push(`  resource block: uri=${uriSafe}${mimePart}`);
+    }
+  }
+
+  return lines;
+}
+
 function textBlock(text: string): TextBlock {
   return { type: "text", text };
+}
+
+function safeUriSummary(uri: string): string {
+  if (uri.startsWith("data:")) return "data:<redacted>";
+  // Normalize backslashes so Windows-style paths don't mislead URL parsing.
+  const normalized = uri.replace(/\\/g, "/");
+  try {
+    const u = new URL(normalized);
+    const segments = u.pathname.split("/").filter(Boolean);
+    const basename = segments.at(-1) ?? "";
+    return `${u.protocol}//...${basename ? "/" + basename : ""}`;
+  } catch {
+    // Not a parseable URL (e.g. a bare local path without scheme).
+    const basename = normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+    return `.../${basename}`;
+  }
 }
 
 function guessExtension(mime: string): string {

--- a/src/protocol/system-prompt.ts
+++ b/src/protocol/system-prompt.ts
@@ -76,6 +76,8 @@ const WORKFLOW = `<problem_solving_workflow>
 Prefer fixing the root cause over papering over a symptom. If you hit an obstacle, diagnose it rather than reaching for a destructive shortcut.
 </problem_solving_workflow>`;
 
+// Annotation tag names (<image_analysis>, <image_attached>, <image_analysis_error>) must
+// match the literals emitted by preprocessImageBlocks() in image-preprocessor.ts.
 const IMAGE_HANDLING = `<image_handling>
 When the user refers to an attached image but the most recent user turn contains no <image_analysis>, <image_attached>, or <image_analysis_error> annotation, no image was received by this agent — this is a client-side attachment problem, not a Vision MCP failure. Do not describe or guess at the image contents. Instead, explain that the agent did not receive an image from the client and ask the user to share it as a local file path (e.g. /home/user/photo.png) or a public URL.
 </image_handling>`;

--- a/src/protocol/system-prompt.ts
+++ b/src/protocol/system-prompt.ts
@@ -76,6 +76,10 @@ const WORKFLOW = `<problem_solving_workflow>
 Prefer fixing the root cause over papering over a symptom. If you hit an obstacle, diagnose it rather than reaching for a destructive shortcut.
 </problem_solving_workflow>`;
 
+const IMAGE_HANDLING = `<image_handling>
+When the user refers to an attached image but the most recent user turn contains no <image_analysis>, <image_attached>, or <image_analysis_error> annotation, no image was received by this agent — this is a client-side attachment problem, not a Vision MCP failure. Do not describe or guess at the image contents. Instead, explain that the agent did not receive an image from the client and ask the user to share it as a local file path (e.g. /home/user/photo.png) or a public URL.
+</image_handling>`;
+
 export function buildSystemPrompt(input: BuildSystemPromptInput): string {
   const { cwd, tools, agentsMd } = input;
   const sections: string[] = [
@@ -87,6 +91,7 @@ export function buildSystemPrompt(input: BuildSystemPromptInput): string {
     CODE_QUALITY,
     TONE,
     WORKFLOW,
+    IMAGE_HANDLING,
   ];
   if (agentsMd !== undefined && agentsMd.trim().length > 0) {
     sections.push(renderProjectContext(agentsMd));

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -176,6 +176,34 @@ test("initialize negotiates lower protocol version when client requests one", as
   assert.equal(result.protocolVersion, 0);
 });
 
+test("initialize advertises image: false when ACP_GLM_PROMPT_IMAGES=false", async () => {
+  const saved = process.env["ACP_GLM_PROMPT_IMAGES"];
+  try {
+    process.env["ACP_GLM_PROMPT_IMAGES"] = "false";
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    const result = await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    assert.equal(result.agentCapabilities?.promptCapabilities?.image, false);
+  } finally {
+    if (saved === undefined) delete process.env["ACP_GLM_PROMPT_IMAGES"];
+    else process.env["ACP_GLM_PROMPT_IMAGES"] = saved;
+  }
+});
+
+test("initialize advertises image: false when ACP_GLM_PROMPT_IMAGES=0", async () => {
+  const saved = process.env["ACP_GLM_PROMPT_IMAGES"];
+  try {
+    process.env["ACP_GLM_PROMPT_IMAGES"] = "0";
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    const result = await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    assert.equal(result.agentCapabilities?.promptCapabilities?.image, false);
+  } finally {
+    if (saved === undefined) delete process.env["ACP_GLM_PROMPT_IMAGES"];
+    else process.env["ACP_GLM_PROMPT_IMAGES"] = saved;
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Session lifecycle
 // ---------------------------------------------------------------------------
@@ -464,6 +492,44 @@ test("the assembled system prompt remains a single system message", async () => 
     assert.equal(systemCount, 1);
   } finally {
     cleanup();
+  }
+});
+
+test("system prompt includes image_handling fallback instructions", async () => {
+  const conn = createConnectionStub();
+  const { glm, ref } = captureSystemPrompt();
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+  assert.ok(ref.value.includes("<image_handling>"), "system prompt must contain image_handling section");
+  assert.ok(
+    ref.value.includes("image_analysis_error") || ref.value.includes("image_analysis"),
+    "image_handling must mention the known annotation tags"
+  );
+  assert.ok(
+    ref.value.toLowerCase().includes("client"),
+    "image_handling must attribute missing image to client-side problem"
+  );
+});
+
+test("image_analysis tool is still listed when ACP_GLM_PROMPT_IMAGES=false", async () => {
+  const saved = process.env["ACP_GLM_PROMPT_IMAGES"];
+  const { cwd, cleanup } = makeTempCwd();
+  try {
+    process.env["ACP_GLM_PROMPT_IMAGES"] = "false";
+    const conn = createConnectionStub();
+    const { glm, ref } = captureSystemPrompt();
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+    assert.ok(ref.value.includes("image_analysis"), "image_analysis tool must remain in system prompt");
+  } finally {
+    cleanup();
+    if (saved === undefined) delete process.env["ACP_GLM_PROMPT_IMAGES"];
+    else process.env["ACP_GLM_PROMPT_IMAGES"] = saved;
   }
 });
 

--- a/src/tests/image-preprocessor.test.ts
+++ b/src/tests/image-preprocessor.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
-import { preprocessImageBlocks } from "../protocol/image-preprocessor.js";
+import { preprocessImageBlocks, buildPromptBlockDiagnosticLines } from "../protocol/image-preprocessor.js";
 import type { VisionMcpClient } from "../tools/vision-mcp-client.js";
 
 function makeClient(impl: VisionMcpClient["callTool"]): VisionMcpClient {
@@ -77,4 +77,65 @@ test("preprocessImageBlocks skips vision when no client is given and notes the i
   assert.equal(block.type, "text");
   assert.match(block.text ?? "", /image attached \(not analyzed/i);
   assert.equal(result.cleanups.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// buildPromptBlockDiagnosticLines
+// ---------------------------------------------------------------------------
+
+test("buildPromptBlockDiagnosticLines summarizes block types without leaking base64", () => {
+  const base64Data = Buffer.from("fake image payload data").toString("base64");
+  const lines = buildPromptBlockDiagnosticLines([
+    { type: "text", text: "hello" },
+    { type: "image", data: base64Data, mimeType: "image/jpeg" },
+  ]);
+  const summary = lines[0] ?? "";
+  assert.ok(summary.includes("text×1"), "summary must count text blocks");
+  assert.ok(summary.includes("image×1"), "summary must count image blocks");
+  for (const line of lines) {
+    assert.ok(!line.includes(base64Data), "base64 payload must not appear in diagnostic output");
+  }
+  const imageLine = lines.find((l) => l.includes("image block"));
+  assert.ok(imageLine, "image block diagnostic line must be present");
+  assert.ok(imageLine!.includes("data_bytes"), "approximate byte count must be logged");
+  assert.ok(imageLine!.includes("uri=false"), "URI presence must be false when uri is absent");
+});
+
+test("buildPromptBlockDiagnosticLines logs approximate decoded byte count for base64 data", () => {
+  // 4 base64 chars ≈ 3 decoded bytes; Math.floor(4 * 0.75) = 3
+  const lines = buildPromptBlockDiagnosticLines([
+    { type: "image", data: "AAAA", mimeType: "image/png" },
+  ]);
+  const imageLine = lines.find((l) => l.includes("image block")) ?? "";
+  assert.ok(imageLine.includes("data_bytes≈3"), "should log approximate decoded byte count");
+});
+
+test("buildPromptBlockDiagnosticLines marks URI presence when uri is set", () => {
+  const lines = buildPromptBlockDiagnosticLines([
+    { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
+  ]);
+  const imageLine = lines.find((l) => l.includes("image block")) ?? "";
+  assert.ok(imageLine.includes("uri=true"), "URI presence must be true when uri is set");
+});
+
+test("buildPromptBlockDiagnosticLines logs safe URI basename for resource_link", () => {
+  const lines = buildPromptBlockDiagnosticLines([
+    { type: "resource_link", uri: "file:///home/user/private/secret-config.ts", name: "secret-config.ts" },
+  ]);
+  const rl = lines.find((l) => l.includes("resource_link block")) ?? "";
+  assert.ok(rl.length > 0, "resource_link diagnostic line must be present");
+  assert.ok(!rl.includes("/home/user/private/"), "full directory path must not appear");
+  assert.ok(rl.includes("secret-config.ts"), "basename should appear");
+});
+
+test("buildPromptBlockDiagnosticLines redacts data: URIs for resources", () => {
+  const lines = buildPromptBlockDiagnosticLines([
+    {
+      type: "resource",
+      resource: { uri: "data:text/plain;base64,SGVsbG8=", text: "Hello" },
+    },
+  ]);
+  const rl = lines.find((l) => l.includes("resource block")) ?? "";
+  assert.ok(rl.includes("data:<redacted>"), "data: URI must be redacted");
+  assert.ok(!rl.includes("SGVsbG8="), "base64 payload in data URI must not appear");
 });


### PR DESCRIPTION
## Purpose
Type: feature. Implement #30 - Harden Zed image attachment handling.

Task: [#30](https://github.com/stefandevo/glm-acp-agent/issues/30)

## Key Changes
- src/llm/logger.ts
- src/protocol/agent.ts
- src/protocol/image-preprocessor.ts
- src/protocol/system-prompt.ts
- src/tests/agent.test.ts
- src/tests/image-preprocessor.test.ts

## Checks
- [ ] Validate behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image prompt support via environment variable
  * Enhanced system prompt guidance for image handling edge cases
  * Added diagnostic logging for image processing operations

* **Tests**
  * Added comprehensive test coverage for environment-driven image capabilities
  * Added validation tests for image handling and diagnostic output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->