### PR TITLE
Support custom MCP servers passed via newSession.mcpServers

### DIFF
--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam, ChatCompletionTool } from "openai/resources/index.js";
 import type { ModelInfo, Usage } from "@agentclientprotocol/sdk";
-import { TOOL_DEFINITIONS } from "../tools/definitions.js";
+import { TOOL_DEFINITIONS, type ToolDefinition } from "../tools/definitions.js";
 import { resolveApiKey } from "./credentials.js";
 import { debug, error } from "./logger.js";
 
@@ -36,6 +36,8 @@ export interface GlmStreamChunk {
 export interface StreamChatOptions {
   /** GLM model identifier to use for this call. */
   model: string;
+  /** Tool schemas available in this specific session. */
+  tools?: ToolDefinition[];
 }
 
 /** Default base URL for the Z.AI / Zhipu OpenAI-compatible API (Coding endpoint). */
@@ -138,7 +140,7 @@ export class GlmClient {
   ): AsyncGenerator<GlmStreamChunk> {
     const model = options?.model ?? getDefaultModel();
     const thinkingEnabled = parseThinking(model);
-    const tools: ChatCompletionTool[] = TOOL_DEFINITIONS.map((t) => ({
+    const tools: ChatCompletionTool[] = (options?.tools ?? TOOL_DEFINITIONS).map((t) => ({
       type: "function" as const,
       function: {
         name: t.function.name,

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -41,7 +41,8 @@ import {
   type StreamChatOptions,
 } from "../llm/glm-client.js";
 import { ToolExecutor } from "../tools/executor.js";
-import { TOOL_DEFINITIONS } from "../tools/definitions.js";
+import { TOOL_DEFINITIONS, type ToolDefinition } from "../tools/definitions.js";
+import { connectSessionMcpServers, type SessionMcpTools } from "../tools/session-mcp-client.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { preprocessImageBlocks, buildPromptBlockDiagnosticLines, type PreprocessedPrompt } from "./image-preprocessor.js";
@@ -73,6 +74,10 @@ interface SessionState {
   updatedAt: string;
   /** Active model for this session (clients can change via `session/set_model`). */
   model: string;
+  /** Per-session tool schemas, including client-supplied MCP tools. */
+  toolDefinitions: ToolDefinition[];
+  /** Connected client-supplied MCP tools for this session. */
+  mcpTools: SessionMcpTools | null;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -209,6 +214,9 @@ export class GlmAcpAgent implements Agent {
       ],
       agentCapabilities: {
         loadSession: true,
+        mcpCapabilities: {
+          http: true,
+        },
         promptCapabilities: {
           // Baseline (text + resource_link) is implicit; we additionally accept
           // embedded resources for inline file context, plus images for
@@ -242,12 +250,14 @@ export class GlmAcpAgent implements Agent {
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     const sessionId = randomUUID();
     debug(`newSession: id=${sessionId} cwd=${params.cwd} model=${getDefaultModel()}`);
+    const mcpTools = await connectSessionMcpServers(params.mcpServers);
+    const toolDefinitions = this.availableToolDefinitions(mcpTools);
 
     const systemPrompt: GlmMessage = {
       role: "system",
       content: buildSystemPrompt({
         cwd: params.cwd,
-        tools: this.availableToolNames(),
+        tools: toolDefinitions.map((tool) => tool.function.name),
         agentsMd: loadProjectContext(params.cwd),
       }),
     };
@@ -262,6 +272,8 @@ export class GlmAcpAgent implements Agent {
       title: null,
       updatedAt: new Date().toISOString(),
       model,
+      toolDefinitions,
+      mcpTools,
     });
 
     return {
@@ -468,6 +480,7 @@ export class GlmAcpAgent implements Agent {
       // pick the conversation back up. closeSession only releases in-memory
       // resources; the on-disk record is intentionally retained.
       this.persistSession(params.sessionId, session);
+      await session.mcpTools?.dispose();
     }
     this.sessions.delete(params.sessionId);
   }
@@ -527,6 +540,9 @@ export class GlmAcpAgent implements Agent {
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
     const persisted = this.requirePersisted(params.sessionId);
+    const mcpTools = await connectSessionMcpServers(params.mcpServers);
+    const toolDefinitions = this.availableToolDefinitions(mcpTools);
+    await this.sessions.get(params.sessionId)?.mcpTools?.dispose();
 
     // Restore in-memory state. We do NOT carry over the abortController /
     // promptPromise — those are transient.
@@ -538,6 +554,8 @@ export class GlmAcpAgent implements Agent {
       title: persisted.title,
       updatedAt: persisted.updatedAt,
       model: persisted.model,
+      toolDefinitions,
+      mcpTools,
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -556,6 +574,8 @@ export class GlmAcpAgent implements Agent {
     const persisted = source
       ? this.snapshot(params.sessionId, source)
       : this.requirePersisted(params.sessionId);
+    const mcpTools = await connectSessionMcpServers(params.mcpServers ?? []);
+    const toolDefinitions = this.availableToolDefinitions(mcpTools);
 
     const newSessionId = randomUUID();
     const forkedTitle =
@@ -569,6 +589,8 @@ export class GlmAcpAgent implements Agent {
       title: forkedTitle,
       updatedAt: new Date().toISOString(),
       model: persisted.model,
+      toolDefinitions,
+      mcpTools,
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
@@ -583,6 +605,9 @@ export class GlmAcpAgent implements Agent {
     params: ResumeSessionRequest
   ): Promise<ResumeSessionResponse> {
     const persisted = this.requirePersisted(params.sessionId);
+    const mcpTools = await connectSessionMcpServers(params.mcpServers ?? []);
+    const toolDefinitions = this.availableToolDefinitions(mcpTools);
+    await this.sessions.get(params.sessionId)?.mcpTools?.dispose();
 
     const restored: SessionState = {
       cwd: params.cwd,
@@ -592,6 +617,8 @@ export class GlmAcpAgent implements Agent {
       title: persisted.title,
       updatedAt: persisted.updatedAt,
       model: persisted.model,
+      toolDefinitions,
+      mcpTools,
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -702,7 +729,8 @@ export class GlmAcpAgent implements Agent {
       sessionId,
       this.clientCapabilities,
       signal,
-      this.visionClient
+      this.visionClient,
+      session.mcpTools
     );
 
     let lastUsage: Usage | undefined;
@@ -725,6 +753,7 @@ export class GlmAcpAgent implements Agent {
       // it's mutated by `unstable_setSessionModel` between turns.
       for await (const chunk of this.glm.streamChat(session.messages, signal, {
         model: session.model,
+        tools: session.toolDefinitions,
       })) {
         if (signal.aborted) return { stopReason: "cancelled" };
 
@@ -823,14 +852,14 @@ export class GlmAcpAgent implements Agent {
     }
   }
 
-  /** Names of tools we expose given the client's capabilities. */
-  private availableToolNames(): string[] {
+  /** Tool schemas we expose given the client's capabilities and session MCP tools. */
+  private availableToolDefinitions(mcpTools: SessionMcpTools | null = null): ToolDefinition[] {
     // If the client never sent capabilities at all (initialize wasn't called,
     // or it omitted the field), advertise the full set so the system prompt
     // still mentions every tool. The executor will surface a clean error if
     // the model invokes one whose capability is missing.
     if (!this.clientCapabilities) {
-      return TOOL_DEFINITIONS.map((t) => t.function.name);
+      return [...TOOL_DEFINITIONS, ...(mcpTools?.toolDefinitions ?? [])];
     }
 
     const fs = this.clientCapabilities.fs ?? {};
@@ -845,7 +874,11 @@ export class GlmAcpAgent implements Agent {
     if (this.visionClientExplicit ? this._visionClient !== null : true) {
       names.push("image_analysis");
     }
-    return names;
+    const allowed = new Set(names);
+    return [
+      ...TOOL_DEFINITIONS.filter((tool) => allowed.has(tool.function.name)),
+      ...(mcpTools?.toolDefinitions ?? []),
+    ];
   }
 }
 

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -78,6 +78,16 @@ function createConnectionStub(): ConnectionStub {
   return stub;
 }
 
+function jsonResponse(
+  body: unknown,
+  init: ResponseInit & { sessionId?: string } = {}
+): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+  if (init.sessionId) headers.set("MCP-Session-Id", init.sessionId);
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
 function makeStreamingGlm(steps: Array<GlmStreamChunk[]>) {
   let i = 0;
   return {
@@ -143,6 +153,7 @@ test("initialize returns negotiated protocol version, agent info, and auth metho
   assert.equal(result.protocolVersion, PROTOCOL_VERSION);
   assert.equal(result.agentInfo?.name, "glm-acp-agent");
   assert.equal(result.agentCapabilities?.loadSession, true);
+  assert.equal(result.agentCapabilities?.mcpCapabilities?.http, true);
   assert.equal(result.agentCapabilities?.promptCapabilities?.embeddedContext, true);
   assert.equal(result.agentCapabilities?.promptCapabilities?.image, true);
   assert.ok(result.agentCapabilities?.sessionCapabilities?.close);
@@ -280,6 +291,220 @@ test("system prompt falls back to all tools when client never sent capabilities"
     "web_reader",
   ]) {
     assert.ok(captured.includes(name), `expected system prompt to mention ${name}`);
+  }
+});
+
+test("newSession connects HTTP MCP servers and exposes discovered tools", async () => {
+  const conn = createConnectionStub();
+  const fetchCalls: Array<{
+    url: string;
+    body: Record<string, unknown>;
+    headers: Headers;
+  }> = [];
+  const savedFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    assert.ok(init, "fetch init is required");
+    const body =
+      typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    fetchCalls.push({
+      url: String(url),
+      body,
+      headers: new Headers(init.headers),
+    });
+    if (body.method === "initialize") {
+      return jsonResponse(
+        {
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "devflow" } },
+        },
+        { sessionId: "mcp-session-1" }
+      );
+    }
+    if (body.method === "notifications/initialized") {
+      return new Response(null, { status: 202 });
+    }
+    if (body.method === "tools/list") {
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          tools: [
+            {
+              name: "devflow_user_choice",
+              description: "Ask the user to choose between options.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  question: { type: "string" },
+                },
+                required: ["question"],
+              },
+            },
+          ],
+        },
+      });
+    }
+    throw new Error(`unexpected MCP method ${String(body.method)}`);
+  }) as typeof fetch;
+
+  try {
+    let capturedSystemPrompt = "";
+    let capturedToolNames: string[] = [];
+    const glm = {
+      async *streamChat(
+        messages: ReadonlyArray<{ role: string; content?: unknown }>,
+        _signal?: AbortSignal,
+        options?: unknown
+      ): AsyncGenerator<GlmStreamChunk> {
+        const sys = messages.find((m) => m.role === "system");
+        capturedSystemPrompt = typeof sys?.content === "string" ? sys.content : "";
+        capturedToolNames =
+          ((options as { tools?: Array<{ function: { name: string } }> } | undefined)?.tools ?? [])
+            .map((tool) => tool.function.name);
+        yield { text: "ok" };
+        yield { done: true, stopReason: "stop" };
+      },
+    };
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+    const { sessionId } = await agent.newSession({
+      cwd: "/tmp",
+      mcpServers: [
+        {
+          type: "http",
+          name: "devflow",
+          url: "https://mcp.example.test/mcp",
+          headers: [{ name: "X-DevFlow", value: "task-35" }],
+        },
+      ],
+    });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    assert.deepEqual(fetchCalls.map((call) => call.body.method), [
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+    ]);
+    assert.equal(fetchCalls[0]?.headers.get("X-DevFlow"), "task-35");
+    assert.equal(fetchCalls[2]?.headers.get("MCP-Session-Id"), "mcp-session-1");
+    assert.ok(capturedSystemPrompt.includes("devflow_user_choice"));
+    assert.ok(capturedToolNames.includes("devflow_user_choice"));
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+});
+
+test("prompt routes discovered HTTP MCP tool calls through tools/call", async () => {
+  const conn = createConnectionStub();
+  const fetchCalls: Array<{ body: Record<string, unknown>; headers: Headers }> = [];
+  const savedFetch = globalThis.fetch;
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    assert.ok(init, "fetch init is required");
+    const body =
+      typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+    fetchCalls.push({ body, headers: new Headers(init.headers) });
+    if (body.method === "initialize") {
+      return jsonResponse(
+        {
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "devflow" } },
+        },
+        { sessionId: "mcp-session-2" }
+      );
+    }
+    if (body.method === "notifications/initialized") {
+      return new Response(null, { status: 202 });
+    }
+    if (body.method === "tools/list") {
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          tools: [
+            {
+              name: "devflow_user_choice",
+              description: "Ask the user to choose between options.",
+              inputSchema: {
+                type: "object",
+                properties: { question: { type: "string" } },
+                required: ["question"],
+              },
+            },
+          ],
+        },
+      });
+    }
+    if (body.method === "tools/call") {
+      assert.deepEqual(body.params, {
+        name: "devflow_user_choice",
+        arguments: { question: "Pick one?" },
+      });
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { content: [{ type: "text", text: "choice accepted" }] },
+      });
+    }
+    throw new Error(`unexpected MCP method ${String(body.method)}`);
+  }) as typeof fetch;
+
+  try {
+    let callIndex = 0;
+    const glm = {
+      async *streamChat(
+        messages: ReadonlyArray<{ role: string; content?: unknown; tool_call_id?: string }>
+      ): AsyncGenerator<GlmStreamChunk> {
+        callIndex++;
+        if (callIndex === 1) {
+          yield {
+            toolCall: {
+              id: "mcp-tool-call-1",
+              name: "devflow_user_choice",
+              arguments: JSON.stringify({ question: "Pick one?" }),
+            },
+          };
+          yield { done: true, stopReason: "tool_calls" };
+        } else {
+          const toolMsg = messages.find((m) => m.role === "tool");
+          assert.equal(toolMsg?.tool_call_id, "mcp-tool-call-1");
+          assert.equal(toolMsg?.content, "choice accepted");
+          yield { text: "Done." };
+          yield { done: true, stopReason: "stop" };
+        }
+      },
+    };
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({
+      cwd: "/tmp",
+      mcpServers: [
+        {
+          type: "http",
+          name: "devflow",
+          url: "https://mcp.example.test/mcp",
+          headers: [],
+        },
+      ],
+    });
+
+    const result = await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "ask me" }],
+    });
+
+    assert.equal(result.stopReason, "end_turn");
+    assert.deepEqual(fetchCalls.map((call) => call.body.method), [
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+      "tools/call",
+    ]);
+    assert.equal(fetchCalls[3]?.headers.get("MCP-Session-Id"), "mcp-session-2");
+  } finally {
+    globalThis.fetch = savedFetch;
   }
 });
 

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -8,6 +8,7 @@ import {
   ZAI_WEB_READER_MCP_ENDPOINT,
   ZAI_WEB_SEARCH_MCP_ENDPOINT,
 } from "./zai-mcp-client.js";
