### PR TITLE
#52 - Harden glm-acp-agent bunx distribution checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,12 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Bunx smoke test (packed tarball)
+        run: |
+          npm pack --pack-destination "$RUNNER_TEMP"
+          VERSION=$(node -p "require('./package.json').version")
+          TMPDIR=$(mktemp -d) bun x --package "$RUNNER_TEMP/glm-acp-agent-$VERSION.tgz" glm-acp-agent < /dev/null

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,11 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Verify published package via bun x
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TMPDIR=$(mktemp -d) bun x --package "glm-acp-agent@$VERSION" glm-acp-agent < /dev/null

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,3 +35,23 @@ npm view glm-acp-agent version    # should match the new tag
   https://www.npmjs.com/package/glm-acp-agent/access — if the workflow file
   is renamed or the repo moves, update it there.
 - `--provenance` in the publish step requires a public repo or paid npm org.
+
+## Troubleshooting: `bun x` failures
+
+If `bun x glm-acp-agent@<version>` fails with `ERR_MODULE_NOT_FOUND` /
+`ERR_UNSUPPORTED_DIR_IMPORT` on one machine but succeeds with a fresh
+`TMPDIR`, the likely cause is a stale or corrupted Bun temp install
+(Bun caches `bun x` packages in a deterministic temp directory).
+
+**Recovery:** clear the cached install for that package/version:
+
+```bash
+# Find and remove the cached bunx install
+rm -rf /private/var/folders/.../T/bunx-<uid>-glm-acp-agent@<version>
+# Or run with a clean temp directory:
+TMPDIR=$(mktemp -d) bun x glm-acp-agent@<version>
+```
+
+This is an operational recovery for corrupted local state — it does **not**
+mean the published tarball is missing `main`, `package.json`, or
+dependencies. Fresh `bun x` installs resolve all dependencies correctly.


### PR DESCRIPTION
## Purpose
Type: feature. Adds bunx distribution smoke checks to verify glm-acp-agent runs correctly via bunx, hardening the release pipeline against distribution regressions.

Task: [#52](https://github.com/stefandevo/glm-acp-agent/issues/52)

## Key Changes
- Add bunx distribution smoke checks to the CI workflow (.github/workflows/ci.yml)
- Update the publish workflow to exercise bunx-based distribution verification (.github/workflows/publish.yml)
- Document the new distribution check steps in RELEASING.md

## Checks
- [ ] CI workflow passes with new bunx smoke checks
- [ ] Publish workflow runs cleanly end-to-end
- [ ] RELEASING.md instructions reflect the updated process
- [ ] Linked issue #52 acceptance criteria met