### PR TITLE
feat(models): add glm-5.2 as default model (1M context) - #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glm-acp-agent
 
-An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.1, GLM-4.7, GLM-4.6, …) as its reasoning core.
+An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.2, GLM-5.1, GLM-4.7, …) as its reasoning core.
 
 The agent connects to any ACP-compatible IDE or client over **stdio**, streams responses back in real time, and can call a rich set of tools to interact with the user's file system, terminal, and the web.
 
@@ -139,7 +139,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `Z_AI_API_KEY` | One of env / `--setup` | — | API key for the Z.AI / Zhipu AI service. If unset, the credentials file is consulted. |
-| `ACP_GLM_MODEL` | No | `glm-5.1` | Default GLM model for new sessions |
+| `ACP_GLM_MODEL` | No | `glm-5.2` | Default GLM model for new sessions |
 | `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
 | `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
@@ -170,7 +170,8 @@ The agent advertises only the models on the current Z.AI Coding Plan allowlist:
 
 | Model | Notes |
 |-------|-------|
-| `glm-5.1` | **Default.** Long-horizon coding model; thinking mode auto-enabled |
+| `glm-5.2` | **Default.** Newest 1M-context coding model; thinking mode auto-enabled |
+| `glm-5.1` | Long-horizon coding model; thinking mode auto-enabled |
 | `glm-5-turbo` | Faster Coding Plan reasoning model |
 | `glm-5v-turbo` | Multimodal Coding Plan model; native image understanding for jpg / jpeg / png inputs |
 | `glm-4.7` | 200K-context reasoning model |
@@ -314,7 +315,7 @@ If `Z_AI_API_KEY` is set in the environment **and** a credentials file exists, t
 2. Open the **agent panel** (use the command palette: `agent panel: toggle focus`).
 3. In the agent picker, select **glm** — Zed labels external agents by their `agent_servers` key.
 4. Start a new thread and send a small prompt that exercises a tool, e.g. `Read package.json and tell me the project name.`
-5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.1`) reasoning surfaced as a separate thought block.
+5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.2`) reasoning surfaced as a separate thought block.
 
 #### 5. Iterating on the agent
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glm-acp-agent",
   "version": "1.1.4",
-  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.1 and GLM-4.7) as the reasoning core",
+  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.2 and GLM-4.7) as the reasoning core",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.2, glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * Environment variables:
  *   Z_AI_API_KEY      - API key for the Z.AI / Zhipu AI service. If unset,
  *                       falls back to the credentials file written by --setup.
- *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.1)
+ *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.2)
  */
 import { startConnection } from "./protocol/connection.js";
 import { runSetup } from "./setup.js";
@@ -36,7 +36,7 @@ if (args.includes("--setup")) {
       "",
       "Environment variables:",
       "  Z_AI_API_KEY                   API key (overrides the stored credentials)",
-      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.1)",
+      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.2)",
       "  ACP_GLM_AVAILABLE_MODELS       Comma-separated list of advertised models",
       "  ACP_GLM_BASE_URL               Override the Z.AI API base URL",
       "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -44,7 +44,7 @@ export interface StreamChatOptions {
 const DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 /** Default GLM model when neither client nor user has chosen one. */
