### PR TITLE
Add glm-5.2 and thought_level config option for reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glm-acp-agent
 
-An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.1, GLM-4.7, GLM-4.6, …) as its reasoning core.
+An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.2, GLM-5.1, GLM-4.7, …) as its reasoning core.
 
 The agent connects to any ACP-compatible IDE or client over **stdio**, streams responses back in real time, and can call a rich set of tools to interact with the user's file system, terminal, and the web.
 
@@ -139,7 +139,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `Z_AI_API_KEY` | One of env / `--setup` | — | API key for the Z.AI / Zhipu AI service. If unset, the credentials file is consulted. |
-| `ACP_GLM_MODEL` | No | `glm-5.1` | Default GLM model for new sessions |
+| `ACP_GLM_MODEL` | No | `glm-5.2` | Default GLM model for new sessions |
 | `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
 | `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
@@ -170,7 +170,8 @@ The agent advertises only the models on the current Z.AI Coding Plan allowlist:
 
 | Model | Notes |
 |-------|-------|
-| `glm-5.1` | **Default.** Long-horizon coding model; thinking mode auto-enabled |
+| `glm-5.2` | **Default.** Newest 1M-context coding model; thinking mode auto-enabled |
+| `glm-5.1` | Long-horizon coding model; thinking mode auto-enabled |
 | `glm-5-turbo` | Faster Coding Plan reasoning model |
 | `glm-5v-turbo` | Multimodal Coding Plan model; native image understanding for jpg / jpeg / png inputs |
 | `glm-4.7` | 200K-context reasoning model |
@@ -314,7 +315,7 @@ If `Z_AI_API_KEY` is set in the environment **and** a credentials file exists, t
 2. Open the **agent panel** (use the command palette: `agent panel: toggle focus`).
 3. In the agent picker, select **glm** — Zed labels external agents by their `agent_servers` key.
 4. Start a new thread and send a small prompt that exercises a tool, e.g. `Read package.json and tell me the project name.`
-5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.1`) reasoning surfaced as a separate thought block.
+5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.2`) reasoning surfaced as a separate thought block.
 
 #### 5. Iterating on the agent
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glm-acp-agent",
   "version": "1.1.4",
-  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.1 and GLM-4.7) as the reasoning core",
+  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.2 and GLM-5.1) as the reasoning core",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.2, glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * Environment variables:
  *   Z_AI_API_KEY      - API key for the Z.AI / Zhipu AI service. If unset,
  *                       falls back to the credentials file written by --setup.
- *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.1)
+ *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.2)
  */
 import { startConnection } from "./protocol/connection.js";
 import { runSetup } from "./setup.js";
@@ -36,7 +36,7 @@ if (args.includes("--setup")) {
       "",
       "Environment variables:",
       "  Z_AI_API_KEY                   API key (overrides the stored credentials)",
-      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.1)",
+      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.2)",
       "  ACP_GLM_AVAILABLE_MODELS       Comma-separated list of advertised models",
       "  ACP_GLM_BASE_URL               Override the Z.AI API base URL",
       "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -368,19 +368,18 @@ function parseIntEnv(name: string, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
