### PR TITLE
#49 - Fix main CI lint failures after context compaction merge

### DIFF
--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -808,6 +808,8 @@ export class GlmAcpAgent implements Agent {
 
     let lastUsage: Usage | undefined;
 
+    let overflowRetryCount = 0;
+
     for (let turn = 0; turn < this.maxTurns; turn++) {
       if (signal.aborted) return { stopReason: "cancelled" };
 
@@ -830,7 +832,6 @@ export class GlmAcpAgent implements Agent {
       let lastStopReason: string | undefined;
 
       let retryTurn = false;
-      let overflowRetryCount = 0;
       try {
         // Stream the GLM response. The session's currently-selected model wins;
         // it's mutated by `unstable_setSessionModel` between turns.
@@ -889,7 +890,7 @@ export class GlmAcpAgent implements Agent {
           overflowRetryCount++;
           retryTurn = true;
         } else if (isOverflow) {
-          throw new Error("Context overflow persisted after emergency compaction");
+          throw new Error("Context overflow persisted after emergency compaction", { cause: err });
         } else {
           throw err;
         }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1658,14 +1658,21 @@ test("prompt performs emergency compaction and retries on 1261 error", async () 
 test("prompt fails fast when context overflow persists after emergency compaction", async () => {
   const conn = createConnectionStub();
   let callCount = 0;
+  let secondOverflow: Error | null = null;
 
   const glm = {
     async *streamChat(): AsyncGenerator<GlmStreamChunk> {
       callCount++;
+      if (callCount > 2) {
+        throw new Error("streamChat retried more than once");
+      }
       // Simulate a persistent Z.AI context overflow error (1261).
       const err = new Error("Prompt still exceeds max length after compaction") as OverflowErrorLike;
       err.error = { code: 1261 };
-      throw err;
+      if (callCount === 2) {
+        secondOverflow = err;
+      }
+      yield await Promise.reject(err);
     },
   };
 
@@ -1677,13 +1684,14 @@ test("prompt fails fast when context overflow persists after emergency compactio
   // Use a try-catch to assert that prompt surfaces the error rather than retrying forever.
   // The agent.prompt method catches internal errors and emits them as agent messages, 
   // so we check the updates emitted to the connection.
+  let caught: unknown;
   try {
     await agent.prompt({
       sessionId,
       prompt: [{ type: "text", text: "Trigger overflow" }],
     });
-  } catch (err) {
-    // Some errors might bubble up depending on where they are caught in GlmAcpAgent.prompt
+  } catch (error) {
+    caught = error;
   }
 
   const errorMessages = conn.updates.filter((u) => {
@@ -1695,5 +1703,8 @@ test("prompt fails fast when context overflow persists after emergency compactio
   });
 
   assert.equal(callCount, 2, "expected exactly two calls: initial and one retry after compaction");
+  assert.ok(caught instanceof Error);
+  assert.equal(caught.message, "Context overflow persisted after emergency compaction");
+  assert.equal(caught.cause, secondOverflow);
   assert.equal(errorMessages.length, 1, "expected an error message reporting persistent overflow");
 });


### PR DESCRIPTION
## Purpose

This bugfix clears the main-branch CI lint failures introduced around context compaction by preserving context-overflow retry state across the emergency retry and keeping the original overflow error attached when the retry still fails.

## Key Changes

- Keep overflow retry bookkeeping outside the per-turn retry loop so persistent overflow stops after one emergency compaction retry.
- Preserve the original persistent overflow error as the `cause` of the surfaced error.
- Tighten the persistent-overflow regression test to prove exactly one retry occurs.
- Clean up the async generator test stub and catch handling so ESLint passes without weakening the behavior assertion.

## Checks

- [x] `npm run lint`
- [x] `npm run build`
- [x] focused persistent-overflow regression test
- [x] `npm test` (152 tests passing)
- [x] `git diff --check`
- [x] DevFlow self-review completed with verdict `READY`

## Task

[#49](https://github.com/stefandevo/glm-acp-agent/issues/49)