+import type { SessionMcpTools } from "./session-mcp-client.js";
 import type { VisionMcpClient } from "./vision-mcp-client.js";
 
 /**
@@ -31,7 +32,8 @@ export class ToolExecutor {
     private sessionId: string,
     private clientCapabilities: ClientCapabilities | null = null,
     private signal?: AbortSignal,
-    private visionClient: VisionMcpClient | null = null
+    private visionClient: VisionMcpClient | null = null,
+    private sessionMcpTools: SessionMcpTools | null = null
   ) {}
 
   /**
@@ -72,6 +74,9 @@ export class ToolExecutor {
       case "image_analysis":
         return this.imageAnalysis(toolCallId, args);
       default: {
+        if (this.sessionMcpTools?.hasTool(toolName)) {
+          return this.sessionMcpTool(toolCallId, toolName, args);
+        }
         const message = `Error: unknown tool "${toolName}"`;
         await this.failedToolCall(toolCallId, toolName, args, message);
         return { content: message };
@@ -649,6 +654,45 @@ export class ToolExecutor {
     }
   }
 
+  private async sessionMcpTool(
+    toolCallId: string,
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<ToolResult> {
+    await this.connection.sessionUpdate({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title: toolName,
+        kind: "other",
+        status: "in_progress",
+        locations: [],
+        rawInput: args,
+      },
+    });
+
+    try {
+      const mcpResult = await this.sessionMcpTools!.callTool(toolName, args, this.signal);
+      const text = unwrapToolText(mcpResult);
+      await this.connection.sessionUpdate({
+        sessionId: this.sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text } }],
+          rawOutput: mcpResult,
+        },
+      });
+      return { content: text };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.markFailed(toolCallId, message);
+      return { content: `Error calling MCP tool ${toolName}: ${message}` };
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Notification helpers
   // ---------------------------------------------------------------------------
@@ -824,6 +868,20 @@ function unwrapVisionText(mcpResult: unknown): string {
       .map((entry) => (isRecord(entry) && typeof entry["text"] === "string" ? (entry["text"] as string) : ""))
       .filter((s) => s.length > 0);
     if (texts.length > 0) return texts.join("\n");
+  }
+  return JSON.stringify(mcpResult);
+}
+
+function unwrapToolText(mcpResult: unknown): string {
+  if (typeof mcpResult === "string") return mcpResult;
+  if (isRecord(mcpResult)) {
+    const content = mcpResult["content"];
+    if (Array.isArray(content)) {
+      const texts = content
+        .map((entry) => (isRecord(entry) && typeof entry["text"] === "string" ? (entry["text"] as string) : ""))
+        .filter((s) => s.length > 0);
+      if (texts.length > 0) return texts.join("\n");
+    }
   }
   return JSON.stringify(mcpResult);
 }

--- a/src/tools/session-mcp-client.ts
+++ b/src/tools/session-mcp-client.ts
@@ -1,0 +1,483 @@
+import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { McpServer, McpServerHttp, McpServerStdio } from "@agentclientprotocol/sdk";
+import { TOOL_DEFINITIONS, type ToolDefinition } from "./definitions.js";
+
+const MCP_PROTOCOL_VERSION = "2025-06-18";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface JsonRpcResponse {
+  jsonrpc?: string;
+  id?: number;
+  result?: unknown;
+  error?: {
+    code?: string | number;
+    message?: string;
+    [key: string]: unknown;
+  };
+}
+
+interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+interface ToolBinding {
+  exposedName: string;
+  sourceName: string;
+  client: ConnectedMcpClient;
+  definition: ToolDefinition;
+}
+
+interface ConnectedMcpClient {
+  listTools(): Promise<McpTool[]>;
+  callTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown>;
+  dispose(): Promise<void>;
+}
+
+export class SessionMcpTools {
+  private bindings = new Map<string, ToolBinding>();
+
+  constructor(bindings: ToolBinding[]) {
+    for (const binding of bindings) {
+      this.bindings.set(binding.exposedName, binding);
+    }
+  }
+
+  get toolDefinitions(): ToolDefinition[] {
+    return Array.from(this.bindings.values()).map((binding) => binding.definition);
+  }
+
+  get toolNames(): string[] {
+    return Array.from(this.bindings.keys());
+  }
+
+  hasTool(name: string): boolean {
+    return this.bindings.has(name);
+  }
+
+  async callTool(
+    exposedName: string,
+    args: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<unknown> {
+    const binding = this.bindings.get(exposedName);
+    if (!binding) throw new Error(`Unknown MCP tool: ${exposedName}`);
+    return binding.client.callTool(binding.sourceName, args, signal);
+  }
+
+  async dispose(): Promise<void> {
+    const clients = new Set(Array.from(this.bindings.values()).map((binding) => binding.client));
+    await Promise.all(Array.from(clients).map((client) => client.dispose().catch(() => undefined)));
+    this.bindings.clear();
+  }
+}
+
+export async function connectSessionMcpServers(
+  servers: ReadonlyArray<McpServer>
+): Promise<SessionMcpTools> {
+  const usedNames = new Set(TOOL_DEFINITIONS.map((tool) => tool.function.name));
+  const bindings: ToolBinding[] = [];
+  const clients: ConnectedMcpClient[] = [];
+
+  try {
+    for (const server of servers) {
+      const client = createClient(server);
+      clients.push(client);
+      const tools = await client.listTools();
+      for (const tool of tools) {
+        const exposedName = chooseToolName(tool.name, server.name, usedNames);
+        usedNames.add(exposedName);
+        bindings.push({
+          exposedName,
+          sourceName: tool.name,
+          client,
+          definition: {
+            type: "function",
+            function: {
+              name: exposedName,
+              description: tool.description ?? `Call ${tool.name} on the ${server.name} MCP server.`,
+              parameters: normalizeSchema(tool.inputSchema),
+            },
+          },
+        });
+      }
+    }
+  } catch (err) {
+    await Promise.all(clients.map((client) => client.dispose().catch(() => undefined)));
+    throw err;
+  }
+
+  return new SessionMcpTools(bindings);
+}
+
+function createClient(server: McpServer): ConnectedMcpClient {
+  if ("type" in server && server.type === "http") {
+    return new HttpMcpClient(server);
+  }
+  if ("type" in server && server.type === "sse") {
+    throw new Error(`MCP server "${server.name}" uses SSE transport, which is not supported yet.`);
+  }
+  return new StdioMcpClient(server);
+}
+
+class HttpMcpClient implements ConnectedMcpClient {
+  private nextId = 1;
+  private initialized: Promise<void> | null = null;
+  private mcpSessionId: string | undefined;
+
+  constructor(private server: McpServerHttp & { type: "http" }) {}
+
+  async listTools(): Promise<McpTool[]> {
+    await this.ensureInitialized();
+    const result = await this.request("tools/list", {}, "tools/list");
+    return extractTools(result);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    await this.ensureInitialized();
+    return this.request("tools/call", { name, arguments: args }, "tools/call", signal, name);
+  }
+
+  async dispose(): Promise<void> {
+    this.initialized = null;
+    this.mcpSessionId = undefined;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return this.initialized;
+    this.initialized = this.initialize();
+    try {
+      await this.initialized;
+    } catch (err) {
+      this.initialized = null;
+      throw err;
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    const response = await this.fetchJsonRpc(
+      "initialize",
+      {
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method: "initialize",
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
+        },
+      },
+      "initialize"
+    );
+    this.mcpSessionId = response.sessionId;
+    await this.sendNotification({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+  }
+
+  private async request(
+    method: string,
+    params: Record<string, unknown>,
+    stage: string,
+    signal?: AbortSignal,
+    mcpName?: string
+  ): Promise<unknown> {
+    const response = await this.fetchJsonRpc(
+      method,
+      {
+        jsonrpc: "2.0",
+        id: this.nextId++,
+        method,
+        params,
+      },
+      stage,
+      signal,
+      mcpName
+    );
+    return response.body.result;
+  }
+
+  private async sendNotification(body: JsonRpcRequest): Promise<void> {
+    const response = await fetch(this.server.url, {
+      method: "POST",
+      headers: this.headers("notifications/initialized"),
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`MCP ${this.server.name} notifications/initialized failed: HTTP ${response.status}: ${await response.text()}`);
+    }
+  }
+
+  private async fetchJsonRpc(
+    mcpMethod: string,
+    body: JsonRpcRequest,
+    stage: string,
+    signal?: AbortSignal,
+    mcpName?: string
+  ): Promise<{ body: JsonRpcResponse; sessionId?: string }> {
+    const response = await fetch(this.server.url, {
+      method: "POST",
+      headers: this.headers(mcpMethod, mcpName),
+      body: JSON.stringify(body),
+      signal,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`MCP ${this.server.name} ${stage} failed: HTTP ${response.status}: ${text}`);
+    }
+    const parsed = parseMcpResponse(text, response.headers.get("Content-Type") ?? "");
+    if (parsed.error) {
+      throw new Error(`MCP ${this.server.name} ${stage} failed: ${JSON.stringify(parsed.error)}`);
+    }
+    return {
+      body: parsed,
+      sessionId: response.headers.get("MCP-Session-Id") ?? undefined,
+    };
+  }
+
+  private headers(mcpMethod: string, mcpName?: string): Headers {
+    const headers = new Headers();
+    for (const header of this.server.headers) {
+      headers.set(header.name, header.value);
+    }
+    headers.set("Accept", "application/json, text/event-stream");
+    headers.set("Content-Type", "application/json");
+    headers.set("MCP-Protocol-Version", MCP_PROTOCOL_VERSION);
+    headers.set("Mcp-Method", mcpMethod);
+    if (this.mcpSessionId) headers.set("MCP-Session-Id", this.mcpSessionId);
+    if (mcpName) headers.set("Mcp-Name", mcpName);
+    return headers;
+  }
+}
+
+class StdioMcpClient implements ConnectedMcpClient {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private initialized: Promise<void> | null = null;
+  private nextId = 1;
+  private pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason: Error) => void;
+      label: string;
+    }
+  >();
+  private buffer = "";
+  private exited = false;
+  private exitReason: string | null = null;
+
+  constructor(private server: McpServerStdio) {}
+
+  async listTools(): Promise<McpTool[]> {
+    await this.ensureInitialized();
+    return extractTools(await this.request("tools/list", {}, "tools/list"));
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
+    await this.ensureInitialized();
+    return this.request("tools/call", { name, arguments: args }, `tools/call ${name}`, signal);
+  }
+
+  async dispose(): Promise<void> {
+    if (this.child && !this.exited) {
+      try {
+        this.child.kill();
+      } catch {
+        // ignore
+      }
+    }
+    this.child = null;
+    this.initialized = null;
+    for (const [, pending] of this.pending) {
+      pending.reject(new Error("MCP client disposed"));
+    }
+    this.pending.clear();
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return this.initialized;
+    this.initialized = this.startAndInitialize();
+    try {
+      await this.initialized;
+    } catch (err) {
+      this.initialized = null;
+      throw err;
+    }
+  }
+
+  private async startAndInitialize(): Promise<void> {
+    try {
+      this.child = nodeSpawn(this.server.command, this.server.args, {
+        env: buildStdioEnv(this.server),
+      });
+    } catch (err) {
+      throw new Error(`MCP ${this.server.name} startup failed: ${(err as Error).message}`);
+    }
+    this.child.stdout.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
+    this.child.on("exit", (code, sig) => {
+      this.exited = true;
+      this.exitReason = `exit code=${code} signal=${sig ?? "(none)"}`;
+      for (const [, pending] of this.pending) {
+        pending.reject(new Error(`server exited (${this.exitReason}).`));
+      }
+      this.pending.clear();
+    });
+    this.child.on("error", (err) => {
+      this.exited = true;
+      this.exitReason = err.message;
+    });
+
+    await this.request(
+      "initialize",
+      {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
+      },
+      "initialize"
+    );
+    this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  }
+
+  private request(
+    method: string,
+    params: Record<string, unknown>,
+    label: string,
+    signal?: AbortSignal
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      this.pending.set(id, {
+        label,
+        resolve,
+        reject: (err) => reject(new Error(`MCP ${this.server.name} ${label} failed: ${err.message}`)),
+      });
+      const onAbort = () => {
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        this.pending.delete(id);
+        pending.reject(new Error("aborted"));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      try {
+        this.send({ jsonrpc: "2.0", id, method, params });
+      } catch (err) {
+        this.pending.delete(id);
+        reject(new Error(`MCP ${this.server.name} ${label} failed: ${(err as Error).message}`));
+      }
+    });
+  }
+
+  private send(message: Record<string, unknown>): void {
+    if (!this.child || this.exited) {
+      throw new Error(`MCP server is not running${this.exitReason ? ` (${this.exitReason})` : ""}.`);
+    }
+    this.child.stdin.write(JSON.stringify(message) + "\n");
+  }
+
+  private handleStdout(chunk: string): void {
+    this.buffer += chunk;
+    let idx: number;
+    while ((idx = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, idx).trim();
+      this.buffer = this.buffer.slice(idx + 1);
+      if (!line) continue;
+      let parsed: JsonRpcResponse;
+      try {
+        parsed = JSON.parse(line) as JsonRpcResponse;
+      } catch {
+        continue;
+      }
+      if (typeof parsed.id !== "number") continue;
+      const pending = this.pending.get(parsed.id);
+      if (!pending) continue;
+      this.pending.delete(parsed.id);
+      if (parsed.error) {
+        pending.reject(new Error(parsed.error.message ?? `code ${parsed.error.code ?? "?"}`));
+      } else {
+        pending.resolve(parsed.result);
+      }
+    }
+  }
+}
+
+function buildStdioEnv(server: McpServerStdio): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const entry of server.env) {
+    env[entry.name] = entry.value;
+  }
+  return env;
+}
+
+function extractTools(result: unknown): McpTool[] {
+  if (!isRecord(result)) return [];
+  const tools = result["tools"];
+  if (!Array.isArray(tools)) return [];
+  return tools
+    .filter((tool): tool is Record<string, unknown> => isRecord(tool) && typeof tool["name"] === "string")
+    .map((tool) => ({
+      name: tool["name"] as string,
+      description: typeof tool["description"] === "string" ? tool["description"] : undefined,
+      inputSchema: isRecord(tool["inputSchema"]) ? tool["inputSchema"] : undefined,
+    }));
+}
+
+function chooseToolName(sourceName: string, serverName: string, usedNames: Set<string>): string {
+  const safeSource = sanitizeToolName(sourceName) || "tool";
+  if (!usedNames.has(safeSource)) return safeSource;
+  const safeServer = sanitizeToolName(serverName) || "mcp";
+  const base = `${safeServer}_${safeSource}`.slice(0, 60);
+  let candidate = base;
+  let suffix = 2;
+  while (usedNames.has(candidate)) {
+    candidate = `${base}_${suffix++}`.slice(0, 64);
+  }
+  return candidate;
+}
+
+function sanitizeToolName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "_").replace(/^_+|_+$/g, "").slice(0, 64);
+}
+
+function normalizeSchema(schema: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!schema) return { type: "object", properties: {} };
+  return schema;
+}
+
+function parseMcpResponse(text: string, contentType: string): JsonRpcResponse {
+  if (!text.trim()) {
+    throw new Error("MCP response was empty.");
+  }
+  if (contentType.toLowerCase().includes("text/event-stream")) {
+    return parseSseJsonRpc(text);
+  }
+  return JSON.parse(text) as JsonRpcResponse;
+}
+
+function parseSseJsonRpc(text: string): JsonRpcResponse {
+  const dataLines: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+  for (const data of dataLines) {
+    if (!data || data === "[DONE]") continue;
+    const parsed = JSON.parse(data) as JsonRpcResponse;
+    if (parsed.result !== undefined || parsed.error !== undefined) return parsed;
+  }
+  throw new Error("MCP SSE response did not contain a JSON-RPC result.");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
## Purpose

This feature lets ACP clients attach custom MCP servers to a session through `newSession.mcpServers`, so discovered MCP tools become available to the model and tool executor for that session.

## Key Changes

- Advertises HTTP MCP support in the ACP initialize capabilities.
- Connects session-supplied MCP servers during new, loaded, resumed, and forked session lifecycles.
- Builds session-specific GLM tool schemas that combine built-in tools with discovered MCP tools.
- Routes model tool calls for discovered MCP tools through `tools/call` and reports ACP tool-call progress updates.
- Adds an MCP client implementation for streamable HTTP and stdio transports, including tool name collision handling.
- Covers HTTP MCP discovery and tool-call routing with agent tests.

## Checks

- [x] Code compiles without errors
- [x] Changes have been tested locally (`npm test`)
- [x] No console.log or debug statements left behind
- [x] Types are properly defined

## Task

[#35](https://github.com/stefandevo/glm-acp-agent/issues/35)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model Context Protocol (MCP) integration enabling seamless connection to external tool servers
  * Automatic tool discovery and integration from both HTTP and stdio-based MCP servers
  * Per-session tool management combining built-in capabilities with dynamically discovered external tools
  * Improved tool execution routing for proper delegation between built-in and external tool providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->