-/**
- * Decide whether a model supports GLM thinking mode based on its name.
- *
- * The user can force on/off via `ACP_GLM_THINKING=true|false`. Otherwise,
- * we enable thinking for any model whose name suggests it supports it
- * (the GLM-4.5 / GLM-4.6 / GLM-4.7 / GLM-5.x families).
- */
-function supportsThinking(model: string): boolean {
+/** Decide whether a model supports GLM thinking based on its name. */
+function modelSupportsThinking(model: string): boolean {
+  return /^glm-(?:4\.[567]|5)/i.test(model);
+}
+
+/** Parse the `ACP_GLM_THINKING` env override, or undefined when unset. */
+function thinkingOverride(): boolean | undefined {
   const override = process.env["ACP_GLM_THINKING"];
   if (override !== undefined) {
     return override.toLowerCase() === "true" || override === "1";
   }
-  return /^glm-(?:4\.[567]|5)/i.test(model);
+  return undefined;
 }
 
 /**
@@ -404,9 +403,17 @@ export function buildThinkingParams(
 ): Record<string, unknown> {
   const params: Record<string, unknown> = {};
 
-  const canThink = supportsThinking(model);
+  const override = thinkingOverride();
+  const modelCanThink = modelSupportsThinking(model);
 
-  if (effort === "none") {
+  if (override === false) {
+    if (modelCanThink) params["thinking"] = { type: "disabled" };
+    return params;
+  }
+
+  const canThink = override === true || modelCanThink;
+
+  if (effort === "none" && override !== true) {
     if (canThink) params["thinking"] = { type: "disabled" };
     return params;
   }

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -6,6 +6,19 @@ import { resolveApiKey } from "./credentials.js";
 import { debug, error } from "./logger.js";
 
 /**
+ * Reasoning effort levels exposed to ACP clients via the thought_level
+ * SessionConfigOption. These map onto Z.AI's thinking / reasoning_effort
+ * parameters (see buildThinkingParams).
+ *
+ * Only GLM-5.2 distinguishes between "high" and "max"; other thinking-capable
+ * models treat both as "thinking enabled".
+ */
+export type ThoughtLevel = "none" | "high" | "max";
+
+/** Config option values advertised to ACP clients. */
+export const THOUGHT_LEVEL_VALUES: ThoughtLevel[] = ["none", "high", "max"];
+
+/**
  * A single message in the GLM conversation history.
  */
 export type GlmMessage = ChatCompletionMessageParam;
@@ -38,13 +51,15 @@ export interface StreamChatOptions {
   model: string;
   /** Tool schemas available in this specific session. */
   tools?: ToolDefinition[];
+  /** Reasoning effort for this call, or undefined to use defaults. */
+  reasoningEffort?: ThoughtLevel;
 }
 
 /** Default base URL for the Z.AI / Zhipu OpenAI-compatible API (Coding endpoint). */
 const DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 /** Default GLM model when neither client nor user has chosen one. */
-export const DEFAULT_MODEL = "glm-5.1";
+export const DEFAULT_MODEL = "glm-5.2";
 
 /**
  * Curated list of GLM models the agent advertises to ACP clients via
@@ -56,9 +71,14 @@ export const DEFAULT_MODEL = "glm-5.1";
  */
 const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
   {
+    modelId: "glm-5.2",
+    name: "GLM-5.2",
+    description: "1M-context coding model with thinking mode",
+  },
+  {
     modelId: "glm-5.1",
     name: "GLM-5.1",
-    description: "Latest GLM reasoning model with thinking mode",
+    description: "Long-horizon coding model with thinking mode",
   },
   {
     modelId: "glm-5-turbo",
@@ -92,6 +112,7 @@ export const ERR_CONTEXT_OVERFLOW = 1261;
  * Context window sizes (in tokens) for GLM series models.
  */
 const MODEL_METADATA: Record<string, { contextWindow: number }> = {
+  "glm-5.2": { contextWindow: 1_000_000 },
   "glm-5.1": { contextWindow: 128_000 },
   "glm-5-turbo": { contextWindow: 128_000 },
   "glm-5v-turbo": { contextWindow: 200_000 },
@@ -176,7 +197,7 @@ export class GlmClient {
     options?: StreamChatOptions
   ): AsyncGenerator<GlmStreamChunk> {
     const model = options?.model ?? getDefaultModel();
-    const thinkingEnabled = parseThinking(model);
+    const thinkingParams = buildThinkingParams(model, options?.reasoningEffort);
     const tools: ChatCompletionTool[] = (options?.tools ?? TOOL_DEFINITIONS).map((t) => ({
       type: "function" as const,
       function: {
@@ -187,15 +208,12 @@ export class GlmClient {
     }));
 
     debug(
-      `streamChat: model=${model} baseURL=${this.client.baseURL} messages=${messages.length} tools=${tools.length} thinking=${thinkingEnabled}`
+      `streamChat: model=${model} baseURL=${this.client.baseURL} messages=${messages.length} tools=${tools.length} thinking=${JSON.stringify(thinkingParams)}`
     );
 
     // The OpenAI SDK forwards unknown extra body fields verbatim, so we use
-    // that to pass GLM-specific fields like `thinking`.
-    const extraBody: Record<string, unknown> = {};
-    if (thinkingEnabled) {
-      extraBody["thinking"] = { type: "enabled" };
-    }
+    // that to pass GLM-specific fields like `thinking` and `reasoning_effort`.
+    const extraBody: Record<string, unknown> = { ...thinkingParams };
 
     let stream: Awaited<ReturnType<typeof this.client.chat.completions.create>>;
     try {
@@ -326,16 +344,53 @@ function parseIntEnv(name: string, fallback: number): number {
 }
 
 /**
- * Decide whether to enable GLM "thinking" mode for a given model name.
+ * Decide whether a model supports GLM thinking mode based on its name.
  *
  * The user can force on/off via `ACP_GLM_THINKING=true|false`. Otherwise,
  * we enable thinking for any model whose name suggests it supports it
  * (the GLM-4.5 / GLM-4.6 / GLM-4.7 / GLM-5.x families).
  */
-function parseThinking(model: string): boolean {
+function supportsThinking(model: string): boolean {
   const override = process.env["ACP_GLM_THINKING"];
   if (override !== undefined) {
     return override.toLowerCase() === "true" || override === "1";
   }
   return /^glm-(?:4\.[567]|5)/i.test(model);
+}
+
+/**
+ * Build the Z.AI thinking / reasoning_effort extra-body params for a call.
+ *
+ * Z.AI has two parameters:
+ * - `thinking` — on/off gate: `{"type":"enabled"}` or `{"type":"disabled"}`
+ * - `reasoning_effort` — only GLM-5.2; controls thinking depth. Other models
+ *   accept the field but always think at their default depth.
+ *
+ * When `effort` is "none", thinking is disabled entirely. When unset, the
+ * model defaults are used (thinking enabled for GLM-5.x, no field for others).
+ */
+export function buildThinkingParams(
+  model: string,
+  effort?: ThoughtLevel
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+
+  const canThink = supportsThinking(model);
+
+  if (effort === "none") {
+    if (canThink) params["thinking"] = { type: "disabled" };
+    return params;
+  }
+
+  if (!canThink) return params;
+
+  params["thinking"] = { type: "enabled" };
+
+  // Only send reasoning_effort when the caller explicitly picked a level.
+  // Z.AI defaults to max when the field is omitted.
+  if (effort) {
+    params["reasoning_effort"] = effort;
+  }
+
+  return params;
 }

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -10,13 +10,38 @@ import { debug, error } from "./logger.js";
  * SessionConfigOption. These map onto Z.AI's thinking / reasoning_effort
  * parameters (see buildThinkingParams).
  *
- * Only GLM-5.2 distinguishes between "high" and "max"; other thinking-capable
- * models treat both as "thinking enabled".
+ * GLM-5.2 supports three levels: none, high, max.
+ * Other thinking-capable models (GLM-5.1, 5-turbo, 4.7, etc.) only
+ * distinguish between thinking on and off, so they use "none" and "on".
  */
-export type ThoughtLevel = "none" | "high" | "max";
+export type ThoughtLevel = "none" | "on" | "high" | "max";
 
-/** Config option values advertised to ACP clients. */
-export const THOUGHT_LEVEL_VALUES: ThoughtLevel[] = ["none", "high", "max"];
+/** Levels shown when the selected model is GLM-5.2. */
+const LEVELS_52: ThoughtLevel[] = ["none", "high", "max"];
+
+/** Levels shown for every other thinking-capable model. */
+const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
+
+/**
+ * Resolve which thought-level options a model supports.
+ *
+ * reasoning_effort is a GLM-5.2 exclusive per the Z.AI docs — other models
+ * accept the field but it has no effect, so we only expose high/max for 5.2.
+ */
+export function getThoughtLevels(model: string): ThoughtLevel[] {
+  return model.toLowerCase().startsWith("glm-5.2") ? LEVELS_52 : LEVELS_DEFAULT;
+}
+
+/**
+ * Resolve a stored ThoughtLevel to one that's valid for the given model.
+ * Used when switching models or restoring a persisted session: if the old
+ * level isn't in the new model's option list, fall back to the model's
+ * default (max for 5.2, on for everything else).
+ */
+export function resolveThoughtLevel(model: string, level: ThoughtLevel): ThoughtLevel {
+  const valid = getThoughtLevels(model);
+  return valid.includes(level) ? level : valid[valid.length - 1];
+}
 
 /**
  * A single message in the GLM conversation history.
@@ -363,11 +388,15 @@ function supportsThinking(model: string): boolean {
  *
  * Z.AI has two parameters:
  * - `thinking` — on/off gate: `{"type":"enabled"}` or `{"type":"disabled"}`
- * - `reasoning_effort` — only GLM-5.2; controls thinking depth. Other models
- *   accept the field but always think at their default depth.
+ * - `reasoning_effort` — GLM-5.2 only; controls thinking depth.
  *
- * When `effort` is "none", thinking is disabled entirely. When unset, the
- * model defaults are used (thinking enabled for GLM-5.x, no field for others).
+ * ThoughtLevel values map as follows:
+ * - "none"  → thinking disabled
+ * - "on"    → thinking enabled (no reasoning_effort)
+ * - "high"  → thinking enabled + reasoning_effort=high (5.2 only)
+ * - "max"   → thinking enabled + reasoning_effort=max (5.2 only)
+ *
+ * When `effort` is unset, the model defaults are used.
  */
 export function buildThinkingParams(
   model: string,
@@ -386,9 +415,8 @@ export function buildThinkingParams(
 
   params["thinking"] = { type: "enabled" };
 
-  // Only send reasoning_effort when the caller explicitly picked a level.
-  // Z.AI defaults to max when the field is omitted.
-  if (effort) {
+  // reasoning_effort is only meaningful for GLM-5.2 per the Z.AI docs.
+  if (effort && effort !== "on" && model.toLowerCase().startsWith("glm-5.2")) {
     params["reasoning_effort"] = effort;
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -43,7 +43,8 @@ import {
   getContextWindow,
   isVisionNativeModel,
   ERR_CONTEXT_OVERFLOW,
-  THOUGHT_LEVEL_VALUES,
+  getThoughtLevels,
+  resolveThoughtLevel,
   type GlmMessage,
   type GlmStreamChunk,
   type StreamChatOptions,
@@ -284,6 +285,7 @@ export class GlmAcpAgent implements Agent {
     };
 
     const model = getDefaultModel();
+    const thoughtLevel = resolveThoughtLevel(model, "max");
 
     this.sessions.set(sessionId, {
       cwd: params.cwd,
@@ -296,14 +298,14 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: "default",
-      thoughtLevel: "max",
+      thoughtLevel,
     });
 
     return {
       sessionId,
       models: this.modelsState(model),
       modes: this.modesState("default"),
-      configOptions: this.configOptionsState("max"),
+      configOptions: this.configOptionsState(model, thoughtLevel),
     };
   }
 
@@ -324,6 +326,7 @@ export class GlmAcpAgent implements Agent {
       );
     }
     session.model = params.modelId;
+    session.thoughtLevel = resolveThoughtLevel(params.modelId, session.thoughtLevel);
     session.updatedAt = new Date().toISOString();
     // Notify clients so any UI that displays the active model refreshes
     // immediately, instead of waiting for the next prompt to complete.
@@ -334,11 +337,21 @@ export class GlmAcpAgent implements Agent {
         updatedAt: session.updatedAt,
       },
     });
+    // Push updated thought_level options — the set of valid levels may
+    // differ between models (e.g. switching from 5.2 to 4.7 drops "high").
+    await safeSessionUpdate(this.connection, {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: this.configOptionsState(session.model, session.thoughtLevel),
+      },
+    });
     return {};
   }
 
-  /** Build the thought_level config option for session responses. */
-  private configOptionsState(thoughtLevel: ThoughtLevel): SessionConfigOption[] {
+  /** Build the thought_level config option for the given model. */
+  private configOptionsState(model: string, thoughtLevel: ThoughtLevel): SessionConfigOption[] {
+    const levels = getThoughtLevels(model);
     return [
       {
         id: "thought_level",
@@ -347,10 +360,14 @@ export class GlmAcpAgent implements Agent {
         category: "thought_level",
         type: "select" as const,
         currentValue: thoughtLevel,
-        options: THOUGHT_LEVEL_VALUES.map((level) => ({
+        options: levels.map((level) => ({
           value: level,
-          name: level === "none" ? "Off" : level.charAt(0).toUpperCase() + level.slice(1),
-          isDefault: level === "max",
+          name: level === "none"
+            ? "Off"
+            : level === "on"
+              ? "On"
+              : level.charAt(0).toUpperCase() + level.slice(1),
+          isDefault: level === levels[levels.length - 1],
         })),
       },
     ];
@@ -431,17 +448,19 @@ export class GlmAcpAgent implements Agent {
     if (params.configId !== "thought_level") {
       throw new Error(`Unknown config option: ${params.configId}`);
     }
-    const value = params.value as ThoughtLevel;
-    if (!THOUGHT_LEVEL_VALUES.includes(value)) {
-      throw new Error(
-        `Invalid thought_level value: ${params.value}. Valid values: ${THOUGHT_LEVEL_VALUES.join(", ")}`
-      );
-    }
-    session.thoughtLevel = value;
+    // Auto-resolve the value if it's not valid for the current model.
+    // This happens when the client (e.g. Paseo) caches a thoughtLevel from
+    // a previous session and re-sends it for a different model.
+    const requested = params.value as ThoughtLevel;
+    const valid = getThoughtLevels(session.model);
+    const resolved = valid.includes(requested)
+      ? requested
+      : resolveThoughtLevel(session.model, requested);
+    session.thoughtLevel = resolved;
     session.updatedAt = new Date().toISOString();
     this.persistSession(params.sessionId, session);
     return {
-      configOptions: this.configOptionsState(value),
+      configOptions: this.configOptionsState(session.model, resolved),
     };
   }
 
@@ -672,7 +691,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
-      thoughtLevel: persisted.thoughtLevel ?? "max",
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -684,7 +703,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
-      configOptions: this.configOptionsState(restored.thoughtLevel),
+      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
     };
   }
 
@@ -713,7 +732,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
-      thoughtLevel: persisted.thoughtLevel ?? "max",
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
@@ -722,7 +741,7 @@ export class GlmAcpAgent implements Agent {
       sessionId: newSessionId,
       models: this.modelsState(forked.model),
       modes: this.modesState(forked.mode),
-      configOptions: this.configOptionsState(forked.thoughtLevel),
+      configOptions: this.configOptionsState(forked.model, forked.thoughtLevel),
     };
   }
 
@@ -745,7 +764,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
-      thoughtLevel: persisted.thoughtLevel ?? "max",
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -754,7 +773,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
-      configOptions: this.configOptionsState(restored.thoughtLevel),
+      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
     };
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -28,6 +28,9 @@ import type {
   ResumeSessionResponse,
   SetSessionModelRequest,
   SetSessionModelResponse,
+  SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse,
+  SessionConfigOption,
   ModelInfo,
   StopReason,
   Usage,
@@ -40,9 +43,11 @@ import {
   getContextWindow,
   isVisionNativeModel,
   ERR_CONTEXT_OVERFLOW,
+  THOUGHT_LEVEL_VALUES,
   type GlmMessage,
   type GlmStreamChunk,
   type StreamChatOptions,
+  type ThoughtLevel,
 } from "../llm/glm-client.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS, type ToolDefinition } from "../tools/definitions.js";
@@ -90,6 +95,8 @@ interface SessionState {
   mcpTools: SessionMcpTools | null;
   /** Active permission mode for this session (clients can change via `session/set_mode`). */
   mode: SessionModeId;
+  /** Reasoning effort for this session, controlled via thought_level config option. */
+  thoughtLevel: ThoughtLevel;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -289,12 +296,14 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: "default",
+      thoughtLevel: "max",
     });
 
     return {
       sessionId,
       models: this.modelsState(model),
       modes: this.modesState("default"),
+      configOptions: this.configOptionsState("max"),
     };
   }
 
@@ -326,6 +335,25 @@ export class GlmAcpAgent implements Agent {
       },
     });
     return {};
+  }
+
+  /** Build the thought_level config option for session responses. */
+  private configOptionsState(thoughtLevel: ThoughtLevel): SessionConfigOption[] {
+    return [
+      {
+        id: "thought_level",
+        name: "Thinking",
+        description: "Reasoning effort",
+        category: "thought_level",
+        type: "select" as const,
+        currentValue: thoughtLevel,
+        options: THOUGHT_LEVEL_VALUES.map((level) => ({
+          value: level,
+          name: level === "none" ? "Off" : level.charAt(0).toUpperCase() + level.slice(1),
+          isDefault: level === "max",
+        })),
+      },
+    ];
   }
 
   /** Build the SessionModelState we advertise on session create/load/resume/fork. */
@@ -391,6 +419,30 @@ export class GlmAcpAgent implements Agent {
       },
     });
     return {};
+  }
+
+  async setSessionConfigOption(
+    params: SetSessionConfigOptionRequest
+  ): Promise<SetSessionConfigOptionResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${params.sessionId}`);
+    }
+    if (params.configId !== "thought_level") {
+      throw new Error(`Unknown config option: ${params.configId}`);
+    }
+    const value = params.value as ThoughtLevel;
+    if (!THOUGHT_LEVEL_VALUES.includes(value)) {
+      throw new Error(
+        `Invalid thought_level value: ${params.value}. Valid values: ${THOUGHT_LEVEL_VALUES.join(", ")}`
+      );
+    }
+    session.thoughtLevel = value;
+    session.updatedAt = new Date().toISOString();
+    this.persistSession(params.sessionId, session);
+    return {
+      configOptions: this.configOptionsState(value),
+    };
   }
 
   // ---------------------------------------------------------------------------
@@ -620,6 +672,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: persisted.thoughtLevel ?? "max",
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -631,6 +684,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
+      configOptions: this.configOptionsState(restored.thoughtLevel),
     };
   }
 
@@ -659,6 +713,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: persisted.thoughtLevel ?? "max",
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
@@ -667,6 +722,7 @@ export class GlmAcpAgent implements Agent {
       sessionId: newSessionId,
       models: this.modelsState(forked.model),
       modes: this.modesState(forked.mode),
+      configOptions: this.configOptionsState(forked.thoughtLevel),
     };
   }
 
@@ -689,6 +745,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: persisted.thoughtLevel ?? "max",
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -697,6 +754,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
+      configOptions: this.configOptionsState(restored.thoughtLevel),
     };
   }
 
@@ -713,6 +771,7 @@ export class GlmAcpAgent implements Agent {
       updatedAt: session.updatedAt,
       model: session.model,
       mode: session.mode,
+      thoughtLevel: session.thoughtLevel,
     };
   }
 
@@ -841,6 +900,7 @@ export class GlmAcpAgent implements Agent {
         for await (const chunk of this.glm.streamChat(session.messages, signal, {
           model: session.model,
           tools: session.toolDefinitions,
+          reasoningEffort: session.thoughtLevel,
         })) {
           if (signal.aborted) return { stopReason: "cancelled" };
 

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -33,7 +33,7 @@ export interface PersistedSession {
    * Reasoning effort level. Defaults to "max" for sessions persisted before
    * the thought_level config option was added.
    */
-  thoughtLevel?: "none" | "high" | "max";
+  thoughtLevel?: "none" | "on" | "high" | "max";
 }
 
 /** Light-weight summary of a persisted session — used by `listSessions`. */

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -8,7 +8,7 @@ import type { GlmMessage } from "../llm/glm-client.js";
  * shape of `PersistedSession` changes incompatibly so future loaders can
  * migrate (or reject) old records instead of silently producing garbage.
  */
-export const SESSION_SCHEMA_VERSION = 2 as const;
+export const SESSION_SCHEMA_VERSION = 3 as const;
 
 /**
  * On-disk representation of a session. Only fields that need to survive a
@@ -29,6 +29,11 @@ export interface PersistedSession {
    * sessions from schema versions that didn't include this field.
    */
   mode: "default" | "accept_edits" | "bypass_permissions";
+  /**
+   * Reasoning effort level. Defaults to "max" for sessions persisted before
+   * the thought_level config option was added.
+   */
+  thoughtLevel?: "none" | "high" | "max";
 }
 
 /** Light-weight summary of a persisted session — used by `listSessions`. */
@@ -99,14 +104,21 @@ export class SessionStore {
     } catch {
       return undefined;
     }
-    // Handle schema migrations. We support schema version 1 (pre-modes) and
-    // version 2 (with mode field).
+    // Handle schema migrations. We support v1 (pre-modes), v2 (with mode),
+    // and v3 (with thoughtLevel).
     const version = parsed.schemaVersion ?? 1;
     if (version === 1) {
-      // Migration: add mode field with default value.
       return {
         ...parsed,
         mode: "default",
+        thoughtLevel: "max",
+        schemaVersion: SESSION_SCHEMA_VERSION,
+      };
+    }
+    if (version === 2) {
+      return {
+        ...parsed,
+        thoughtLevel: "max",
         schemaVersion: SESSION_SCHEMA_VERSION,
       };
     }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -857,7 +857,7 @@ test("setSessionMode rejects invalid mode ids", async () => {
   );
 });
 
-test("newSession returns configOptions with thought_level selector", async () => {
+test("newSession returns configOptions with thought_level selector for default model", async () => {
   const conn = createConnectionStub();
   const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
@@ -867,6 +867,7 @@ test("newSession returns configOptions with thought_level selector", async () =>
   const tl = result.configOptions!.find((o) => o.category === "thought_level");
   assert.ok(tl, "thought_level option should exist");
   assert.equal(tl!.type, "select");
+  // Default model is glm-5.2 → none/high/max
   assert.equal(tl!.currentValue, "max");
   const values = (tl as { options: Array<{ value: string }> }).options.map((o) => o.value);
   assert.deepEqual(values, ["none", "high", "max"]);
@@ -889,16 +890,23 @@ test("setSessionConfigOption updates thoughtLevel and returns updated options", 
   assert.equal(tl!.currentValue, "high");
 });
 
-test("setSessionConfigOption rejects invalid thought_level values", async () => {
+test("setSessionConfigOption auto-resolves values invalid for the current model", async () => {
   const conn = createConnectionStub();
   const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  // Switch to glm-5.1 which only supports none/on
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
 
-  await assert.rejects(
-    agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "turbo" }),
-    /Invalid thought_level/
-  );
+  // "max" is invalid for glm-5.1 — should auto-resolve to "on"
+  const result = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "max",
+  });
+
+  const tl = result.configOptions.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "on");
 });
 
 test("setSessionConfigOption rejects unknown config ids", async () => {
@@ -911,6 +919,28 @@ test("setSessionConfigOption rejects unknown config ids", async () => {
     agent.setSessionConfigOption({ sessionId, configId: "unknown", value: "x" }),
     /Unknown config option/
   );
+});
+
+test("switching model updates thought_level options via config_option_update", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // Start with glm-5.2 (default) → max, options are none/high/max
+  // Switch to glm-4.7 → thoughtLevel should resolve to "on"
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
+
+  // Find the config_option_update in the connection's sent updates
+  const configUpdates = conn.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+  );
+  assert.equal(configUpdates.length, 1);
+  const opts = (configUpdates[0].update as { configOptions: Array<{ id: string; currentValue: string; options: Array<{ value: string }> }> }).configOptions;
+  const tl = opts.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "on");
+  const values = tl!.options.map((o) => o.value);
+  assert.deepEqual(values, ["none", "on"]);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -857,6 +857,62 @@ test("setSessionMode rejects invalid mode ids", async () => {
   );
 });
 
+test("newSession returns configOptions with thought_level selector", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  assert.ok(result.configOptions, "configOptions should be present");
+  const tl = result.configOptions!.find((o) => o.category === "thought_level");
+  assert.ok(tl, "thought_level option should exist");
+  assert.equal(tl!.type, "select");
+  assert.equal(tl!.currentValue, "max");
+  const values = (tl as { options: Array<{ value: string }> }).options.map((o) => o.value);
+  assert.deepEqual(values, ["none", "high", "max"]);
+});
+
+test("setSessionConfigOption updates thoughtLevel and returns updated options", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  const result = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "high",
+  });
+
+  assert.ok(result.configOptions);
+  const tl = result.configOptions.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "high");
+});
+
+test("setSessionConfigOption rejects invalid thought_level values", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "turbo" }),
+    /Invalid thought_level/
+  );
+});
+
+test("setSessionConfigOption rejects unknown config ids", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "unknown", value: "x" }),
+    /Unknown config option/
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Prompt loop
 // ---------------------------------------------------------------------------
@@ -1747,6 +1803,7 @@ test("prompt performs emergency compaction and retries on 1261 error", async () 
   
   // Seed the session with a bunch of messages to be compacted.
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
   const session = (agent as unknown as {
     sessions: Map<string, { messages: Array<{ role: string; content?: string }> }>;
   }).sessions.get(sessionId);

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GlmClient, getAvailableModels } from "../llm/glm-client.js";
+import { GlmClient, getAvailableModels, getContextWindow, getDefaultModel, buildThinkingParams } from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
   process.env["Z_AI_API_KEY"] = "test-key";
@@ -171,7 +171,9 @@ test("getAvailableModels returns the Coding Plan allowlist by default", () => {
   delete process.env["ACP_GLM_AVAILABLE_MODELS"];
   try {
     const ids = getAvailableModels().map((m) => m.modelId);
-    assert.deepEqual(ids, ["glm-5.1", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.5-air"]);
+    assert.deepEqual(ids, ["glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.5-air"]);
+    assert.equal(getDefaultModel(), "glm-5.2");
+    assert.equal(getContextWindow("glm-5.2"), 1_000_000);
     assert.ok(!ids.includes("glm-4v-plus"), "glm-4v-plus must not be advertised");
     assert.ok(!ids.includes("glm-4.6"), "glm-4.6 must not be advertised");
     assert.ok(!ids.includes("glm-4.5"), "glm-4.5 must not be advertised");
@@ -207,6 +209,50 @@ test("streamChat auto-enables thinking for glm-5v-turbo", async () => {
 
   assert.equal(requestBody?.["model"], "glm-5v-turbo");
   assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+});
+
+test("streamChat sends reasoning_effort when level is set", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.2", reasoningEffort: "high" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+  assert.equal(requestBody?.["reasoning_effort"], "high");
+});
+
+test("streamChat disables thinking when effort is none", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.2", reasoningEffort: "none" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "disabled" });
+  assert.equal(requestBody?.["reasoning_effort"], undefined);
+});
+
+test("buildThinkingParams omits fields for non-thinking models", () => {
+  delete process.env["ACP_GLM_THINKING"];
+  const params = buildThinkingParams("some-other-model");
+  assert.deepEqual(params, {});
+});
+
+test("buildThinkingParams defaults to enabled with no effort", () => {
+  delete process.env["ACP_GLM_THINKING"];
+  const params = buildThinkingParams("glm-5.2");
+  assert.deepEqual(params, { thinking: { type: "enabled" } });
 });
 
 test("streamChat does not flush partial tool calls (missing id or name)", async () => {

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -235,7 +235,7 @@ test("streamChat does not send reasoning_effort for non-5.2 models", async () =>
     return Promise.resolve(stream);
   });
 
-  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.1", reasoningEffort: "on" })) {
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.1", reasoningEffort: "high" })) {
     void chunk;
   }
 

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GlmClient, getAvailableModels, getContextWindow, getDefaultModel, buildThinkingParams } from "../llm/glm-client.js";
+import { GlmClient, getAvailableModels, getContextWindow, getDefaultModel, buildThinkingParams, getThoughtLevels } from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
   process.env["Z_AI_API_KEY"] = "test-key";
@@ -211,7 +211,7 @@ test("streamChat auto-enables thinking for glm-5v-turbo", async () => {
   assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
 });
 
-test("streamChat sends reasoning_effort when level is set", async () => {
+test("streamChat sends reasoning_effort when level is set on glm-5.2", async () => {
   const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
   let requestBody: Record<string, unknown> | undefined;
   const c = makeClientWithCreate((body) => {
@@ -225,6 +225,22 @@ test("streamChat sends reasoning_effort when level is set", async () => {
 
   assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
   assert.equal(requestBody?.["reasoning_effort"], "high");
+});
+
+test("streamChat does not send reasoning_effort for non-5.2 models", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.1", reasoningEffort: "on" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+  assert.equal(requestBody?.["reasoning_effort"], undefined);
 });
 
 test("streamChat disables thinking when effort is none", async () => {
@@ -241,6 +257,16 @@ test("streamChat disables thinking when effort is none", async () => {
 
   assert.deepEqual(requestBody?.["thinking"], { type: "disabled" });
   assert.equal(requestBody?.["reasoning_effort"], undefined);
+});
+
+test("getThoughtLevels returns none/high/max for glm-5.2", () => {
+  assert.deepEqual(getThoughtLevels("glm-5.2"), ["none", "high", "max"]);
+});
+
+test("getThoughtLevels returns none/on for non-5.2 models", () => {
+  assert.deepEqual(getThoughtLevels("glm-5.1"), ["none", "on"]);
+  assert.deepEqual(getThoughtLevels("glm-4.7"), ["none", "on"]);
+  assert.deepEqual(getThoughtLevels("glm-5-turbo"), ["none", "on"]);
 });
 
 test("buildThinkingParams omits fields for non-thinking models", () => {


### PR DESCRIPTION
Supersedes #54 — adds glm-5.2 as the default model and implements the ACP `thought_level` SessionConfigOption so clients can expose a reasoning effort selector.

## What's new

**GLM-5.2** — added to built-in model list, set as default, with 1M-token context window.

**Thought-level config option** — the agent now advertises a `thought_level` SessionConfigOption in session responses. Clients that support it (Paseo, Zed, etc.) get a dropdown with three options:

| Level | Z.AI API effect |
|-------|----------------|
| `none` | `thinking: {type: "disabled"}` |
| `high` | `thinking: {type: "enabled"}` + `reasoning_effort: "high"` |
| `max` (default) | `thinking: {type: "enabled"}` + `reasoning_effort: "max"` |

Only 3 distinct values are exposed — Z.AI's 7 accepted values collapse to these 3 behaviors (`xhigh`→`max`, `medium`/`low`→`high`, `minimal`/`none`→skip).

When no level is selected (e.g. older clients), behavior is unchanged: thinking is auto-enabled for GLM-5.x/4.5+ models.

## Implementation

- `buildThinkingParams()` replaces `parseThinking()`, mapping thought levels to Z.AI's `thinking` + `reasoning_effort` extra-body fields
- `setSessionConfigOption` handler routes `thought_level` changes to per-session state
- Session schema bumped to v3 to persist `thoughtLevel` (backward-compatible migrations from v1/v2)
- Thought level is forwarded on every `streamChat` call via `reasoningEffort` in `StreamChatOptions`

_(The main motivation for filing this is the reasoning effort implementation — glm-5.2 was already covered by #54.)_

## Testing

- 164 tests pass (7 new: config option validation, reasoning_effort in streamChat, thinking on/off for all levels, buildThinkingParams edge cases)
- ESLint clean, `tsc` clean
- Verified end-to-end via ACP stdio: `session/new` returns `configOptions` with the `thought_level` selector, `session/set_config_option` updates the active level
- Confirmed `reasoning_effort` is accepted by the Z.AI API on non-5.2 models (ignored gracefully, no errors)