### PR TITLE
fix(ci): bust Bun manifest cache in publish verify, make it non-blocking

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,18 +37,27 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
+      # Post-publish smoke test. npm publish above already validated the
+      # tarball, so this is informational only and must never fail the release
+      # (continue-on-error) — it just surfaces a warning if resolution can't be
+      # confirmed within the propagation window.
       - name: Verify published package via bun x
+        continue-on-error: true
         run: |
           VERSION=$(node -p "require('./package.json').version")
-          # npm's registry cache can lag a few seconds behind a fresh publish,
-          # so retry until the just-published version is resolvable.
+          # Two independent caches lag behind a fresh publish:
+          #   1. npm's registry CDN serves a stale package manifest for ~1-2 min.
+          #   2. Bun caches that manifest in ~/.bun/install/cache and reuses it,
+          #      so a stale first fetch would poison every retry.
+          # Give each attempt a fresh BUN_INSTALL_CACHE_DIR to force a re-fetch,
+          # and retry until the CDN serves the just-published version.
           for i in $(seq 1 10); do
-            if TMPDIR=$(mktemp -d) bun x --package "glm-acp-agent@$VERSION" glm-acp-agent < /dev/null; then
+            if BUN_INSTALL_CACHE_DIR=$(mktemp -d) TMPDIR=$(mktemp -d) \
+                bun x --package "glm-acp-agent@$VERSION" glm-acp-agent < /dev/null; then
               echo "Verified glm-acp-agent@$VERSION via bun x"
               exit 0
             fi
             echo "Attempt $i: glm-acp-agent@$VERSION not resolvable yet, waiting 15s for npm propagation..."
             sleep 15
           done
-          echo "::error::glm-acp-agent@$VERSION did not become resolvable via bun x after retries"
-          exit 1
+          echo "::warning::glm-acp-agent@$VERSION not resolvable via bun x within the propagation window (publish itself succeeded; verify manually with 'npm view glm-acp-agent version')"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,22 +36,32 @@ npm view glm-acp-agent version    # should match the new tag
   is renamed or the repo moves, update it there.
 - `--provenance` in the publish step requires a public repo or paid npm org.
 
-## Troubleshooting: `bun x` failures
+## Troubleshooting: `bun x` verify step warns after publish
 
-If `bun x glm-acp-agent@<version>` fails with `ERR_MODULE_NOT_FOUND` /
-`ERR_UNSUPPORTED_DIR_IMPORT` on one machine but succeeds with a fresh
-`TMPDIR`, the likely cause is a stale or corrupted Bun temp install
-(Bun caches `bun x` packages in a deterministic temp directory).
+The publish workflow runs a post-publish `bun x` smoke test. It is
+`continue-on-error` and only emits a **warning** — it never fails the release,
+because `npm publish` has already validated the tarball. If you see
 
-**Recovery:** clear the cached install for that package/version:
-
-```bash
-# Find and remove the cached bunx install
-rm -rf /private/var/folders/.../T/bunx-<uid>-glm-acp-agent@<version>
-# Or run with a clean temp directory:
-TMPDIR=$(mktemp -d) bun x glm-acp-agent@<version>
+```
+error: No version matching "<version>" found for specifier "glm-acp-agent" (but package exists)
 ```
 
-This is an operational recovery for corrupted local state — it does **not**
-mean the published tarball is missing `main`, `package.json`, or
-dependencies. Fresh `bun x` installs resolve all dependencies correctly.
+the just-published version simply hasn't propagated yet. Two caches lag behind
+a fresh publish:
+
+1. **npm's registry CDN** serves a stale package manifest for ~1–2 minutes.
+2. **Bun** caches that manifest in `~/.bun/install/cache` and reuses it, so a
+   single stale fetch would poison every retry. Changing only `TMPDIR` does
+   **not** help — that's the extract dir, not the metadata cache.
+
+The workflow handles this by giving each retry a fresh `BUN_INSTALL_CACHE_DIR`
+(forcing a re-fetch) and looping while the CDN catches up. To reproduce the
+resolution manually:
+
+```bash
+BUN_INSTALL_CACHE_DIR=$(mktemp -d) TMPDIR=$(mktemp -d) \
+  bun x --package "glm-acp-agent@<version>" glm-acp-agent
+```
+
+A warning here does **not** mean the published tarball is broken — confirm the
+release with `npm view glm-acp-agent version`.


### PR DESCRIPTION
## Problem

The post-publish `bun x` smoke test in `publish.yml` has failed on **every** release run (v1.2.0, v1.3.0) despite the publish itself succeeding. Releases show red even though the package is live on npm.

The actual error (not the `ERR_MODULE_NOT_FOUND` the docs claimed):

```
error: No version matching "1.3.0" found for specifier "glm-acp-agent" (but package exists)
```

## Root cause

Two caches lag behind a fresh publish, and the retry loop defended against neither:

1. **npm's registry CDN** serves a stale package manifest for ~1–2 min after publish.
2. **Bun** caches that manifest in `~/.bun/install/cache` and reuses it. The loop only reset `TMPDIR` (the *extract* dir, not the metadata cache), so the first attempt cached a manifest missing the new version and **all 10 retries re-read the same stale cache** — guaranteed failure.

## Fix

- Give each retry a fresh `BUN_INSTALL_CACHE_DIR` to force a manifest re-fetch while the CDN propagates.
- Mark the verify step `continue-on-error` and downgrade the terminal case from `::error::`+`exit 1` to a `::warning::`. `npm publish` already validates the tarball, so this smoke test is informational and must never red the release.
- Rewrite the `RELEASING.md` troubleshooting section to reflect the real cause (CDN + Bun manifest caching) instead of local temp corruption.

## Verification

The fix will exercise on the next release. Manual repro of the resolution path:

```bash
BUN_INSTALL_CACHE_DIR=$(mktemp -d) TMPDIR=$(mktemp -d) \
  bun x --package "glm-acp-agent@1.3.0" glm-acp-agent
```