### PR TITLE
#63 - Add thought_level / reasoning-effort config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. The multimo
 
 When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5v-turbo`. Override with `ACP_GLM_THINKING=false` if you want plain completions only.
 
+#### Thought level (reasoning effort)
+
+The agent advertises a `thought_level` [SessionConfigOption](https://agentclientprotocol.com) so clients that support config options (e.g. a "Thinking" selector) can control reasoning effort per session. The available levels depend on the active model:
+
+| Model | Levels | Mapping to the Z.AI request |
+|-------|--------|-----------------------------|
+| `glm-5.2` | `Off` / `High` / `Max` | `Off` → `thinking: { type: "disabled" }`; `High`/`Max` → `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
+| other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
+
+`reasoning_effort` is a GLM-5.2 extra — other models never receive it. New sessions default to the model's own default effort (`Max` on GLM-5.2, which is also Z.AI's default when the field is omitted), so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (e.g. a `High` selection reverts to `On` when you move off GLM-5.2) and pushes a `config_option_update`. The `ACP_GLM_THINKING` env override still wins: `false` forces thinking off regardless of the selected level. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+
 `ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, users can pick `glm-5v-turbo` for text work but clients should not offer image attachments.
 
 ### Vision MCP

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.2, glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.2, glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -6,6 +6,57 @@ import { resolveApiKey } from "./credentials.js";
 import { debug, error } from "./logger.js";
 
 /**
+ * Reasoning effort levels exposed to ACP clients via the `thought_level`
+ * SessionConfigOption. These map onto Z.AI's `thinking` / `reasoning_effort`
+ * request parameters (see {@link buildThinkingParams}).
+ *
+ * GLM-5.2 supports three levels: `none`, `high`, `max`. Other thinking-capable
+ * models (GLM-5.1, 5-turbo, 4.7, …) only distinguish thinking on vs. off, so
+ * they use `none` and `on`.
+ */
+export type ThoughtLevel = "none" | "on" | "high" | "max";
+
+/** Levels shown when the selected model is GLM-5.2. */
+const LEVELS_52: ThoughtLevel[] = ["none", "high", "max"];
+
+/** Levels shown for every other thinking-capable model. */
+const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
+
+/** Whether a model id is in the GLM-5.2 family (case-insensitive). */
+function isGlm52(model: string): boolean {
+  return model.toLowerCase().startsWith("glm-5.2");
+}
+
+/** The complete set of thought levels the agent understands. */
+const ALL_THOUGHT_LEVELS: readonly ThoughtLevel[] = ["none", "on", "high", "max"];
+
+/** Type guard: whether an arbitrary string is a known ThoughtLevel. */
+export function isThoughtLevel(value: string): value is ThoughtLevel {
+  return (ALL_THOUGHT_LEVELS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve which thought-level options a model supports.
+ *
+ * `reasoning_effort` is a GLM-5.2 exclusive per the Z.AI docs — other models
+ * accept the field but it has no effect, so we only expose high/max for 5.2.
+ */
+export function getThoughtLevels(model: string): ThoughtLevel[] {
+  return isGlm52(model) ? LEVELS_52 : LEVELS_DEFAULT;
+}
+
+/**
+ * Resolve a stored ThoughtLevel to one that's valid for the given model.
+ * Used when switching models or restoring a persisted session: if the old
+ * level isn't in the new model's option list, fall back to the model's
+ * default (max for 5.2, on for everything else — the last entry in the list).
+ */
+export function resolveThoughtLevel(model: string, level: ThoughtLevel): ThoughtLevel {
+  const valid = getThoughtLevels(model);
+  return valid.includes(level) ? level : valid[valid.length - 1]!;
+}
+
+/**
  * A single message in the GLM conversation history.
  */
 export type GlmMessage = ChatCompletionMessageParam;
@@ -38,6 +89,8 @@ export interface StreamChatOptions {
   model: string;
   /** Tool schemas available in this specific session. */
   tools?: ToolDefinition[];
+  /** Reasoning effort for this call, or undefined to use the model defaults. */
+  reasoningEffort?: ThoughtLevel;
 }
 
 /** Default base URL for the Z.AI / Zhipu OpenAI-compatible API (Coding endpoint). */
@@ -182,7 +235,7 @@ export class GlmClient {
     options?: StreamChatOptions
   ): AsyncGenerator<GlmStreamChunk> {
     const model = options?.model ?? getDefaultModel();
-    const thinkingEnabled = parseThinking(model);
+    const thinkingParams = buildThinkingParams(model, options?.reasoningEffort);
     const tools: ChatCompletionTool[] = (options?.tools ?? TOOL_DEFINITIONS).map((t) => ({
       type: "function" as const,
       function: {
@@ -193,15 +246,12 @@ export class GlmClient {
     }));
 
     debug(
-      `streamChat: model=${model} baseURL=${this.client.baseURL} messages=${messages.length} tools=${tools.length} thinking=${thinkingEnabled}`
+      `streamChat: model=${model} baseURL=${this.client.baseURL} messages=${messages.length} tools=${tools.length} thinking=${JSON.stringify(thinkingParams)}`
     );
 
     // The OpenAI SDK forwards unknown extra body fields verbatim, so we use
-    // that to pass GLM-specific fields like `thinking`.
-    const extraBody: Record<string, unknown> = {};
-    if (thinkingEnabled) {
-      extraBody["thinking"] = { type: "enabled" };
-    }
+    // that to pass GLM-specific fields like `thinking` and `reasoning_effort`.
+    const extraBody: Record<string, unknown> = { ...thinkingParams };
 
     let stream: Awaited<ReturnType<typeof this.client.chat.completions.create>>;
     try {
@@ -332,16 +382,78 @@ function parseIntEnv(name: string, fallback: number): number {
 }
 
 /**
- * Decide whether to enable GLM "thinking" mode for a given model name.
- *
- * The user can force on/off via `ACP_GLM_THINKING=true|false`. Otherwise,
- * we enable thinking for any model whose name suggests it supports it
+ * Decide whether a model supports GLM "thinking" mode based on its name
  * (the GLM-4.5 / GLM-4.6 / GLM-4.7 / GLM-5.x families).
  */
-function parseThinking(model: string): boolean {
+function modelSupportsThinking(model: string): boolean {
+  return /^glm-(?:4\.[567]|5)/i.test(model);
+}
+
+/**
+ * Parse the `ACP_GLM_THINKING` env override into an explicit boolean, or
+ * `undefined` when the variable is unset. `true`/`1` force thinking on;
+ * anything else forces it off.
+ */
+function thinkingOverride(): boolean | undefined {
   const override = process.env["ACP_GLM_THINKING"];
   if (override !== undefined) {
     return override.toLowerCase() === "true" || override === "1";
   }
-  return /^glm-(?:4\.[567]|5)/i.test(model);
+  return undefined;
+}
+
+/**
+ * Build the Z.AI `thinking` / `reasoning_effort` extra-body params for a call.
+ *
+ * Z.AI exposes two parameters:
+ * - `thinking` — an on/off gate: `{"type":"enabled"}` or `{"type":"disabled"}`
+ * - `reasoning_effort` — GLM-5.2 only; controls thinking depth (`high`/`max`,
+ *   defaulting to `max` when omitted).
+ *
+ * {@link ThoughtLevel} values map as follows:
+ * - `none` → thinking disabled
+ * - `on`   → thinking enabled (no reasoning_effort)
+ * - `high` → thinking enabled + reasoning_effort=high (5.2 only)
+ * - `max`  → thinking enabled + reasoning_effort=max (5.2 only)
+ *
+ * The `ACP_GLM_THINKING` env override still wins: `false` forces thinking off,
+ * `true` forces it on (ignoring a `none` level). When `effort` is unset the
+ * model defaults are used, preserving the pre-thought-level behaviour.
+ */
+export function buildThinkingParams(
+  model: string,
+  effort?: ThoughtLevel
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+
+  const override = thinkingOverride();
+  const modelCanThink = modelSupportsThinking(model);
+
+  // Explicit env override to disable wins over everything.
+  if (override === false) {
+    if (modelCanThink) params["thinking"] = { type: "disabled" };
+    return params;
+  }
+
+  const canThink = override === true || modelCanThink;
+
+  // A `none` level disables thinking, unless the env override forces it on.
+  if (effort === "none" && override !== true) {
+    if (canThink) params["thinking"] = { type: "disabled" };
+    return params;
+  }
+
+  if (!canThink) return params;
+
+  params["thinking"] = { type: "enabled" };
+
+  // reasoning_effort is only meaningful for GLM-5.2 per the Z.AI docs, and Z.AI
+  // only accepts the "high"/"max" values there. Other levels ("on", and "none"
+  // when thinking is force-enabled via the env override) carry no valid
+  // reasoning_effort, so we omit the field entirely.
+  if ((effort === "high" || effort === "max") && isGlm52(model)) {
+    params["reasoning_effort"] = effort;
+  }
+
+  return params;
 }

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -28,6 +28,9 @@ import type {
   ResumeSessionResponse,
   SetSessionModelRequest,
   SetSessionModelResponse,
+  SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse,
+  SessionConfigOption,
   ModelInfo,
   StopReason,
   Usage,
@@ -40,9 +43,13 @@ import {
   getContextWindow,
   isVisionNativeModel,
   ERR_CONTEXT_OVERFLOW,
+  getThoughtLevels,
+  resolveThoughtLevel,
+  isThoughtLevel,
   type GlmMessage,
   type GlmStreamChunk,
   type StreamChatOptions,
+  type ThoughtLevel,
 } from "../llm/glm-client.js";
 import { ToolExecutor } from "../tools/executor.js";
 import { TOOL_DEFINITIONS, type ToolDefinition } from "../tools/definitions.js";
@@ -90,6 +97,8 @@ interface SessionState {
   mcpTools: SessionMcpTools | null;
   /** Active permission mode for this session (clients can change via `session/set_mode`). */
   mode: SessionModeId;
+  /** Reasoning effort for this session, controlled via the `thought_level` config option. */
+  thoughtLevel: ThoughtLevel;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -277,6 +286,10 @@ export class GlmAcpAgent implements Agent {
     };
 
     const model = getDefaultModel();
+    // Default to the model's own default effort ("max" for 5.2, "on"
+    // otherwise) so out-of-the-box behaviour matches the pre-thought-level
+    // default (thinking on, no explicit reasoning_effort).
+    const thoughtLevel = resolveThoughtLevel(model, "max");
 
     this.sessions.set(sessionId, {
       cwd: params.cwd,
@@ -289,12 +302,14 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: "default",
+      thoughtLevel,
     });
 
     return {
       sessionId,
       models: this.modelsState(model),
       modes: this.modesState("default"),
+      configOptions: this.configOptionsState(model, thoughtLevel),
     };
   }
 
@@ -315,7 +330,14 @@ export class GlmAcpAgent implements Agent {
       );
     }
     session.model = params.modelId;
+    // The valid thought levels differ per model (e.g. 5.2 offers high/max
+    // while others only offer none/on), so clamp the current level to what
+    // the new model supports.
+    session.thoughtLevel = resolveThoughtLevel(params.modelId, session.thoughtLevel);
     session.updatedAt = new Date().toISOString();
+    // Persist immediately so a fork/reload before the next prompt doesn't
+    // resurrect the previous model or thought level (matches setSessionConfigOption).
+    this.persistSession(params.sessionId, session);
     // Notify clients so any UI that displays the active model refreshes
     // immediately, instead of waiting for the next prompt to complete.
     await safeSessionUpdate(this.connection, {
@@ -325,7 +347,73 @@ export class GlmAcpAgent implements Agent {
         updatedAt: session.updatedAt,
       },
     });
+    // Push updated thought_level options — the set of valid levels may
+    // differ between models (e.g. switching from 5.2 to 4.7 drops "high").
+    await safeSessionUpdate(this.connection, {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: this.configOptionsState(session.model, session.thoughtLevel),
+      },
+    });
     return {};
+  }
+
+  /**
+   * Build the `thought_level` SessionConfigOption for the given model. The
+   * available levels depend on the model (see {@link getThoughtLevels}).
+   */
+  private configOptionsState(
+    model: string,
+    thoughtLevel: ThoughtLevel
+  ): SessionConfigOption[] {
+    const levels = getThoughtLevels(model);
+    return [
+      {
+        id: "thought_level",
+        name: "Thinking",
+        description: "Reasoning effort",
+        category: "thought_level",
+        type: "select" as const,
+        currentValue: thoughtLevel,
+        options: levels.map((level) => ({
+          value: level,
+          name:
+            level === "none"
+              ? "Off"
+              : level === "on"
+                ? "On"
+                : level.charAt(0).toUpperCase() + level.slice(1),
+        })),
+      },
+    ];
+  }
+
+  async setSessionConfigOption(
+    params: SetSessionConfigOptionRequest
+  ): Promise<SetSessionConfigOptionResponse> {
+    const session = this.sessions.get(params.sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${params.sessionId}`);
+    }
+    if (params.configId !== "thought_level") {
+      throw new Error(`Unknown config option: ${params.configId}`);
+    }
+    // Reject values that aren't a thought level at all (typos, stale ids from
+    // another agent version) rather than silently coercing them.
+    if (typeof params.value !== "string" || !isThoughtLevel(params.value)) {
+      throw new Error(`Invalid thought_level value: ${String(params.value)}`);
+    }
+    // Auto-resolve a *known* level that isn't valid for the current model to
+    // that model's default. This happens when a client caches a thoughtLevel
+    // from a previous session (or model) and re-sends it for a model with a
+    // different level set (e.g. "max" from glm-5.2 sent while on glm-4.7).
+    session.thoughtLevel = resolveThoughtLevel(session.model, params.value);
+    session.updatedAt = new Date().toISOString();
+    this.persistSession(params.sessionId, session);
+    return {
+      configOptions: this.configOptionsState(session.model, session.thoughtLevel),
+    };
   }
 
   /** Build the SessionModelState we advertise on session create/load/resume/fork. */
