### PR TITLE
#37 - Run file and shell tools inside glm-acp-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 - **Image input via Coding Plan Vision MCP** – `promptCapabilities.image` is advertised; pasted ACP image blocks are routed through Z.AI Vision MCP (`@z_ai/mcp-server`) and the resulting analysis is fed into the main coding model. Direct chat-image (e.g. `glm-4v-plus`) calls are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Six built-in tools** (see below)
-- **Capability-aware** – every tool is gated on the client capabilities advertised at `initialize` time; tools the client can't run return a clear error to the model instead of crashing
+- **Self-sufficient local tools** – file reads/writes, directory listings, and shell commands run in the agent process, so they do not depend on ACP client `fs` or `terminal` capabilities
 - **Permissioned writes / commands** – every `write_file` and `run_command` call asks the user via `session/request_permission` before doing anything
 - **Protocol-correct stop reasons** – maps model and runtime conditions to ACP `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, and `cancelled`
 - **Protocol-correct tool statuses** – `pending` → `in_progress` → `completed` / `failed`
@@ -51,15 +51,15 @@ ACP Client (IDE plugin, CLI, …)
         ├─ GlmClient   ← Z.AI / Zhipu AI Coding Plan Chat Completions  (src/llm/)
         │
         ├─ ToolExecutor ← executes tool calls  (src/tools/)
-        │    ├─ read_file / write_file       → ACP client (fs.*)
-        │    ├─ list_files / run_command     → ACP client (terminal)
+        │    ├─ read_file / write_file       → Agent process (Node fs)
+        │    ├─ list_files / run_command     → Agent process (Node fs / child_process)
         │    ├─ web_search / web_reader      → Z.AI Coding Plan Web MCP (HTTP)
         │    └─ image_analysis               → Z.AI Coding Plan Vision MCP (stdio)
         │
         └─ VisionMcpClient ← spawns `npx @z_ai/mcp-server` on demand
 ```
 
-The agent process needs network access to `api.z.ai` for chat completions and Web MCP, plus `npx` available on `PATH` so it can launch `@z_ai/mcp-server` for vision. Filesystem and shell operations remain delegated to the ACP client; the agent itself only writes to the OS temp directory when it needs to materialize a pasted image for Vision MCP, and those temp files are removed once the prompt completes.
+The agent process needs network access to `api.z.ai` for chat completions and Web MCP, plus `npx` available on `PATH` so it can launch `@z_ai/mcp-server` for vision. Filesystem and shell operations run inside the agent process with paths resolved against the ACP session working directory. Writes and arbitrary shell commands still go through ACP `session/request_permission`, so clients can render an approval prompt before the operation runs.
 
 ---
 
@@ -67,10 +67,10 @@ The agent process needs network access to `api.z.ai` for chat completions and We
 
 | Tool | Runs on | Requires client capability | Description |
 |------|---------|----------------------------|-------------|
-| `read_file` | ACP client | `fs.readTextFile` | Read the text content of a file |
-| `write_file` | ACP client | `fs.writeTextFile` | Write or overwrite a text file (asks for permission) |
-| `list_files` | ACP client | `terminal` | List a directory via `ls -la` (POSIX shell required) |
-| `run_command` | ACP client | `terminal` | Run an arbitrary shell command via `sh -c` (asks for permission) |
+| `read_file` | Agent process | – | Read the text content of a file |
+| `write_file` | Agent process | ACP permission prompt | Write or overwrite a text file (asks for permission) |
+| `list_files` | Agent process | – | List a directory using Node filesystem APIs |
+| `run_command` | Agent process | ACP permission prompt | Run an arbitrary shell command via `sh -c` in the session cwd (asks for permission) |
 | `web_search` | Agent (Z.AI Coding Plan MCP) | – | Search the web — returns titles, URLs, and summaries |
 | `web_reader` | Agent (Z.AI Coding Plan MCP) | – | Fetch and parse a web page (markdown or plain text) |
 | `image_analysis` | Agent (Z.AI Vision MCP, stdio) | – | Analyze a local image path or remote URL using `@z_ai/mcp-server` |
@@ -284,7 +284,7 @@ For a tighter inner loop, run `npm run dev` in a terminal so `dist/` rebuilds on
 - **`Error: Cannot find module '/.../dist/index.js'`** — you skipped `npm run build`, or the path in `args` is wrong. It must be absolute and point at a file that exists.
 - **`No API key found.`** — neither `Z_AI_API_KEY` nor `~/.config/glm-acp-agent/credentials.json` is set. Use Option A or Option B in step 3.
 - **`HTTP 401: Invalid API key`** — your key is wrong, expired, or for the wrong region. Rotate it on <https://z.ai/manage-apikey/apikey-list>.
-- **`client does not advertise the … capability`** — Zed didn't expose that capability to the agent (e.g. `terminal` for `run_command`/`list_files`). Ask the model to use a different tool, or upgrade Zed.
+- **A write or command did not run.** — approve the ACP permission prompt for that tool call. Rejected or cancelled prompts are reported back to the model as skipped operations.
 
 ### Neovim / VS Code / JetBrains / any ACP client
 
@@ -343,7 +343,7 @@ The test suite covers:
 - Content-block conversion (`text`, `resource_link`, embedded `resource`)
 - Token usage reporting on the `PromptResponse`
 - Tool call lifecycle (`pending` → `in_progress` → `completed` / `failed`)