-export const DEFAULT_MODEL = "glm-5.1";
+export const DEFAULT_MODEL = "glm-5.2";
 
 /**
  * Curated list of GLM models the agent advertises to ACP clients via
@@ -56,9 +56,14 @@ export const DEFAULT_MODEL = "glm-5.1";
  */
 const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
   {
+    modelId: "glm-5.2",
+    name: "GLM-5.2",
+    description: "Newest 1M-context coding model with thinking mode",
+  },
+  {
     modelId: "glm-5.1",
     name: "GLM-5.1",
-    description: "Latest GLM reasoning model with thinking mode",
+    description: "Long-horizon coding model with thinking mode",
   },
   {
     modelId: "glm-5-turbo",
@@ -92,6 +97,7 @@ export const ERR_CONTEXT_OVERFLOW = 1261;
  * Context window sizes (in tokens) for GLM series models.
  */
 const MODEL_METADATA: Record<string, { contextWindow: number }> = {
+  "glm-5.2": { contextWindow: 1_000_000 },
   "glm-5.1": { contextWindow: 128_000 },
   "glm-5-turbo": { contextWindow: 128_000 },
   "glm-5v-turbo": { contextWindow: 200_000 },

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1745,8 +1745,11 @@ test("prompt performs emergency compaction and retries on 1261 error", async () 
   const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   
-  // Seed the session with a bunch of messages to be compacted.
+  // Seed the session with a bunch of messages to be compacted. Pin the session
+  // to a 128K-window model so the seeded history triggers the proactive/
+  // emergency compaction paths (the default model now has a 1M window).
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
   const session = (agent as unknown as {
     sessions: Map<string, { messages: Array<{ role: string; content?: string }> }>;
   }).sessions.get(sessionId);

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { GlmClient, getAvailableModels } from "../llm/glm-client.js";
+import {
+  GlmClient,
+  getAvailableModels,
+  getDefaultModel,
+  getContextWindow,
+} from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
   process.env["Z_AI_API_KEY"] = "test-key";
@@ -171,13 +176,34 @@ test("getAvailableModels returns the Coding Plan allowlist by default", () => {
   delete process.env["ACP_GLM_AVAILABLE_MODELS"];
   try {
     const ids = getAvailableModels().map((m) => m.modelId);
-    assert.deepEqual(ids, ["glm-5.1", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.5-air"]);
+    assert.deepEqual(ids, [
+      "glm-5.2",
+      "glm-5.1",
+      "glm-5-turbo",
+      "glm-5v-turbo",
+      "glm-4.7",
+      "glm-4.5-air",
+    ]);
     assert.ok(!ids.includes("glm-4v-plus"), "glm-4v-plus must not be advertised");
     assert.ok(!ids.includes("glm-4.6"), "glm-4.6 must not be advertised");
     assert.ok(!ids.includes("glm-4.5"), "glm-4.5 must not be advertised");
   } finally {
     if (old !== undefined) process.env["ACP_GLM_AVAILABLE_MODELS"] = old;
   }
+});
+
+test("getDefaultModel returns glm-5.2 without an env override", () => {
+  const old = process.env["ACP_GLM_MODEL"];
+  delete process.env["ACP_GLM_MODEL"];
+  try {
+    assert.equal(getDefaultModel(), "glm-5.2");
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_MODEL"] = old;
+  }
+});
+
+test("getContextWindow reports the 1M window for glm-5.2", () => {
+  assert.equal(getContextWindow("glm-5.2"), 1_000_000);
 });
 
 test("ACP_GLM_AVAILABLE_MODELS env override still wins over the built-in list", () => {


### PR DESCRIPTION
## Summary

Bumps the default GLM model to **`glm-5.2`**, Z.AI's newest Coding Plan model, with a **verified 1M-token context window** ([Z.AI docs](https://docs.z.ai/guides/llm/glm-5.2)) and thinking mode auto-enabled.

Resolves the duplication across the three community PRs by landing a single clean model bump. Adopts **PR #54**'s approach (cleanest of the three).

## Changes

- **`src/llm/glm-client.ts`**
  - `DEFAULT_MODEL` → `glm-5.2`
  - Prepend `glm-5.2` to `BUILTIN_AVAILABLE_MODELS` (first entry = default in pickers), name `GLM-5.2`, description "Newest 1M-context coding model with thinking mode"
  - Add `"glm-5.2": { contextWindow: 1_000_000 }` to `MODEL_METADATA`
  - Downgrade the old `glm-5.1` description now that it's no longer the default
  - Thinking mode auto-enables for `glm-5.2` via the existing `glm-5` regex — no change needed
- **Docs / metadata**: `README.md` (family blurb, `ACP_GLM_MODEL` default, supported-models table + new row, thinking example), `package.json` description, `registry/glm-acp-agent/agent.json` description, `src/index.ts` (JSDoc + `--help` text)
- **Tests**
  - `src/tests/agent.test.ts` — pin the "emergency compaction on 1261" test to `glm-5.1` (128K) via the public `unstable_setSessionModel` path; the 1M default no longer overflows the seeded history
  - `src/tests/glm-client.test.ts` — update the allowlist assertion to `["glm-5.2", "glm-5.1", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.5-air"]`; add `getDefaultModel()` and `getContextWindow("glm-5.2")` coverage; keep the `glm-4.6`/`glm-4.5` negative assertions

## Verification

- Confirmed the **1M context-window** figure against Z.AI's current docs (5× jump from glm-5.1)
- `npm test` — full `node --test` suite passes (**158/158**)
- `npm run lint` — clean

## Housekeeping

Credit **proteanx** (#54) and **ClarePhang** (duplicate #61). Supersedes and closes **#54**, **#61**, and **#56** — #56's author's `thought_level` reasoning-effort work is being evaluated separately in the follow-up task.

Closes #62