@@ -620,6 +708,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -631,6 +720,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
+      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
     };
   }
 
@@ -659,6 +749,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
@@ -667,6 +758,7 @@ export class GlmAcpAgent implements Agent {
       sessionId: newSessionId,
       models: this.modelsState(forked.model),
       modes: this.modesState(forked.mode),
+      configOptions: this.configOptionsState(forked.model, forked.thoughtLevel),
     };
   }
 
@@ -689,6 +781,7 @@ export class GlmAcpAgent implements Agent {
       toolDefinitions,
       mcpTools,
       mode: persisted.mode,
+      thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -697,6 +790,7 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
+      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
     };
   }
 
@@ -713,6 +807,7 @@ export class GlmAcpAgent implements Agent {
       updatedAt: session.updatedAt,
       model: session.model,
       mode: session.mode,
+      thoughtLevel: session.thoughtLevel,
     };
   }
 
@@ -841,6 +936,7 @@ export class GlmAcpAgent implements Agent {
         for await (const chunk of this.glm.streamChat(session.messages, signal, {
           model: session.model,
           tools: session.toolDefinitions,
+          reasoningEffort: session.thoughtLevel,
         })) {
           if (signal.aborted) return { stopReason: "cancelled" };
 

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -1,14 +1,14 @@
 import { mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { GlmMessage } from "../llm/glm-client.js";
+import type { GlmMessage, ThoughtLevel } from "../llm/glm-client.js";
 
 /**
  * Schema version embedded in every persisted session file. Bump whenever the
  * shape of `PersistedSession` changes incompatibly so future loaders can
  * migrate (or reject) old records instead of silently producing garbage.
  */
-export const SESSION_SCHEMA_VERSION = 2 as const;
+export const SESSION_SCHEMA_VERSION = 3 as const;
 
 /**
  * On-disk representation of a session. Only fields that need to survive a
@@ -29,6 +29,12 @@ export interface PersistedSession {
    * sessions from schema versions that didn't include this field.
    */
   mode: "default" | "accept_edits" | "bypass_permissions";
+  /**
+   * Reasoning effort level, controlled via the `thought_level` config option.
+   * Optional so sessions persisted before this field was added still parse;
+   * the migration (and load-time resolution) default it to "max".
+   */
+  thoughtLevel?: ThoughtLevel;
 }
 
 /** Light-weight summary of a persisted session — used by `listSessions`. */
@@ -99,14 +105,25 @@ export class SessionStore {
     } catch {
       return undefined;
     }
-    // Handle schema migrations. We support schema version 1 (pre-modes) and
-    // version 2 (with mode field).
+    // Handle schema migrations. We support v1 (pre-modes), v2 (with mode
+    // field), and v3 (with thoughtLevel). Defaulting thoughtLevel to "max"
+    // is safe: it's GLM-5.2's own default effort, and load-time resolution
+    // clamps it to a valid level for the session's actual model.
     const version = parsed.schemaVersion ?? 1;
     if (version === 1) {
-      // Migration: add mode field with default value.
+      // Migration: add mode + thoughtLevel fields with default values.
       return {
         ...parsed,
         mode: "default",
+        thoughtLevel: "max",
+        schemaVersion: SESSION_SCHEMA_VERSION,
+      };
+    }
+    if (version === 2) {
+      // Migration: add thoughtLevel field with default value.
+      return {
+        ...parsed,
+        thoughtLevel: "max",
         schemaVersion: SESSION_SCHEMA_VERSION,
       };
     }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -858,6 +858,216 @@ test("setSessionMode rejects invalid mode ids", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Thought level / config options
+// ---------------------------------------------------------------------------
+
+test("newSession returns configOptions with thought_level selector for default model", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  assert.ok(result.configOptions, "configOptions should be present");
+  const tl = result.configOptions!.find((o) => o.category === "thought_level");
+  assert.ok(tl, "thought_level option should exist");
+  assert.equal(tl!.type, "select");
+  // Default model is glm-5.2 → none/high/max, defaulting to max.
+  assert.equal(tl!.currentValue, "max");
+  const values = (tl as { options: Array<{ value: string }> }).options.map((o) => o.value);
+  assert.deepEqual(values, ["none", "high", "max"]);
+});
+
+test("setSessionConfigOption updates thoughtLevel and returns updated options", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  const result = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "high",
+  });
+
+  assert.ok(result.configOptions);
+  const tl = result.configOptions.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "high");
+});
+
+test("setSessionConfigOption auto-resolves values invalid for the current model", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  // Switch to glm-5.1 which only supports none/on.
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
+
+  // "max" is invalid for glm-5.1 — should auto-resolve to "on".
+  const result = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "max",
+  });
+
+  const tl = result.configOptions.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "on");
+});
+
+test("setSessionConfigOption rejects unknown config ids", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "unknown", value: "x" }),
+    /Unknown config option/
+  );
+});
+
+test("setSessionConfigOption rejects values that aren't a known thought level", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // "medium" is not a ThoughtLevel at all — reject rather than silently coerce.
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "medium" }),
+    /Invalid thought_level value/
+  );
+  // A cross-model-but-known value ("max" while on the default glm-5.2) is fine.
+  const ok = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "max",
+  });
+  assert.equal(ok.configOptions.find((o) => o.id === "thought_level")!.currentValue, "max");
+});
+
+test("switching model updates thought_level options via config_option_update", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // Start with glm-5.2 (default) → max, options none/high/max.
+  // Switch to glm-4.7 → thoughtLevel should resolve to "on".
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
+
+  const configUpdates = conn.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+  );
+  assert.equal(configUpdates.length, 1);
+  const opts = (configUpdates[0]!.update as {
+    configOptions: Array<{ id: string; currentValue: string; options: Array<{ value: string }> }>;
+  }).configOptions;
+  const tl = opts.find((o) => o.id === "thought_level");
+  assert.equal(tl!.currentValue, "on");
+  const values = tl!.options.map((o) => o.value);
+  assert.deepEqual(values, ["none", "on"]);
+});
+
+test("thoughtLevel is forwarded to streamChat as reasoningEffort", async () => {
+  const conn = createConnectionStub();
+  let seenEffort: string | undefined;
+  const glm = {
+    async *streamChat(
+      _messages: ReadonlyArray<{ role: string }>,
+      _signal?: AbortSignal,
+      options?: { reasoningEffort?: string }
+    ): AsyncGenerator<GlmStreamChunk> {
+      seenEffort = options?.reasoningEffort;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "high" });
+
+  await agent.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+  assert.equal(seenEffort, "high");
+});
+
+test("thoughtLevel round-trips through fork via persistence", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-thoughtlevel-"));
+  try {
+    const store = new SessionStore(dir);
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "high" });
+
+    const forked = await agent.unstable_forkSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    const tl = forked.configOptions!.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "high");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("model switch persists model + clamped thoughtLevel before any prompt (fork sees it)", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-switch-"));
+  try {
+    const store = new SessionStore(dir);
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+    // Switch model with no prompt in between: glm-5.2/max → glm-4.7, which
+    // clamps the level to "on". Both must survive a fork that reads from disk.
+    await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
+
+    const forked = await agent.unstable_forkSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    assert.equal(forked.models!.currentModelId, "glm-4.7");
+    const tl = forked.configOptions!.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "on");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on load", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-migrate-"));
+  const sessionId = "abcd1234-abcd-abcd-abcd-abcdabcd1234";
+  try {
+    // Write a raw v2 record: has `mode` but no `thoughtLevel`.
+    const v2 = {
+      schemaVersion: 2,
+      sessionId,
+      cwd: "/tmp",
+      messages: [{ role: "system", content: "you are a coding assistant" }],
+      title: "old session",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+      mode: "default",
+    };
+    writeFileSync(pathJoin(dir, `${sessionId}.json`), JSON.stringify(v2), "utf8");
+
+    // The store migrates the raw record, defaulting thoughtLevel to "max".
+    const store = new SessionStore(dir);
+    const migrated = store.load(sessionId);
+    assert.equal(migrated?.schemaVersion, 3);
+    assert.equal(migrated?.thoughtLevel, "max");
+
+    // On load the agent clamps that to the session's model (glm-5.1 → "on").
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const result = await agent.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    const tl = result.configOptions!.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "on");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Prompt loop
 // ---------------------------------------------------------------------------
 

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -5,6 +5,9 @@ import {
   getAvailableModels,
   getDefaultModel,
   getContextWindow,
+  getThoughtLevels,
+  resolveThoughtLevel,
+  buildThinkingParams,
 } from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
