### PR TITLE
#32 - Fix Vision MCP preprocessing: add prompt + prefer data over URI

### DIFF
--- a/src/protocol/image-preprocessor.ts
+++ b/src/protocol/image-preprocessor.ts
@@ -48,9 +48,7 @@ export async function preprocessImageBlocks(
     }
 
     let imageSource = "";
-    if (typeof block.uri === "string" && block.uri.length > 0) {
-      imageSource = block.uri;
-    } else if (typeof block.data === "string" && block.data.length > 0) {
+    if (typeof block.data === "string" && block.data.length > 0) {
       const dir = await mkdtemp(pathJoin(tmpdir(), "glm-acp-image-"));
       const ext = guessExtension(block.mimeType);
       const path = pathJoin(dir, `image-${imageIndex}${ext}`);
@@ -59,13 +57,18 @@ export async function preprocessImageBlocks(
       cleanups.push(async () => {
         try { await rm(dir, { recursive: true, force: true }); } catch { /* best effort */ }
       });
+    } else if (typeof block.uri === "string" && block.uri.length > 0) {
+      imageSource = block.uri;
     } else {
       out.push(textBlock(`<image_analysis_error index="${imageIndex}">image block has neither a uri nor base64 data</image_analysis_error>`));
       continue;
     }
 
     try {
-      const result = await visionClient.callTool("image_analysis", { image_source: imageSource }, signal);
+      const result = await visionClient.callTool("image_analysis", {
+        image_source: imageSource,
+        prompt: "Describe this image in detail, including any text, code, UI elements, or other visible content.",
+      }, signal);
       const text = extractText(result);
       out.push(textBlock(`<image_analysis index="${imageIndex}">\n${text}\n</image_analysis>`));
     } catch (err) {

--- a/src/tests/image-preprocessor.test.ts
+++ b/src/tests/image-preprocessor.test.ts
@@ -30,6 +30,7 @@ test("preprocessImageBlocks forwards a remote URI directly to the vision client"
     })
   );
   assert.equal(seen?.["image_source"], "https://example.com/cat.png");
+  assert.equal(typeof seen?.["prompt"], "string", "callTool must always receive a prompt field");
   // Image block must have been replaced with a text annotation.
   assert.equal(result.blocks.length, 2);
   const last = result.blocks[1] as { type: string; text?: string };
@@ -37,12 +38,31 @@ test("preprocessImageBlocks forwards a remote URI directly to the vision client"
   assert.match(last.text ?? "", /<image_analysis index="1">[\s\S]*A cat\.[\s\S]*<\/image_analysis>/);
 });
 
+test("preprocessImageBlocks prefers base64 data over URI when both are present", async () => {
+  let seenSource = "";
+  let seenPrompt: unknown;
+  const result = await preprocessImageBlocks(
+    [{ type: "image", data: "AAAA", mimeType: "image/png", uri: "https://example.com/should-not-use.png" }],
+    makeClient(async (_name, args) => {
+      seenSource = String(args["image_source"]);
+      seenPrompt = args["prompt"];
+      return { content: [{ type: "text", text: "blank image" }] };
+    })
+  );
+  for (const c of result.cleanups) await c();
+  assert.ok(!seenSource.startsWith("https://"), "URI must not be used when base64 data is available");
+  assert.ok(seenSource.length > 0, "a temp file path must have been passed");
+  assert.equal(typeof seenPrompt, "string", "callTool must receive a prompt field");
+});
+
 test("preprocessImageBlocks materializes inline data to a temp file and cleans it up", async () => {
   let seenPath = "";
+  let seenPrompt: unknown;
   const result = await preprocessImageBlocks(
     [{ type: "image", data: "AAAA", mimeType: "image/png" }],
     makeClient(async (_name, args) => {
       seenPath = String(args["image_source"]);
+      seenPrompt = args["prompt"];
       assert.ok(existsSync(seenPath), "temp file must exist while vision MCP is invoked");
       const bytes = readFileSync(seenPath);
       assert.equal(bytes.length, 3); // base64 "AAAA" = 3 bytes
@@ -52,6 +72,7 @@ test("preprocessImageBlocks materializes inline data to a temp file and cleans i
   // Run cleanups after the call returns and verify the file is gone.
   for (const c of result.cleanups) await c();
   assert.equal(existsSync(seenPath), false);
+  assert.equal(typeof seenPrompt, "string", "callTool must receive a prompt field");
 });
 
 test("preprocessImageBlocks degrades gracefully when the vision client fails", async () => {


### PR DESCRIPTION
## Purpose
Type: feature. Implement #32 - Fix Vision MCP preprocessing: add prompt + prefer data over URI.

Task: [#32](https://github.com/stefandevo/glm-acp-agent/issues/32)

## Key Changes
- src/protocol/image-preprocessor.ts
- src/tests/image-preprocessor.test.ts

## Checks
- [ ] Validate behavior locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image analysis requests now include detailed prompts for improved content description.
  * Enhanced image source prioritization when multiple input formats are available.

* **Tests**
  * Extended test coverage for image analysis across different input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->