### PR TITLE
#67 - Fix run_command hang on scripts that spawn background processes

### DIFF
--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -385,6 +385,39 @@ test("run_command includes stderr and non-zero exit code in the tool result", as
   assert.equal(last.update.rawOutput?.stderr, "bad");
 });
 
+test(
+  "run_command returns promptly when a script spawns a background process (#67)",
+  { timeout: 10_000 },
+  async () => {
+    // Regression test for #67, fixed by PR #66.
+    // A backgrounded process (`&`, `nohup`, `disown`) inherits the stdout/stderr
+    // pipe FDs and holds them open after the shell exits; resolving on "close"
+    // hung forever. The fix detaches the child and force-destroys the streams
+    // shortly after the shell exits. Without the fix this test never resolves
+    // and fails via the test timeout.
+    const conn = createConnectionStub();
+    const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);
+
+    const start = Date.now();
+    const result = await exec.execute(
+      "tc1",
+      "run_command",
+      // `sleep 3` outlives the shell and keeps the inherited pipes open.
+      JSON.stringify({ command: "sleep 3 & echo spawned; exit 0" })
+    );
+    const elapsed = Date.now() - start;
+
+    assert.match(result.content, /Exit code: 0/);
+    assert.match(result.content, /STDOUT:\nspawned/);
+    // Must return well before the 3s background sleep finishes — proves we did
+    // not block on the inherited pipe FDs.
+    assert.ok(elapsed < 2000, `run_command took ${elapsed}ms; expected < 2000ms`);
+
+    const last = conn.updates.at(-1) as { update: { status?: string } };
+    assert.equal(last.update.status, "completed");
+  }
+);
+
 test("run_command rejected by user marks call failed and skips execution", async () => {
   const conn = createConnectionStub({ permission: "reject" });
   const exec = new ToolExecutor(conn as never, "s1", FULL_CAPS);

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -831,8 +831,15 @@ function runShellCommand(
     const child = spawn("sh", ["-c", command], {
       cwd,
       signal,
+      detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    // Detach the child process group from this agent's event loop so that
+    // background processes (nohup, disown, &) don't keep the Node process
+    // alive after the main sh -c exits. Combined with "exit" (not "close")
+    // this lets run_command return immediately for scripts that spawn
+    // long-running daemons (e.g. llama-server, mcp-bridges).
+    child.unref();
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
     let settled = false;
@@ -843,6 +850,18 @@ function runShellCommand(
       if (settled) return;
       settled = true;
       reject(err);
+    });
+    child.on("exit", () => {
+      // The shell exited. Normal commands will close their streams immediately,
+      // firing "close" within milliseconds. For daemons that inherit stdio and
+      // keep pipes open, forcefully destroy the streams after a brief grace
+      // period so "close" fires and the Promise can resolve.
+      setTimeout(() => {
+        if (!settled) {
+          child.stdout.destroy();
+          child.stderr.destroy();
+        }
+      }, 50);
     });
     child.on("close", (exitCode, closeSignal) => {
       if (settled) return;


### PR DESCRIPTION
## Purpose

This bugfix stops `run_command` from hanging forever when a shell command starts a background process (`&`, `nohup`, `disown`) — the common case for launching local servers, build watchers, or daemons. `runShellCommand` resolved its Promise on the child's `"close"` event, which Node only fires after the process exits **and** all of its stdio streams are closed. A backgrounded process inherits the shell's stdout/stderr pipe file descriptors and holds them open indefinitely, so `"close"` never fired and the tool call hung, forcing a full editor restart to recover.

## Key Changes

- Spawn the shell with `detached: true` and call `child.unref()`, so a spawned daemon runs in its own process group and no longer keeps the agent process alive after the tool call returns.
- Add a `child.on("exit", ...)` handler that, after a 50 ms grace period, force-destroys `stdout`/`stderr` if the Promise hasn't settled — letting the existing `"close"` handler fire and resolve. The grace lets already-flushed output drain before the pipes are torn down.
- Normal commands are unaffected: their streams close naturally within milliseconds, so `"close"` fires first and the 50 ms timer never runs.
- Add a regression test (`src/tests/executor.test.ts`) that runs `sleep 3 & echo spawned; exit 0` and asserts `run_command` resolves in under 2 s. On pre-fix code it never resolves and fails via the node test-runner timeout.

## Notes

- The executor change matches PR #66 exactly; this PR carries that fix plus the regression test so both land together.
- Intended semantic change: background processes are now genuinely detached and outlive the tool call — the point of the fix for daemon-launching scripts.
- Pre-existing limitation (not a regression): cancelling via `AbortSignal` still only signals the direct `sh` child, not the detached process group.

## Checks

- [x] Type-check passes (`tsc`)
- [x] Tests pass (`npm test` — 179 pass, 0 fail)
- [x] Code compiles without errors
- [x] Changes have been tested locally

## Task

[#67](https://github.com/stefandevo/glm-acp-agent/issues/67)