@@ -233,6 +236,119 @@ test("streamChat auto-enables thinking for glm-5v-turbo", async () => {
 
   assert.equal(requestBody?.["model"], "glm-5v-turbo");
   assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+});
+
+test("streamChat sends reasoning_effort when level is set on glm-5.2", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.2", reasoningEffort: "high" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+  assert.equal(requestBody?.["reasoning_effort"], "high");
+});
+
+test("streamChat does not send reasoning_effort for non-5.2 models", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.1", reasoningEffort: "high" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+  assert.equal(requestBody?.["reasoning_effort"], undefined);
+});
+
+test("streamChat disables thinking when effort is none", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.2", reasoningEffort: "none" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "disabled" });
+  assert.equal(requestBody?.["reasoning_effort"], undefined);
+});
+
+test("getThoughtLevels returns none/high/max for glm-5.2", () => {
+  assert.deepEqual(getThoughtLevels("glm-5.2"), ["none", "high", "max"]);
+});
+
+test("getThoughtLevels returns none/on for non-5.2 models", () => {
+  assert.deepEqual(getThoughtLevels("glm-5.1"), ["none", "on"]);
+  assert.deepEqual(getThoughtLevels("glm-4.7"), ["none", "on"]);
+  assert.deepEqual(getThoughtLevels("glm-5-turbo"), ["none", "on"]);
+});
+
+test("resolveThoughtLevel clamps invalid levels to the model default", () => {
+  // "high"/"max" are 5.2-only; other models fall back to "on".
+  assert.equal(resolveThoughtLevel("glm-5.1", "max"), "on");
+  assert.equal(resolveThoughtLevel("glm-4.7", "high"), "on");
+  // Valid levels are preserved.
+  assert.equal(resolveThoughtLevel("glm-5.2", "high"), "high");
+  assert.equal(resolveThoughtLevel("glm-5.1", "none"), "none");
+});
+
+test("buildThinkingParams omits fields for non-thinking models", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  delete process.env["ACP_GLM_THINKING"];
+  try {
+    assert.deepEqual(buildThinkingParams("some-other-model"), {});
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams defaults to enabled with no effort", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  delete process.env["ACP_GLM_THINKING"];
+  try {
+    assert.deepEqual(buildThinkingParams("glm-5.2"), { thinking: { type: "enabled" } });
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams never emits reasoning_effort='none' when thinking is force-enabled", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  process.env["ACP_GLM_THINKING"] = "true";
+  try {
+    // Force-on + level "none" on glm-5.2: thinking is enabled, but "none" is
+    // not a valid reasoning_effort value, so the field must be omitted.
+    // Exact deep-equality proves reasoning_effort is absent (not "none").
+    assert.deepEqual(buildThinkingParams("glm-5.2", "none"), { thinking: { type: "enabled" } });
+  } finally {
+    if (old === undefined) delete process.env["ACP_GLM_THINKING"];
+    else process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams honours ACP_GLM_THINKING=false override", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  process.env["ACP_GLM_THINKING"] = "false";
+  try {
+    // Forced off even when a level requests thinking.
+    assert.deepEqual(buildThinkingParams("glm-5.2", "max"), { thinking: { type: "disabled" } });
+  } finally {
+    if (old === undefined) delete process.env["ACP_GLM_THINKING"];
+    else process.env["ACP_GLM_THINKING"] = old;
+  }
 });
 
 test("streamChat does not flush partial tool calls (missing id or name)", async () => {


### PR DESCRIPTION
## Purpose

This feature adds a `thought_level` ACP `SessionConfigOption` so clients can control GLM reasoning effort per session. It ports the reasoning-effort part of PR #56 (the GLM-5.2 model bump already landed via #62), with the review focus items verified and several defects from #56 corrected.

Verified against the Z.AI docs: `reasoning_effort` accepts `high`/`max`, is GLM-5.2-only, and `max` is the API's own default when the field is omitted — so defaulting new sessions to `max` is behaviourally non-regressive relative to the pre-change wire format.

## Key Changes

- Add a `ThoughtLevel` type with `getThoughtLevels`/`resolveThoughtLevel`, and replace `parseThinking` with `buildThinkingParams`, which emits `thinking: {type}` plus a GLM-5.2-only `reasoning_effort` (`high`/`max`) while preserving the `ACP_GLM_THINKING` env override.
- Advertise a `thought_level` select option in new/load/resume/fork responses, handle `session/set_config_option`, and push `config_option_update` when the model switches (valid levels differ per model).
- Persist `thoughtLevel`: bump the session schema v2→v3 with v1→v3 and v2→v3 migrations defaulting to `max`; the value is re-clamped to the session's model on load.
- Persist the model + clamped thought level on model switch so a fork/reload before the next prompt no longer resurrects the old selection.
- Reject genuinely unknown `thought_level` values instead of silently coercing them, while still auto-resolving known-but-wrong-model values; only emit `reasoning_effort` for the valid `high`/`max` levels (fixes an invalid `reasoning_effort: "none"` edge case under `ACP_GLM_THINKING=true`).
- Drop the invalid `isDefault` select-option field carried from #56 (not part of the ACP SDK 0.20.0 schema).
- Document the option in the README and registry description.

## Checks

- [x] Type-check passes (`tsc`)
- [x] Tests pass (178/178)
- [x] Lint passes (`eslint`)
- [x] Changes verified locally end-to-end over ACP stdio (session/new advertises the option; set_config_option updates, auto-resolves across models, and rejects invalid values)

## Task

[#63](https://github.com/stefandevo/glm-acp-agent/issues/63)