-- Capability gating (tools refuse cleanly when the client did not advertise the required capability)
+- Agent-owned local file and shell tools that work without ACP `fs` / `terminal` client capabilities
 - Permission flows for `write_file` and `run_command` (allow / reject / cancel)
 - Shell-quoted argument handling for `list_files` and `run_command`
 - GLM streaming: text deltas, `reasoning_content` deltas, multi-chunk tool-call assembly, and trailing usage
@@ -355,8 +355,7 @@ The test suite covers:
 
 - **`No API key found.`** — either set `Z_AI_API_KEY` in the environment, or run `node dist/index.js --setup` (or `glm-acp-agent --setup` if installed globally) once to store the key on disk.
 - **`HTTP 401: Invalid API key`** — your key is wrong or expired; rotate it on <https://z.ai/manage-apikey/apikey-list>.
-- **The agent says "client does not advertise the … capability".** — your ACP client doesn't expose that capability (e.g. terminal). Ask the model to use a different tool, or upgrade the client.
-- **Tools never get to run.** — make sure the client is sending the `clientCapabilities` field in `initialize`; the agent uses it to decide which tools to expose to the model.
+- **Writes or commands never get to run.** — make sure your ACP client supports `session/request_permission` and that you approve the prompt for the specific tool call.
 
 ---
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -173,8 +173,9 @@ export class GlmAcpAgent implements Agent {
     const negotiatedVersion =
       params.protocolVersion <= VERSION ? params.protocolVersion : VERSION;
 
-    // Track client capabilities so we can adapt tool calls to what the client
-    // actually supports.
+    // Keep client capabilities for compatibility with ACP initialize payloads.
+    // Built-in local tools run in this agent process and are not gated on
+    // client fs/terminal support.
     this.clientCapabilities = params.clientCapabilities ?? null;
 
     return {
@@ -730,7 +731,8 @@ export class GlmAcpAgent implements Agent {
       this.clientCapabilities,
       signal,
       this.visionClient,
-      session.mcpTools
+      session.mcpTools,
+      session.cwd
     );
 
     let lastUsage: Usage | undefined;
@@ -852,25 +854,9 @@ export class GlmAcpAgent implements Agent {
     }
   }
 
-  /** Tool schemas we expose given the client's capabilities and session MCP tools. */
+  /** Tool schemas we expose for agent-owned local tools plus session MCP tools. */
   private availableToolDefinitions(mcpTools: SessionMcpTools | null = null): ToolDefinition[] {
-    // If the client never sent capabilities at all (initialize wasn't called,
-    // or it omitted the field), advertise the full set so the system prompt
-    // still mentions every tool. The executor will surface a clean error if
-    // the model invokes one whose capability is missing.
-    if (!this.clientCapabilities) {
-      return [...TOOL_DEFINITIONS, ...(mcpTools?.toolDefinitions ?? [])];
-    }
-
-    const fs = this.clientCapabilities.fs ?? {};
-    const terminal = this.clientCapabilities.terminal ?? false;
-    const names: string[] = [];
-    if (fs.readTextFile) names.push("read_file");
-    if (fs.writeTextFile) names.push("write_file");
-    if (terminal) names.push("list_files", "run_command");
-    // Web tools and image_analysis run inside the agent process, so they are
-    // unconditional except when vision is explicitly disabled.
-    names.push("web_search", "web_reader");
+    const names = ["read_file", "write_file", "list_files", "run_command", "web_search", "web_reader"];
     if (this.visionClientExplicit ? this._visionClient !== null : true) {
       names.push("image_analysis");
     }

--- a/src/protocol/system-prompt.ts
+++ b/src/protocol/system-prompt.ts
@@ -29,12 +29,13 @@ export interface BuildSystemPromptInput {
 const PERSONA = `You are glm-acp-agent, an ACP coding agent backed by the GLM model family (Z.AI / Zhipu AI).
 You help developers read, understand, and modify code in their projects.
 You operate over the Agent Client Protocol (ACP); your client is an IDE or
-terminal that proxies file-system, terminal, and permission access on the
-user's behalf.`;
+terminal that renders tool calls and prompts the user for permission before
+writes or command execution. File-system and shell operations run inside this
+agent process with paths resolved from the session working directory.`;
 
 const TOOLS_TEMPLATE = `<tools>
 Available tools: __TOOLS__
-- Use only tools listed above; the client has explicitly granted them.
+- Use only tools listed above.
 - Prefer reading before writing: when modifying a file, read it first so your edit is grounded in the current contents.
 - Issue independent lookups (multiple file reads, separate searches) in parallel rather than sequentially.
 - Briefly state what you are about to do before invoking any tool that touches the file system, terminal, or network.

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -236,7 +236,7 @@ test("newSession returns a unique session id and seeds a system prompt", async (
   assert.equal(list.sessions.length, 2);
 });
 
-test("system prompt advertises only the tools matching client capabilities", async () => {
+test("system prompt advertises agent-owned local tools without client fs or terminal capabilities", async () => {
   const conn = createConnectionStub();
   let captured = "";
   const glm = {
@@ -255,13 +255,16 @@ test("system prompt advertises only the tools matching client capabilities", asy
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
   await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
 
-  // Web tools are unconditional, but file/terminal tools must NOT appear.
-  assert.ok(captured.includes("web_search"));
-  assert.ok(captured.includes("web_reader"));
-  assert.ok(!captured.includes("read_file"));
-  assert.ok(!captured.includes("write_file"));
-  assert.ok(!captured.includes("list_files"));
-  assert.ok(!captured.includes("run_command"));
+  for (const name of [
+    "read_file",
+    "write_file",
+    "list_files",
+    "run_command",
+    "web_search",
+    "web_reader",
+  ]) {
+    assert.ok(captured.includes(name), `expected system prompt to mention ${name}`);
+  }
 });
 
 test("system prompt falls back to all tools when client never sent capabilities", async () => {
@@ -1004,8 +1007,9 @@ test("prompt converts resource_link and embedded resource blocks", async () => {
 });
 
 test("tool call result is fed back into the next streamChat call", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-agent-tool-read-"));
+  writeFileSync(pathJoin(dir, "x.ts"), "export const x = 1;", "utf8");
   const conn = createConnectionStub();
-  conn.fileResponses.set("/tmp/x.ts", "export const x = 1;");
 
   let callIndex = 0;
   const glm = {
@@ -1015,7 +1019,7 @@ test("tool call result is fed back into the next streamChat call", async () => {
       callIndex++;
       if (callIndex === 1) {
         yield {
-          toolCall: { id: "tc1", name: "read_file", arguments: JSON.stringify({ path: "/tmp/x.ts" }) },
+          toolCall: { id: "tc1", name: "read_file", arguments: JSON.stringify({ path: "x.ts" }) },
         };
         yield { done: true, stopReason: "tool_calls" };
       } else {
@@ -1034,15 +1038,19 @@ test("tool call result is fed back into the next streamChat call", async () => {
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
   });
-  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  const { sessionId } = await agent.newSession({ cwd: dir, mcpServers: [] });
 
-  const result = await agent.prompt({
-    sessionId,
-    prompt: [{ type: "text", text: "read it" }],
-  });
-  assert.equal(result.stopReason, "end_turn");
-  assert.equal(callIndex, 2);
-  assert.deepEqual(conn.reads, ["/tmp/x.ts"]);
+  try {
+    const result = await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "read it" }],
+    });
+    assert.equal(result.stopReason, "end_turn");
+    assert.equal(callIndex, 2);
+    assert.deepEqual(conn.reads, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("prompt without title sets title from first user message", async () => {

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeCredentials } from "../llm/credentials.js";
@@ -71,6 +71,10 @@ const FULL_CAPS = {
   fs: { readTextFile: true, writeTextFile: true },
   terminal: true,
 };
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 type FetchCall = {
   url: string;
@@ -168,34 +172,55 @@ test("empty arguments string is accepted as empty object", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Capability gating
+// Client capability independence
 // ---------------------------------------------------------------------------
 
-test("read_file is unavailable without fs.readTextFile capability", async () => {
+test("read_file reads from the agent process without fs.readTextFile capability", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-read-"));
+  const path = join(dir, "note.txt");
+  writeFileSync(path, "from disk", "utf8");
   const conn = createConnectionStub();
   const exec = new ToolExecutor(conn as never, "s1", { fs: {} });
-  const result = await exec.execute("tc1", "read_file", JSON.stringify({ path: "/x" }));
-  assert.match(result.content, /does not advertise the fs.readTextFile capability/);
+  try {
+    const result = await exec.execute("tc1", "read_file", JSON.stringify({ path }));
+    assert.equal(result.content, "from disk");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
-test("write_file is unavailable without fs.writeTextFile capability", async () => {
+test("write_file writes from the agent process without fs.writeTextFile capability", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-write-"));
+  const path = join(dir, "out.txt");
   const conn = createConnectionStub();
   const exec = new ToolExecutor(conn as never, "s1", { fs: { readTextFile: true } });
-  const result = await exec.execute(
-    "tc1",
-    "write_file",
-    JSON.stringify({ path: "/x", content: "hi" })
-  );
-  assert.match(result.content, /does not advertise the fs.writeTextFile capability/);
+  try {
+    const result = await exec.execute(
+      "tc1",
+      "write_file",
+      JSON.stringify({ path, content: "hi" })
+    );
+    assert.match(result.content, /written successfully/);
+    assert.equal(readFileSync(path, "utf8"), "hi");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
-test("list_files / run_command are unavailable without terminal capability", async () => {
+test("list_files and run_command execute in the agent process without terminal capability", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-local-"));
+  writeFileSync(join(dir, "entry.txt"), "data", "utf8");
   const conn = createConnectionStub();
-  const exec = new ToolExecutor(conn as never, "s1", { fs: {} });
-  const ls = await exec.execute("tc1", "list_files", JSON.stringify({ path: "/" }));
-  assert.match(ls.content, /does not advertise the terminal capability/);
-  const rc = await exec.execute("tc2", "run_command", JSON.stringify({ command: "ls" }));
-  assert.match(rc.content, /does not advertise the terminal capability/);
+  const exec = new ToolExecutor(conn as never, "s1", { fs: {} }, undefined, null, null, dir);
+  try {
+    const ls = await exec.execute("tc1", "list_files", JSON.stringify({ path: "." }));
+    assert.match(ls.content, /entry\.txt/);
+    const rc = await exec.execute("tc2", "run_command", JSON.stringify({ command: "pwd" }));
+    assert.match(rc.content, new RegExp(escapeRegExp(dir)));
+    assert.equal(conn.terminalCalls.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -203,30 +228,42 @@ test("list_files / run_command are unavailable without terminal capability", asy
 // ---------------------------------------------------------------------------
 
 test("read_file success path emits in_progress and completed updates", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-read-success-"));
+  const path = join(dir, "x.txt");
+  writeFileSync(path, "hello", "utf8");
   const conn = createConnectionStub();
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
-  const result = await exec.execute("tc1", "read_file", JSON.stringify({ path: "/x.txt" }));
-  assert.equal(result.content, "hello");
+  try {
+    const result = await exec.execute("tc1", "read_file", JSON.stringify({ path }));
+    assert.equal(result.content, "hello");
 
-  const sequence = conn.updates.map(
-    (u) => ({
-      type: (u.update as { sessionUpdate: string }).sessionUpdate,
-      status: (u.update as { status?: string }).status,
-    })
-  );
-  assert.deepEqual(sequence, [
-    { type: "tool_call", status: "in_progress" },
-    { type: "tool_call_update", status: "completed" },
-  ]);
+    const sequence = conn.updates.map(
+      (u) => ({
+        type: (u.update as { sessionUpdate: string }).sessionUpdate,
+        status: (u.update as { status?: string }).status,
+      })
+    );
+    assert.deepEqual(sequence, [
+      { type: "tool_call", status: "in_progress" },
+      { type: "tool_call_update", status: "completed" },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("read_file failure is reported with status=failed and an error message", async () => {
-  const conn = createConnectionStub({ readError: true });
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-read-fail-"));
+  const conn = createConnectionStub();
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
-  const result = await exec.execute("tc1", "read_file", JSON.stringify({ path: "/x.txt" }));
-  assert.match(result.content, /Error reading file:/);
-  const last = conn.updates.at(-1) as { update: { status?: string } };
-  assert.equal(last.update.status, "failed");
+  try {
+    const result = await exec.execute("tc1", "read_file", JSON.stringify({ path: join(dir, "missing.txt") }));
+    assert.match(result.content, /Error reading file:/);
+    const last = conn.updates.at(-1) as { update: { status?: string } };
+    assert.equal(last.update.status, "failed");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -234,38 +271,52 @@ test("read_file failure is reported with status=failed and an error message", as
 // ---------------------------------------------------------------------------
 
 test("write_file requests permission, then transitions through pending → in_progress → completed", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-write-success-"));
+  const path = join(dir, "y.txt");
   const conn = createConnectionStub({ permission: "allow" });
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
-  const result = await exec.execute(
-    "tc1",
-    "write_file",
-    JSON.stringify({ path: "/y.txt", content: "data" })
-  );
-  assert.match(result.content, /written successfully/);
+  try {
+    const result = await exec.execute(
+      "tc1",
+      "write_file",
+      JSON.stringify({ path, content: "data" })
+    );
+    assert.match(result.content, /written successfully/);
+    assert.equal(readFileSync(path, "utf8"), "data");
 
-  assert.equal(conn.permissionRequests.length, 1);
-  const sequence = conn.updates.map((u) => ({
-    type: (u.update as { sessionUpdate: string }).sessionUpdate,
-    status: (u.update as { status?: string }).status,
-  }));
-  assert.deepEqual(sequence, [
-    { type: "tool_call", status: "pending" },
-    { type: "tool_call_update", status: "in_progress" },
-    { type: "tool_call_update", status: "completed" },
-  ]);
+    assert.equal(conn.permissionRequests.length, 1);
+    const sequence = conn.updates.map((u) => ({
+      type: (u.update as { sessionUpdate: string }).sessionUpdate,
+      status: (u.update as { status?: string }).status,
+    }));
+    assert.deepEqual(sequence, [
+      { type: "tool_call", status: "pending" },
+      { type: "tool_call_update", status: "in_progress" },
+      { type: "tool_call_update", status: "completed" },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("write_file rejected by user marks call failed and skips writing", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-write-reject-"));
+  const path = join(dir, "y.txt");
   const conn = createConnectionStub({ permission: "reject" });
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
-  const result = await exec.execute(
-    "tc1",
-    "write_file",
-    JSON.stringify({ path: "/y.txt", content: "data" })
-  );
-  assert.match(result.content, /rejected by user/i);
-  const last = conn.updates.at(-1) as { update: { status?: string } };
-  assert.equal(last.update.status, "failed");
+  try {
+    const result = await exec.execute(
+      "tc1",
+      "write_file",
+      JSON.stringify({ path, content: "data" })
+    );
+    assert.match(result.content, /rejected by user/i);
+    assert.equal(existsSync(path), false);
+    const last = conn.updates.at(-1) as { update: { status?: string } };
+    assert.equal(last.update.status, "failed");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("write_file cancelled by user marks call failed", async () => {
@@ -299,37 +350,84 @@ test("run_command rejects empty input", async () => {
 });
 
 test("run_command runs through sh -c so quoting/pipes work", async () => {
-  const conn = createConnectionStub({ terminalOutput: "/tmp" });
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-cmd-"));
+  const conn = createConnectionStub();
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS, undefined, null, null, dir);
+  const result = await exec.execute(
+    "tc1",
+    "run_command",
+    JSON.stringify({ command: "printf 'mixed' | tr a-z A-Z && pwd" })
+  );
+  assert.match(result.content, /Exit code: 0/);
+  assert.match(result.content, /MIXED/);
+  assert.match(result.content, new RegExp(escapeRegExp(dir)));
+  assert.equal(conn.terminalCalls.length, 0);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("run_command includes stderr and non-zero exit code in the tool result", async () => {
+  const conn = createConnectionStub();
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
   const result = await exec.execute(
     "tc1",
     "run_command",
-    JSON.stringify({ command: "echo $HOME | tr a-z A-Z" })
+    JSON.stringify({ command: "printf 'bad' >&2; exit 7" })
   );
-  assert.equal(result.content, "/tmp");
-  const call = conn.terminalCalls[0];
-  assert.equal(call?.command, "sh");
-  assert.deepEqual(call?.args, ["-c", "echo $HOME | tr a-z A-Z"]);
+  assert.match(result.content, /Exit code: 7/);
+  assert.match(result.content, /STDERR:\nbad/);
+  const last = conn.updates.at(-1) as {
+    update: { status?: string; rawOutput?: { exitCode?: number; stderr?: string } };
+  };
+  assert.equal(last.update.status, "completed");
+  assert.equal(last.update.rawOutput?.exitCode, 7);
+  assert.equal(last.update.rawOutput?.stderr, "bad");
+});
+
+test("run_command rejected by user marks call failed and skips execution", async () => {
+  const conn = createConnectionStub({ permission: "reject" });
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+  const result = await exec.execute(
+    "tc1",
+    "run_command",
+    JSON.stringify({ command: "printf should-not-run" })
+  );
+  assert.match(result.content, /rejected by user/i);
+  const last = conn.updates.at(-1) as { update: { status?: string } };
+  assert.equal(last.update.status, "failed");
+  assert.equal(conn.terminalCalls.length, 0);
+});
+
+test("run_command cancelled by user marks call failed and skips execution", async () => {
+  const conn = createConnectionStub({ permission: "cancelled" });
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+  const result = await exec.execute(
+    "tc1",
+    "run_command",
+    JSON.stringify({ command: "printf should-not-run" })
+  );
+  assert.match(result.content, /cancelled by user/i);
+  const last = conn.updates.at(-1) as { update: { status?: string } };
+  assert.equal(last.update.status, "failed");
+  assert.equal(conn.terminalCalls.length, 0);
 });
 
 // ---------------------------------------------------------------------------
 // list_files
 // ---------------------------------------------------------------------------
 
-test("list_files runs through sh -c with shell-quoted path", async () => {
-  const conn = createConnectionStub({ terminalOutput: "drwxr-xr-x ..." });
-  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+test("list_files resolves relative paths against the session cwd", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "glm-executor-list-"));
+  writeFileSync(join(dir, "with space.txt"), "data", "utf8");
+  const conn = createConnectionStub();
+  const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS, undefined, null, null, dir);
   const result = await exec.execute(
     "tc1",
     "list_files",
-    JSON.stringify({ path: "/tmp/with space" })
+    JSON.stringify({ path: "." })
   );
-  assert.match(result.content, /drwxr-xr-x/);
-  const call = conn.terminalCalls[0];
-  assert.equal(call?.command, "sh");
-  assert.equal(call?.args?.[0], "-c");
-  assert.match(call?.args?.[1] ?? "", /^ls -la --/);
-  assert.match(call?.args?.[1] ?? "", /'\/tmp\/with space'/);
+  assert.match(result.content, /with space\.txt/);
+  assert.equal(conn.terminalCalls.length, 0);
+  rmSync(dir, { recursive: true, force: true });
 });
 
 test("list_files rejects empty path", async () => {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 
@@ -117,10 +117,11 @@ test("end-to-end initialize / new session / prompt round-trip via real SDK trans
   assert.ok(updateKinds.includes("session_info_update"));
 });
 
-test("end-to-end tool call: agent reads a file via the stub client", async () => {
+test("end-to-end tool call: agent reads a local file from the session cwd", async () => {
   const { a, b } = pairedStreams();
   const stub = new StubClient();
-  stub.fileContents.set("/tmp/x.ts", "export const x = 1;");
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-integration-read-"));
+  writeFileSync(pathJoin(dir, "x.ts"), "export const x = 1;", "utf8");
 
   let callIndex = 0;
   const glm = {
@@ -131,7 +132,7 @@ test("end-to-end tool call: agent reads a file via the stub client", async () =>
           toolCall: {
             id: "tc1",
             name: "read_file",
-            arguments: JSON.stringify({ path: "/tmp/x.ts" }),
+            arguments: JSON.stringify({ path: "x.ts" }),
           },
         };
         yield { done: true, stopReason: "tool_calls" };
@@ -153,21 +154,25 @@ test("end-to-end tool call: agent reads a file via the stub client", async () =>
     protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
   });
-  const session = await clientConn.newSession({ cwd: "/tmp", mcpServers: [] });
-  const result = await clientConn.prompt({
-    sessionId: session.sessionId,
-    prompt: [{ type: "text", text: "read it" }],
-  });
+  const session = await clientConn.newSession({ cwd: dir, mcpServers: [] });
+  try {
+    const result = await clientConn.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "read it" }],
+    });
 
-  assert.equal(result.stopReason, "end_turn");
-  assert.deepEqual(stub.reads, [{ path: "/tmp/x.ts" }]);
+    assert.equal(result.stopReason, "end_turn");
+    assert.deepEqual(stub.reads, []);
 
-  // The client should have seen `tool_call` and `tool_call_update` notifications.
-  const updateKinds = stub.updates.map(
-    (u) => (u.update as { sessionUpdate: string }).sessionUpdate
-  );
-  assert.ok(updateKinds.includes("tool_call"));
-  assert.ok(updateKinds.includes("tool_call_update"));
+    // The client should have seen `tool_call` and `tool_call_update` notifications.
+    const updateKinds = stub.updates.map(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate
+    );
+    assert.ok(updateKinds.includes("tool_call"));
+    assert.ok(updateKinds.includes("tool_call_update"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("end-to-end cancellation via session/cancel notification", async () => {

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -2,9 +2,9 @@
  * Tool JSON schemas exposed to the GLM model.
  *
  * These definitions follow the OpenAI function-calling format and map
- * directly to ACP Client capabilities. The agent advertises the same set
- * of tools on every call; whether a tool actually works at runtime depends
- * on the client capabilities advertised at `initialize` time.
+ * directly to ToolExecutor implementations. Local file and shell tools run in
+ * the agent process; writes and command execution still ask the ACP client for
+ * permission before doing anything.
  */
 
 export interface ToolDefinition {
@@ -22,7 +22,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: "read_file",
       description:
-        "Read the text content of a file from the client's file system. Requires the `fs.readTextFile` client capability.",
+        "Read the text content of a file from the agent process. Relative paths resolve against the ACP session working directory.",
       parameters: {
         type: "object",
         properties: {
@@ -40,7 +40,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: "write_file",
       description:
-        "Write or overwrite a text file in the client's file system. The user is asked for permission before any write occurs. Requires the `fs.writeTextFile` client capability.",
+        "Write or overwrite a text file from the agent process after asking the user for permission. Relative paths resolve against the ACP session working directory.",
       parameters: {
         type: "object",
         properties: {
@@ -62,7 +62,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: "list_files",
       description:
-        "List the files and directories at the given path by running `ls -la` through a shell on the client machine. Requires the `terminal` client capability and a POSIX-compatible shell.",
+        "List the files and directories at the given path from the agent process. Relative paths resolve against the ACP session working directory.",
       parameters: {
         type: "object",
         properties: {
@@ -80,7 +80,7 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     function: {
       name: "run_command",
       description:
-        "Execute a shell command via `sh -c` on the client machine and return its output. The user is asked for permission before each invocation. Requires the `terminal` client capability.",
+        "Execute a shell command via `sh -c` in the ACP session working directory and return stdout, stderr, and exit code. The user is asked for permission before each invocation.",
       parameters: {
         type: "object",
         properties: {

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -2,6 +2,9 @@ import type {
   AgentSideConnection,
   ClientCapabilities,
 } from "@agentclientprotocol/sdk";
+import { spawn } from "node:child_process";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join as pathJoin, resolve as pathResolve } from "node:path";
 import { resolveApiKey } from "../llm/credentials.js";
 import {
   callZaiMcpTool,
@@ -19,12 +22,11 @@ export interface ToolResult {
 }
 
 /**
- * Executes GLM tool calls by delegating to the corresponding ACP Client methods.
+ * Executes GLM tool calls from inside the agent process.
  *
- * Permission is requested from the user before any write or execute operation.
- * Tools that require capabilities the client did not advertise return a clear
- * error string instead of throwing, so the model can recover by trying a
- * different approach.
+ * Permission is requested from the user before any write or execute operation,
+ * while read/list operations and approved writes/commands run locally with
+ * paths resolved relative to the ACP session cwd.
  */
 export class ToolExecutor {
   constructor(
@@ -33,7 +35,8 @@ export class ToolExecutor {
     private clientCapabilities: ClientCapabilities | null = null,
     private signal?: AbortSignal,
     private visionClient: VisionMcpClient | null = null,
-    private sessionMcpTools: SessionMcpTools | null = null
+    private sessionMcpTools: SessionMcpTools | null = null,
+    private sessionCwd: string = process.cwd()
   ) {}
 
   /**
@@ -85,25 +88,6 @@ export class ToolExecutor {
   }
 
   // ---------------------------------------------------------------------------
-  // Capability helpers
-  // ---------------------------------------------------------------------------
-
-  private requireCap(
-    toolCallId: string,
-    toolName: string,
-    args: Record<string, unknown>,
-    available: boolean,
-    capName: string
-  ): Promise<ToolResult> | null {
-    if (available) return null;
-    const message = `Error: client does not advertise the ${capName} capability; this tool is unavailable.`;
-    return (async () => {
-      await this.failedToolCall(toolCallId, toolName, args, message);
-      return { content: message };
-    })();
-  }
-
-  // ---------------------------------------------------------------------------
   // Private tool implementations
   // ---------------------------------------------------------------------------
 
@@ -111,19 +95,11 @@ export class ToolExecutor {
     toolCallId: string,
     args: Record<string, unknown>
   ): Promise<ToolResult> {
-    const cap = this.requireCap(
-      toolCallId,
-      "read_file",
-      args,
-      Boolean(this.clientCapabilities?.fs?.readTextFile),
-      "fs.readTextFile"
-    );
-    if (cap) return cap;
-
     const path = String(args["path"] ?? "").trim();
     if (!path) {
       return this.failAndReturn(toolCallId, "read_file", args, "Error: `path` is required.");
     }
+    const absolutePath = this.resolvePath(path);
 
     await this.connection.sessionUpdate({
       sessionId: this.sessionId,
@@ -139,10 +115,7 @@ export class ToolExecutor {
     });
 
     try {
-      const response = await this.connection.readTextFile({
-        sessionId: this.sessionId,
-        path,
-      });
+      const content = await readFile(absolutePath, "utf8");
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -150,12 +123,12 @@ export class ToolExecutor {
           sessionUpdate: "tool_call_update",
           toolCallId,
           status: "completed",
-          content: [{ type: "content", content: { type: "text", text: response.content } }],
-          rawOutput: { content: response.content },
+          content: [{ type: "content", content: { type: "text", text: content } }],
+          rawOutput: { content },
         },
       });
 
-      return { content: response.content };
+      return { content };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       await this.markFailed(toolCallId, message);
@@ -167,20 +140,12 @@ export class ToolExecutor {
     toolCallId: string,
     args: Record<string, unknown>
   ): Promise<ToolResult> {
-    const cap = this.requireCap(
-      toolCallId,
-      "write_file",
-      args,
-      Boolean(this.clientCapabilities?.fs?.writeTextFile),
-      "fs.writeTextFile"
-    );
-    if (cap) return cap;
-
     const path = String(args["path"] ?? "").trim();
     const content = String(args["content"] ?? "");
     if (!path) {
       return this.failAndReturn(toolCallId, "write_file", args, "Error: `path` is required.");
     }
+    const absolutePath = this.resolvePath(path);
 
     // Step 1: announce the pending tool call so the client can show it.
     await this.connection.sessionUpdate({
@@ -244,11 +209,7 @@ export class ToolExecutor {
     });
 
     try {
-      await this.connection.writeTextFile({
-        sessionId: this.sessionId,
-        path,
-        content,
-      });
+      await writeFile(absolutePath, content, "utf8");
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -272,15 +233,6 @@ export class ToolExecutor {
     toolCallId: string,
     args: Record<string, unknown>
   ): Promise<ToolResult> {
-    const cap = this.requireCap(
-      toolCallId,
-      "list_files",
-      args,
-      Boolean(this.clientCapabilities?.terminal),
-      "terminal"
-    );
-    if (cap) return cap;
-
     const rawPath = args["path"];
     if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
       return this.failAndReturn(
@@ -290,7 +242,8 @@ export class ToolExecutor {
         "Error listing files: `path` must be a non-empty string."
       );
     }
-    const path = rawPath;
+    const path = rawPath.trim();
+    const absolutePath = this.resolvePath(path);
 
     await this.connection.sessionUpdate({
       sessionId: this.sessionId,
@@ -305,18 +258,19 @@ export class ToolExecutor {
       },
     });
 
-    let terminal;
     try {
-      terminal = await this.connection.createTerminal({
-        sessionId: this.sessionId,
-        // Run via a shell so quoting / wildcards behave like a real ls call.
-        command: "sh",
-        args: ["-c", `ls -la -- ${shellQuote(path)}`],
-      });
-
-      await terminal.waitForExit();
-      const outputResponse = await terminal.currentOutput();
-      const output = outputResponse.output;
+      const entries = await readdir(absolutePath, { withFileTypes: true });
+      const lines = await Promise.all(
+        entries
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map(async (entry) => {
+            const entryPath = pathJoin(absolutePath, entry.name);
+            const info = await stat(entryPath);
+            const type = entry.isDirectory() ? "dir" : entry.isSymbolicLink() ? "link" : "file";
+            return `${type}\t${info.size}\t${entry.name}`;
+          })
+      );
+      const output = [`Listing for ${path} (${absolutePath})`, ...lines].join("\n");
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -324,7 +278,7 @@ export class ToolExecutor {
           sessionUpdate: "tool_call_update",
           toolCallId,
           status: "completed",
-          content: [{ type: "terminal", terminalId: terminal.id }],
+          content: [{ type: "content", content: { type: "text", text: output } }],
           rawOutput: { output },
         },
       });
@@ -334,12 +288,6 @@ export class ToolExecutor {
       const message = err instanceof Error ? err.message : String(err);
       await this.markFailed(toolCallId, message);
       return { content: `Error listing files: ${message}` };
-    } finally {
-      try {
-        await terminal?.release();
-      } catch {
-        // ignore release errors
-      }
     }
   }
 
@@ -347,15 +295,6 @@ export class ToolExecutor {
     toolCallId: string,
     args: Record<string, unknown>
   ): Promise<ToolResult> {
-    const cap = this.requireCap(
-      toolCallId,
-      "run_command",
-      args,
-      Boolean(this.clientCapabilities?.terminal),
-      "terminal"
-    );
-    if (cap) return cap;
-
     const command = String(args["command"] ?? "").trim();
     if (!command) {
       return this.failAndReturn(
@@ -417,10 +356,10 @@ export class ToolExecutor {
       return { content: "Command rejected by user." };
     }
 
-    return this.runTerminalCommand(toolCallId, command);
+    return this.runLocalCommand(toolCallId, command);
   }
 
-  private async runTerminalCommand(
+  private async runLocalCommand(
     toolCallId: string,
     command: string
   ): Promise<ToolResult> {
@@ -433,19 +372,13 @@ export class ToolExecutor {
       },
     });
 
-    let terminal;
     try {
-      // Run via `sh -c` so the command string is interpreted by a real shell –
-      // this preserves quoting, pipes, redirects and environment expansion.
-      terminal = await this.connection.createTerminal({
-        sessionId: this.sessionId,
-        command: "sh",
-        args: ["-c", command],
-      });
-
-      await terminal.waitForExit();
-      const outputResponse = await terminal.currentOutput();
-      const output = outputResponse.output;
+      const { stdout, stderr, exitCode, signal } = await runShellCommand(
+        command,
+        this.sessionCwd,
+        this.signal
+      );
+      const output = formatCommandOutput({ stdout, stderr, exitCode, signal });
 
       await this.connection.sessionUpdate({
         sessionId: this.sessionId,
@@ -453,8 +386,8 @@ export class ToolExecutor {
           sessionUpdate: "tool_call_update",
           toolCallId,
           status: "completed",
-          content: [{ type: "terminal", terminalId: terminal.id }],
-          rawOutput: { output },
+          content: [{ type: "content", content: { type: "text", text: output } }],
+          rawOutput: { stdout, stderr, exitCode, signal },
         },
       });
 
@@ -463,13 +396,11 @@ export class ToolExecutor {
       const message = err instanceof Error ? err.message : String(err);
       await this.markFailed(toolCallId, message);
       return { content: `Error running command: ${message}` };
-    } finally {
-      try {
-        await terminal?.release();
-      } catch {
-        // ignore release errors
-      }
     }
+  }
+
+  private resolvePath(path: string): string {
+    return pathResolve(this.sessionCwd, path);
   }
 
   private async webSearch(
@@ -852,12 +783,52 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/**
- * Quote a string for safe inclusion in a `sh -c` command line.
- * We use single quotes and escape any embedded single quotes via `'\''`.
- */
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
+function runShellCommand(
+  command: string,
+  cwd: string,
+  signal?: AbortSignal
+): Promise<{ stdout: string; stderr: string; exitCode: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("sh", ["-c", command], {
+      cwd,
+      signal,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let settled = false;
+
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+    child.on("close", (exitCode, closeSignal) => {
+      if (settled) return;
+      settled = true;
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        exitCode,
+        signal: closeSignal,
+      });
+    });
+  });
+}
+
+function formatCommandOutput(result: {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+}): string {
+  const lines = [`Exit code: ${result.exitCode ?? "unknown"}`];
+  if (result.signal) lines.push(`Signal: ${result.signal}`);
+  lines.push("", "STDOUT:", result.stdout.length > 0 ? result.stdout : "(empty)");
+  lines.push("", "STDERR:", result.stderr.length > 0 ? result.stderr : "(empty)");
+  return lines.join("\n");
 }
 
 function unwrapVisionText(mcpResult: unknown): string {

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -3,7 +3,7 @@ import type {
   ClientCapabilities,
 } from "@agentclientprotocol/sdk";
 import { spawn } from "node:child_process";
-import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { lstat, readdir, readFile, writeFile } from "node:fs/promises";
 import { join as pathJoin, resolve as pathResolve } from "node:path";
 import { resolveApiKey } from "../llm/credentials.js";
 import {
@@ -265,7 +265,7 @@ export class ToolExecutor {
           .sort((a, b) => a.name.localeCompare(b.name))
           .map(async (entry) => {
             const entryPath = pathJoin(absolutePath, entry.name);
-            const info = await stat(entryPath);
+            const info = await lstat(entryPath);
             const type = entry.isDirectory() ? "dir" : entry.isSymbolicLink() ? "link" : "file";
             return `${type}\t${info.size}\t${entry.name}`;
           })


### PR DESCRIPTION
## Purpose

This feature makes glm-acp-agent self-sufficient for local coding tools by running file and shell operations inside the adapter process instead of depending on ACP client `fs` or `terminal` capabilities, while preserving ACP permission prompts for writes and commands.

## Key Changes

- Pass the ACP session working directory into `ToolExecutor` so relative paths resolve against the active project cwd.
- Execute `read_file`, `write_file`, and `list_files` with Node filesystem APIs inside the agent process.
- Execute `run_command` via local `sh -c` with the session cwd and return stdout, stderr, exit code, and signal details to the model.
- Keep `session/update` tool-call lifecycle updates and ACP `session/request_permission` prompts for writes and command execution.
- Always advertise built-in local tools regardless of client `fs` / `terminal` capabilities, while leaving web, vision, and session MCP behavior unchanged.
- Update README, system prompt wording, and tool descriptions to document agent-owned local execution.
- Expand protocol, executor, and integration tests for capability-independent local tools, permission rejection/cancel paths, cwd resolution, and command output detail.

## Checks

- [x] `npm run build && node --test --test-name-pattern 'run_command' dist/tests/executor.test.js`
- [x] `npm test`
- [x] `git diff --check`
- [x] Self-review completed with autofix

## Task

[#37](https://github.com/stefandevo/glm-acp-agent/issues/37)