### PR TITLE
#74 - Add GLM-5.3 support and refresh the Coding Plan model catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The agent advertises a `thought_level` [SessionConfigOption](https://agentclient
 
 | Model | Levels | Mapping to the Z.AI request |
 |-------|--------|-----------------------------|
-| `glm-5.3` (and `glm-5.2`, which routes to it) | `High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
+| `glm-5.3` (and `glm-5.2` / `glm-5.1`, which route to it) | `High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
 | other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
 
 **GLM-5.3 has no `Off` level, because thinking cannot be turned off on it.** The endpoint accepts both `thinking: { type: "disabled" }` and `reasoning_effort: "none"` without error, but keeps emitting reasoning either way — so `ACP_GLM_THINKING=false` is a no-op on GLM-5.3. Use `glm-4.7` if you need non-reasoning completions.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Only models the Coding Plan endpoint serves **under their own name** are adverti
 
 `ACP_GLM_AVAILABLE_MODELS` lets you advertise any id you like, including the ones above. Custom ids sit outside the supported Coding Plan list — the endpoint rejects any model code Z.AI hasn't whitelisted (business code `1211`). The native-vision path is unchanged, so if your plan does include `glm-5v-turbo`, add it back with `ACP_GLM_AVAILABLE_MODELS` and image blocks still reach it as native `image_url` content parts.
 
-Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. Every advertised model uses the [Vision MCP](#vision-mcp) path for image analysis.
+Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. Every built-in advertised model uses the [Vision MCP](#vision-mcp) path for image analysis; `glm-5v-turbo`, when re-added via the override above, is the one exception and keeps native `image_url` handling.
 
 When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5v-turbo`. `ACP_GLM_THINKING=false` asks for plain completions instead — but note it has no effect on GLM-5.3, which ignores every attempt to turn thinking off (see [Thought level](#thought-level-reasoning-effort) below).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glm-acp-agent
 
-An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.2, GLM-5.1, GLM-4.7, …) as its reasoning core.
+An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.3, GLM-5 Turbo, GLM-4.7) as its reasoning core.
 
 The agent connects to any ACP-compatible IDE or client over **stdio**, streams responses back in real time, and can call a rich set of tools to interact with the user's file system, terminal, and the web.
 
@@ -30,7 +30,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
 - **Session permission modes** – supports `default`, `accept_edits`, and `bypass_permissions` via `session/set_mode`. Clients like DevFlow can use this to toggle between prompting for every edit, auto-approving edits while prompting for commands, or bypassing permissions entirely.
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
-- **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; `glm-5v-turbo` sessions send supported image parts directly to the model, while non-native coding models route pasted ACP image blocks through Z.AI Vision MCP (`@z_ai/mcp-server`). Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
+- **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; the advertised coding models route pasted ACP image blocks through Z.AI Vision MCP (`@z_ai/mcp-server`), while `glm-5v-turbo` sessions — opt-in via `ACP_GLM_AVAILABLE_MODELS`, since it is no longer on the Coding Plan allowlist — send supported image parts directly to the model. Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Six built-in tools** (see below)
 - **Self-sufficient local tools** – file reads/writes, directory listings, and shell commands run in the agent process, so they do not depend on ACP client `fs` or `terminal` capabilities
@@ -139,7 +139,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `Z_AI_API_KEY` | One of env / `--setup` | — | API key for the Z.AI / Zhipu AI service. If unset, the credentials file is consulted. |
-| `ACP_GLM_MODEL` | No | `glm-5.2` | Default GLM model for new sessions |
+| `ACP_GLM_MODEL` | No | `glm-5.3` | Default GLM model for new sessions |
 | `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
 | `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
@@ -170,18 +170,17 @@ The agent advertises only the models on the current Z.AI Coding Plan allowlist:
 
 | Model | Notes |
 |-------|-------|
-| `glm-5.2` | **Default.** Newest 1M-context coding model; thinking mode auto-enabled |
-| `glm-5.1` | Long-horizon coding model; thinking mode auto-enabled |
-| `glm-5-turbo` | Faster Coding Plan reasoning model |
-| `glm-5v-turbo` | Multimodal Coding Plan model; native image understanding for jpg / jpeg / png inputs |
+| `glm-5.3` | **Default.** Newest 1M-context coding model; thinking mode always on |
+| `glm-5-turbo` | Faster Coding Plan reasoning model; 128K context |
 | `glm-4.7` | 200K-context reasoning model |
-| `glm-4.5-air` | Lightweight, lower-latency model |
 
-`ACP_GLM_AVAILABLE_MODELS` still lets you advertise custom IDs, but custom IDs sit outside the supported Coding Plan list — the Coding Plan endpoint will reject any model code Z.AI hasn't whitelisted (business code `1211`). If you override the model list, include `glm-5v-turbo` yourself to keep it visible in the picker.
+Only models the Coding Plan endpoint serves **under their own name** are advertised. Several ids that used to be listed are now aliases: a request for `glm-5.2` or `glm-5.1` comes back with `"model": "glm-5.3"`, and `glm-4.5-air` comes back as `glm-4.7`. They still work, but advertising them would report a model you are not actually talking to. `glm-5v-turbo` is no longer on the Coding Plan allowlist — selecting it fails with business code `1311` ("subscription plan does not yet include access").
 
-Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. The multimodal coding model `glm-5v-turbo` is advertised because it is on the Coding Plan and receives supported ACP image blocks directly as native `image_url` content parts. Other advertised models keep using the [Vision MCP](#vision-mcp) path for image analysis.
+`ACP_GLM_AVAILABLE_MODELS` lets you advertise any id you like, including the ones above. Custom ids sit outside the supported Coding Plan list — the endpoint rejects any model code Z.AI hasn't whitelisted (business code `1211`). The native-vision path is unchanged, so if your plan does include `glm-5v-turbo`, add it back with `ACP_GLM_AVAILABLE_MODELS` and image blocks still reach it as native `image_url` content parts.
 
-When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5v-turbo`. Override with `ACP_GLM_THINKING=false` if you want plain completions only.
+Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. Every advertised model uses the [Vision MCP](#vision-mcp) path for image analysis.
+
+When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5v-turbo`. `ACP_GLM_THINKING=false` asks for plain completions instead — but note it has no effect on GLM-5.3, which ignores every attempt to turn thinking off (see [Thought level](#thought-level-reasoning-effort) below).
 
 #### Thought level (reasoning effort)
 
@@ -189,12 +188,16 @@ The agent advertises a `thought_level` [SessionConfigOption](https://agentclient
 
 | Model | Levels | Mapping to the Z.AI request |
 |-------|--------|-----------------------------|
-| `glm-5.2` | `Off` / `High` / `Max` | `Off` → `thinking: { type: "disabled" }`; `High`/`Max` → `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
+| `glm-5.3` (and `glm-5.2`, which routes to it) | `High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
 | other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
 
-`reasoning_effort` is a GLM-5.2 extra — other models never receive it. New sessions default to the model's own default effort (`Max` on GLM-5.2, which is also Z.AI's default when the field is omitted), so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (e.g. a `High` selection reverts to `On` when you move off GLM-5.2) and pushes a `config_option_update`. The `ACP_GLM_THINKING` env override still wins: `false` forces thinking off regardless of the selected level. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+**GLM-5.3 has no `Off` level, because thinking cannot be turned off on it.** The endpoint accepts both `thinking: { type: "disabled" }` and `reasoning_effort: "none"` without error, but keeps emitting reasoning either way — so `ACP_GLM_THINKING=false` is a no-op on GLM-5.3. Use `glm-4.7` if you need non-reasoning completions.
 
-`ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, users can pick `glm-5v-turbo` for text work but clients should not offer image attachments.
+`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (a `High` selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+
+The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent currently exposes only `high` and `max` as thought levels.
+
+`ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, clients should not offer image attachments at all.
 
 ### Vision MCP
 
@@ -326,7 +329,7 @@ If `Z_AI_API_KEY` is set in the environment **and** a credentials file exists, t
 2. Open the **agent panel** (use the command palette: `agent panel: toggle focus`).
 3. In the agent picker, select **glm** — Zed labels external agents by their `agent_servers` key.
 4. Start a new thread and send a small prompt that exercises a tool, e.g. `Read package.json and tell me the project name.`
-5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.2`) reasoning surfaced as a separate thought block.
+5. You should see streaming text, a `read_file` tool call awaiting permission, and (with a thinking-capable model like `glm-5.3`) reasoning surfaced as a separate thought block.
 
 #### 5. Iterating on the agent
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glm-acp-agent",
   "version": "1.3.0",
-  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.2 and GLM-4.7) as the reasoning core",
+  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.3 and GLM-4.7) as the reasoning core",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.0.0",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.2, glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  * Environment variables:
  *   Z_AI_API_KEY      - API key for the Z.AI / Zhipu AI service. If unset,
  *                       falls back to the credentials file written by --setup.
- *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.2)
+ *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.3)
  */
 import { startConnection } from "./protocol/connection.js";
 import { runSetup } from "./setup.js";
@@ -36,7 +36,7 @@ if (args.includes("--setup")) {
       "",
       "Environment variables:",
       "  Z_AI_API_KEY                   API key (overrides the stored credentials)",
-      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.2)",
+      "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.3)",
       "  ACP_GLM_AVAILABLE_MODELS       Comma-separated list of advertised models",
       "  ACP_GLM_BASE_URL               Override the Z.AI API base URL",
       "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -10,21 +10,37 @@ import { debug, error } from "./logger.js";
  * SessionConfigOption. These map onto Z.AI's `thinking` / `reasoning_effort`
  * request parameters (see {@link buildThinkingParams}).
  *
- * GLM-5.2 supports three levels: `none`, `high`, `max`. Other thinking-capable
- * models (GLM-5.1, 5-turbo, 4.7, …) only distinguish thinking on vs. off, so
- * they use `none` and `on`.
+ * GLM-5.3 (and GLM-5.2, which the Coding Plan endpoint serves with 5.3)
+ * supports `high` and `max`. Other thinking-capable models (5-turbo, 4.7, …)
+ * only distinguish thinking on vs. off, so they use `none` and `on`.
  */
 export type ThoughtLevel = "none" | "on" | "high" | "max";
 
-/** Levels shown when the selected model is GLM-5.2. */
-const LEVELS_52: ThoughtLevel[] = ["none", "high", "max"];
+/**
+ * Levels shown for the models that honour `reasoning_effort`.
+ *
+ * Deliberately has no `none`: probing the Coding Plan endpoint on 2026-08-15
+ * showed GLM-5.3 keeps emitting `reasoning_content` whether you send
+ * `thinking: { type: "disabled" }` or `reasoning_effort: "none"`, so an "Off"
+ * option would advertise something the model does not do.
+ */
+const LEVELS_REASONING_EFFORT: ThoughtLevel[] = ["high", "max"];
 
 /** Levels shown for every other thinking-capable model. */
 const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
 
-/** Whether a model id is in the GLM-5.2 family (case-insensitive). */
-function isGlm52(model: string): boolean {
-  return model.toLowerCase().startsWith("glm-5.2");
+/**
+ * Whether a model id is one the Coding Plan endpoint serves with GLM-5.3 —
+ * the models that validate and honour `reasoning_effort` (case-insensitive).
+ *
+ * `glm-5.2` is included because the endpoint routes it to 5.3 (confirmed by
+ * probe: a `glm-5.2` request comes back with `"model": "glm-5.3"`). `glm-5.1`
+ * routes there too but is no longer advertised, so it keeps the conservative
+ * on/off treatment.
+ */
+function isReasoningEffortModel(model: string): boolean {
+  const id = model.toLowerCase();
+  return id.startsWith("glm-5.3") || id.startsWith("glm-5.2");
 }
 
 /** The complete set of thought levels the agent understands. */
@@ -38,18 +54,19 @@ export function isThoughtLevel(value: string): value is ThoughtLevel {
 /**
  * Resolve which thought-level options a model supports.
  *
- * `reasoning_effort` is a GLM-5.2 exclusive per the Z.AI docs — other models
- * accept the field but it has no effect, so we only expose high/max for 5.2.
+ * Only the GLM-5.3 family honours `reasoning_effort`; on `glm-5-turbo` and
+ * `glm-4.7` the endpoint accepts the field without validating it and the
+ * response depth does not change, so those models only get on/off.
  */
 export function getThoughtLevels(model: string): ThoughtLevel[] {
-  return isGlm52(model) ? LEVELS_52 : LEVELS_DEFAULT;
+  return isReasoningEffortModel(model) ? LEVELS_REASONING_EFFORT : LEVELS_DEFAULT;
 }
 
 /**
  * Resolve a stored ThoughtLevel to one that's valid for the given model.
  * Used when switching models or restoring a persisted session: if the old
  * level isn't in the new model's option list, fall back to the model's
- * default (max for 5.2, on for everything else — the last entry in the list).
+ * default (max on 5.3, on for everything else — the last entry in the list).
  */
 export function resolveThoughtLevel(model: string, level: ThoughtLevel): ThoughtLevel {
   const valid = getThoughtLevels(model);
@@ -97,7 +114,7 @@ export interface StreamChatOptions {
 const DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 /** Default GLM model when neither client nor user has chosen one. */
-export const DEFAULT_MODEL = "glm-5.2";
+export const DEFAULT_MODEL = "glm-5.3";
 
 /**
  * Curated list of GLM models the agent advertises to ACP clients via
@@ -106,17 +123,19 @@ export const DEFAULT_MODEL = "glm-5.2";
  *
  * The descriptions are intentionally short — clients render them in compact
  * model pickers.
+ *
+ * Only models the Coding Plan endpoint actually serves under their own name
+ * are listed. Probing on 2026-08-15 showed `glm-5.2` and `glm-5.1` come back
+ * as `glm-5.3`, `glm-4.5-air` comes back as `glm-4.7`, and `glm-5v-turbo` is
+ * rejected with business code 1311 ("subscription plan does not yet include
+ * access"). Advertising those would report a model the user is not talking to.
+ * All of them remain selectable via `ACP_GLM_AVAILABLE_MODELS`.
  */
 const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
   {
-    modelId: "glm-5.2",
-    name: "GLM-5.2",
+    modelId: "glm-5.3",
+    name: "GLM-5.3",
     description: "Newest 1M-context coding model with thinking mode",
-  },
-  {
-    modelId: "glm-5.1",
-    name: "GLM-5.1",
-    description: "Long-horizon coding model with thinking mode",
   },
   {
     modelId: "glm-5-turbo",
@@ -124,19 +143,9 @@ const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
     description: "Faster Coding Plan reasoning model",
   },
   {
-    modelId: "glm-5v-turbo",
-    name: "GLM-5V Turbo",
-    description: "Multimodal Coding Plan model with native vision",
-  },
-  {
     modelId: "glm-4.7",
     name: "GLM-4.7",
     description: "200K-context reasoning model",
-  },
-  {
-    modelId: "glm-4.5-air",
-    name: "GLM-4.5 Air",
-    description: "Lightweight, lower-latency model",
   },
 ];
 
@@ -148,14 +157,22 @@ export const ERR_CONTEXT_OVERFLOW = 1261;
 
 /**
  * Context window sizes (in tokens) for GLM series models.
+ *
+ * De-listed ids are kept here so `ACP_GLM_AVAILABLE_MODELS` users still get an
+ * accurate window, and they report the window of the model that actually
+ * answers them rather than their own historical spec.
  */
 const MODEL_METADATA: Record<string, { contextWindow: number }> = {
-  "glm-5.2": { contextWindow: 1_000_000 },
-  "glm-5.1": { contextWindow: 128_000 },
+  "glm-5.3": { contextWindow: 1_000_000 },
   "glm-5-turbo": { contextWindow: 128_000 },
-  "glm-5v-turbo": { contextWindow: 200_000 },
   "glm-4.7": { contextWindow: 200_000 },
-  "glm-4.5-air": { contextWindow: 128_000 },
+  // Routed to glm-5.3 by the Coding Plan endpoint.
+  "glm-5.2": { contextWindow: 1_000_000 },
+  "glm-5.1": { contextWindow: 1_000_000 },
+  // Routed to glm-4.7 by the Coding Plan endpoint.
+  "glm-4.5-air": { contextWindow: 200_000 },
+  // Not Coding Plan accessible, but the native-vision path still supports it.
+  "glm-5v-turbo": { contextWindow: 200_000 },
 };
 
 /** Models that accept image content parts directly through chat completions. */
@@ -407,14 +424,21 @@ function thinkingOverride(): boolean | undefined {
  *
  * Z.AI exposes two parameters:
  * - `thinking` — an on/off gate: `{"type":"enabled"}` or `{"type":"disabled"}`
- * - `reasoning_effort` — GLM-5.2 only; controls thinking depth (`high`/`max`,
- *   defaulting to `max` when omitted).
+ * - `reasoning_effort` — controls thinking depth. The endpoint validates it
+ *   against `none | minimal | low | medium | high | xhigh | max` (an invalid
+ *   value returns business code 1210) but only the GLM-5.3 family acts on it.
  *
  * {@link ThoughtLevel} values map as follows:
  * - `none` → thinking disabled
  * - `on`   → thinking enabled (no reasoning_effort)
- * - `high` → thinking enabled + reasoning_effort=high (5.2 only)
- * - `max`  → thinking enabled + reasoning_effort=max (5.2 only)
+ * - `high` → thinking enabled + reasoning_effort=high (5.3 family only)
+ * - `max`  → thinking enabled + reasoning_effort=max (5.3 family only)
+ *
+ * Caveat: GLM-5.3 ignores every attempt to turn thinking off — it keeps
+ * emitting `reasoning_content` for `thinking: { type: "disabled" }` and for
+ * `reasoning_effort: "none"` alike. `none` is therefore not offered as a level
+ * for those models (see {@link getThoughtLevels}), and the `ACP_GLM_THINKING=false`
+ * override below is a no-op there even though the request is still sent.
  *
  * The `ACP_GLM_THINKING` env override still wins: `false` forces thinking off,
  * `true` forces it on (ignoring a `none` level). When `effort` is unset the
@@ -447,11 +471,11 @@ export function buildThinkingParams(
 
   params["thinking"] = { type: "enabled" };
 
-  // reasoning_effort is only meaningful for GLM-5.2 per the Z.AI docs, and Z.AI
-  // only accepts the "high"/"max" values there. Other levels ("on", and "none"
-  // when thinking is force-enabled via the env override) carry no valid
-  // reasoning_effort, so we omit the field entirely.
-  if ((effort === "high" || effort === "max") && isGlm52(model)) {
+  // reasoning_effort is only meaningful for the GLM-5.3 family — glm-5-turbo
+  // and glm-4.7 accept it without validating it and answer identically either
+  // way. The remaining levels ("on", and "none" when thinking is force-enabled
+  // via the env override) carry no valid effort, so we omit the field.
+  if ((effort === "high" || effort === "max") && isReasoningEffortModel(model)) {
     params["reasoning_effort"] = effort;
   }
 

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -33,14 +33,15 @@ const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
  * Whether a model id is one the Coding Plan endpoint serves with GLM-5.3 —
  * the models that validate and honour `reasoning_effort` (case-insensitive).
  *
- * `glm-5.2` is included because the endpoint routes it to 5.3 (confirmed by
- * probe: a `glm-5.2` request comes back with `"model": "glm-5.3"`). `glm-5.1`
- * routes there too but is no longer advertised, so it keeps the conservative
- * on/off treatment.
+ * `glm-5.2` and `glm-5.1` are included because the endpoint routes both to 5.3
+ * (confirmed by probe: either request comes back with `"model": "glm-5.3"`).
+ * They are no longer advertised, but a user can still reach them through
+ * `ACP_GLM_AVAILABLE_MODELS` or a persisted session — and when they do, the
+ * levels must describe the model that actually answers.
  */
 function isReasoningEffortModel(model: string): boolean {
   const id = model.toLowerCase();
-  return id.startsWith("glm-5.3") || id.startsWith("glm-5.2");
+  return id.startsWith("glm-5.3") || id.startsWith("glm-5.2") || id.startsWith("glm-5.1");
 }
 
 /** The complete set of thought levels the agent understands. */

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -286,8 +286,8 @@ export class GlmAcpAgent implements Agent {
     };
 
     const model = getDefaultModel();
-    // Default to the model's own default effort ("max" for 5.2, "on"
-    // otherwise) so out-of-the-box behaviour matches the pre-thought-level
+    // Default to the model's own default effort ("max" on the 5.3 family,
+    // "on" otherwise) so out-of-the-box behaviour matches the pre-thought-level
     // default (thinking on, no explicit reasoning_effort).
     const thoughtLevel = resolveThoughtLevel(model, "max");
 
@@ -330,7 +330,7 @@ export class GlmAcpAgent implements Agent {
       );
     }
     session.model = params.modelId;
-    // The valid thought levels differ per model (e.g. 5.2 offers high/max
+    // The valid thought levels differ per model (e.g. 5.3 offers high/max
     // while others only offer none/on), so clamp the current level to what
     // the new model supports.
     session.thoughtLevel = resolveThoughtLevel(params.modelId, session.thoughtLevel);
@@ -407,7 +407,7 @@ export class GlmAcpAgent implements Agent {
     // Auto-resolve a *known* level that isn't valid for the current model to
     // that model's default. This happens when a client caches a thoughtLevel
     // from a previous session (or model) and re-sends it for a model with a
-    // different level set (e.g. "max" from glm-5.2 sent while on glm-4.7).
+    // different level set (e.g. "max" from glm-5.3 sent while on glm-4.7).
     session.thoughtLevel = resolveThoughtLevel(session.model, params.value);
     session.updatedAt = new Date().toISOString();
     this.persistSession(params.sessionId, session);

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -416,13 +416,26 @@ export class GlmAcpAgent implements Agent {
     };
   }
 
-  /** Build the SessionModelState we advertise on session create/load/resume/fork. */
+  /**
+   * Build the SessionModelState we advertise on session create/load/resume/fork.
+   *
+   * The active model is always included in `availableModels`, even when it
+   * isn't in the advertised list — a session restored from disk can be pinned
+   * to a de-listed id (`glm-5.2` was the previous default), and `ACP_GLM_MODEL`
+   * / `session/set_model` both accept uncatalogued ids on purpose. Returning a
+   * `currentModelId` outside the advertised set leaves pickers unable to
+   * represent the selection the agent is actually using.
+   */
   private modelsState(currentModelId: string): {
     availableModels: ModelInfo[];
     currentModelId: string;
   } {
+    const available = getAvailableModels();
+    if (available.some((m) => m.modelId === currentModelId)) {
+      return { availableModels: available, currentModelId };
+    }
     return {
-      availableModels: getAvailableModels(),
+      availableModels: [...available, { modelId: currentModelId, name: currentModelId }],
       currentModelId,
     };
   }

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -107,7 +107,7 @@ export class SessionStore {
     }
     // Handle schema migrations. We support v1 (pre-modes), v2 (with mode
     // field), and v3 (with thoughtLevel). Defaulting thoughtLevel to "max"
-    // is safe: it's GLM-5.2's own default effort, and load-time resolution
+    // is safe: it's GLM-5.3's own default effort, and load-time resolution
     // clamps it to a valid level for the session's actual model.
     const version = parsed.schemaVersion ?? 1;
     if (version === 1) {

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1045,7 +1045,7 @@ test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on 
       messages: [{ role: "system", content: "you are a coding assistant" }],
       title: "old session",
       updatedAt: "2026-01-01T00:00:00.000Z",
-      model: "glm-5.1",
+      model: "glm-4.7",
       mode: "default",
     };
     writeFileSync(pathJoin(dir, `${sessionId}.json`), JSON.stringify(v2), "utf8");
@@ -1056,7 +1056,7 @@ test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on 
     assert.equal(migrated?.schemaVersion, 3);
     assert.equal(migrated?.thoughtLevel, "max");
 
-    // On load the agent clamps that to the session's model (glm-5.1 → "on").
+    // On load the agent clamps that to the session's model (glm-4.7 → "on").
     const conn = createConnectionStub();
     const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
     await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
@@ -1065,6 +1065,61 @@ test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on 
     assert.equal(tl!.currentValue, "on");
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadSession advertises the restored model even when it is de-listed", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-delisted-"));
+  const sessionId = "abcd1234-abcd-abcd-abcd-abcdabcd5252";
+  try {
+    // glm-5.2 was the previous default, so real users have sessions on disk
+    // pinned to it. It is no longer in the built-in list, but the session
+    // keeps using it — so it must still appear in availableModels, otherwise
+    // the client's picker has a currentModelId outside the advertised set.
+    const persisted = {
+      schemaVersion: 3,
+      sessionId,
+      cwd: "/tmp",
+      messages: [{ role: "system", content: "you are a coding assistant" }],
+      title: "old session",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.2",
+      mode: "default",
+      thoughtLevel: "max",
+    };
+    writeFileSync(pathJoin(dir, `${sessionId}.json`), JSON.stringify(persisted), "utf8");
+
+    const store = new SessionStore(dir);
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const result = await agent.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+
+    assert.equal(result.models?.currentModelId, "glm-5.2");
+    const ids = result.models!.availableModels.map((m) => m.modelId);
+    assert.ok(ids.includes("glm-5.2"), `expected glm-5.2 in availableModels, got ${ids.join(", ")}`);
+    // The built-in entries are still advertised alongside it.
+    assert.ok(ids.includes("glm-5.3"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("newSession advertises an ACP_GLM_MODEL override that is not in the built-in list", async () => {
+  const old = process.env["ACP_GLM_MODEL"];
+  process.env["ACP_GLM_MODEL"] = "glm-4.5-air";
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+    assert.equal(result.models?.currentModelId, "glm-4.5-air");
+    const ids = result.models!.availableModels.map((m) => m.modelId);
+    assert.ok(ids.includes("glm-4.5-air"), `expected glm-4.5-air in availableModels, got ${ids.join(", ")}`);
+  } finally {
+    if (old === undefined) delete process.env["ACP_GLM_MODEL"];
+    else process.env["ACP_GLM_MODEL"] = old;
   }
 });
 

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -871,10 +871,11 @@ test("newSession returns configOptions with thought_level selector for default m
   const tl = result.configOptions!.find((o) => o.category === "thought_level");
   assert.ok(tl, "thought_level option should exist");
   assert.equal(tl!.type, "select");
-  // Default model is glm-5.2 → none/high/max, defaulting to max.
+  // Default model is glm-5.3 → high/max, defaulting to max. There is no "Off"
+  // level because thinking cannot be disabled on 5.3.
   assert.equal(tl!.currentValue, "max");
   const values = (tl as { options: Array<{ value: string }> }).options.map((o) => o.value);
-  assert.deepEqual(values, ["none", "high", "max"]);
+  assert.deepEqual(values, ["high", "max"]);
 });
 
 test("setSessionConfigOption updates thoughtLevel and returns updated options", async () => {
@@ -899,10 +900,10 @@ test("setSessionConfigOption auto-resolves values invalid for the current model"
   const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
-  // Switch to glm-5.1 which only supports none/on.
-  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
+  // Switch to glm-4.7 which only supports none/on.
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
 
-  // "max" is invalid for glm-5.1 — should auto-resolve to "on".
+  // "max" is invalid for glm-4.7 — should auto-resolve to "on".
   const result = await agent.setSessionConfigOption({
     sessionId,
     configId: "thought_level",
@@ -936,7 +937,7 @@ test("setSessionConfigOption rejects values that aren't a known thought level", 
     agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "medium" }),
     /Invalid thought_level value/
   );
-  // A cross-model-but-known value ("max" while on the default glm-5.2) is fine.
+  // A cross-model-but-known value ("max" while on the default glm-5.3) is fine.
   const ok = await agent.setSessionConfigOption({
     sessionId,
     configId: "thought_level",
@@ -951,7 +952,7 @@ test("switching model updates thought_level options via config_option_update", a
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
-  // Start with glm-5.2 (default) → max, options none/high/max.
+  // Start with glm-5.3 (default) → max, options high/max.
   // Switch to glm-4.7 → thoughtLevel should resolve to "on".
   await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
 
@@ -1019,7 +1020,7 @@ test("model switch persists model + clamped thoughtLevel before any prompt (fork
     await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
     const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
-    // Switch model with no prompt in between: glm-5.2/max → glm-4.7, which
+    // Switch model with no prompt in between: glm-5.3/max → glm-4.7, which
     // clamps the level to "on". Both must survive a fork that reads from disk.
     await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
 
@@ -1062,6 +1063,42 @@ test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on 
     const result = await agent.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
     const tl = result.configOptions!.find((o) => o.id === "thought_level");
     assert.equal(tl!.currentValue, "on");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a persisted 'none' level clamps up to max when the session is on glm-5.3", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-clamp-"));
+  const sessionId = "abcd1234-abcd-abcd-abcd-abcdabcd5353";
+  try {
+    // A v3 record saved while "Off" was still offered for the 5.x flagship.
+    // glm-5.3 has no "none" level, so load must clamp rather than fail.
+    const v3 = {
+      schemaVersion: 3,
+      sessionId,
+      cwd: "/tmp",
+      messages: [{ role: "system", content: "you are a coding assistant" }],
+      title: "old session",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.3",
+      mode: "default",
+      thoughtLevel: "none",
+    };
+    writeFileSync(pathJoin(dir, `${sessionId}.json`), JSON.stringify(v3), "utf8");
+
+    const store = new SessionStore(dir);
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const result = await agent.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+
+    const tl = result.configOptions!.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "max");
+    assert.deepEqual(
+      (tl as { options: Array<{ value: string }> }).options.map((o) => o.value),
+      ["high", "max"]
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -1959,7 +1996,7 @@ test("prompt performs emergency compaction and retries on 1261 error", async () 
   // to a 128K-window model so the seeded history triggers the proactive/
   // emergency compaction paths (the default model now has a 1M window).
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
-  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.1" });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5-turbo" });
   const session = (agent as unknown as {
     sessions: Map<string, { messages: Array<{ role: string; content?: string }> }>;
   }).sessions.get(sessionId);

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 import {
   GlmClient,
   getAvailableModels,
@@ -166,11 +169,20 @@ test("streamChat captures usage from the trailing usage chunk", async () => {
 
 test("constructor throws if Z_AI_API_KEY is missing", () => {
   const old = process.env["Z_AI_API_KEY"];
+  const oldXdg = process.env["XDG_CONFIG_HOME"];
   delete process.env["Z_AI_API_KEY"];
+  // resolveApiKey() also reads $XDG_CONFIG_HOME/glm-acp-agent/credentials.json,
+  // so point it at an empty dir — otherwise this fails on any machine where the
+  // developer has actually run `--setup`.
+  const emptyConfig = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-noconfig-"));
+  process.env["XDG_CONFIG_HOME"] = emptyConfig;
   try {
     assert.throws(() => new GlmClient(), /Z_AI_API_KEY/);
   } finally {
     if (old !== undefined) process.env["Z_AI_API_KEY"] = old;
+    if (oldXdg === undefined) delete process.env["XDG_CONFIG_HOME"];
+    else process.env["XDG_CONFIG_HOME"] = oldXdg;
+    rmSync(emptyConfig, { recursive: true, force: true });
   }
 });
 
@@ -179,34 +191,46 @@ test("getAvailableModels returns the Coding Plan allowlist by default", () => {
   delete process.env["ACP_GLM_AVAILABLE_MODELS"];
   try {
     const ids = getAvailableModels().map((m) => m.modelId);
-    assert.deepEqual(ids, [
-      "glm-5.2",
-      "glm-5.1",
-      "glm-5-turbo",
-      "glm-5v-turbo",
-      "glm-4.7",
-      "glm-4.5-air",
-    ]);
+    assert.deepEqual(ids, ["glm-5.3", "glm-5-turbo", "glm-4.7"]);
     assert.ok(!ids.includes("glm-4v-plus"), "glm-4v-plus must not be advertised");
     assert.ok(!ids.includes("glm-4.6"), "glm-4.6 must not be advertised");
     assert.ok(!ids.includes("glm-4.5"), "glm-4.5 must not be advertised");
+    // Aliases: the Coding Plan endpoint answers these with a different model
+    // (5.2/5.1 → glm-5.3, 4.5-air → glm-4.7), so advertising them would report
+    // a model the user is not actually talking to.
+    assert.ok(!ids.includes("glm-5.2"), "glm-5.2 is an alias for glm-5.3");
+    assert.ok(!ids.includes("glm-5.1"), "glm-5.1 is an alias for glm-5.3");
+    assert.ok(!ids.includes("glm-4.5-air"), "glm-4.5-air is an alias for glm-4.7");
+    // Not on the Coding Plan allowlist — selecting it fails with code 1311.
+    assert.ok(!ids.includes("glm-5v-turbo"), "glm-5v-turbo is not Coding Plan accessible");
   } finally {
     if (old !== undefined) process.env["ACP_GLM_AVAILABLE_MODELS"] = old;
   }
 });
 
-test("getDefaultModel returns glm-5.2 without an env override", () => {
+test("getDefaultModel returns glm-5.3 without an env override", () => {
   const old = process.env["ACP_GLM_MODEL"];
   delete process.env["ACP_GLM_MODEL"];
   try {
-    assert.equal(getDefaultModel(), "glm-5.2");
+    assert.equal(getDefaultModel(), "glm-5.3");
   } finally {
     if (old !== undefined) process.env["ACP_GLM_MODEL"] = old;
   }
 });
 
+test("getContextWindow reports the 1M window for glm-5.3", () => {
+  assert.equal(getContextWindow("glm-5.3"), 1_000_000);
+});
+
 test("getContextWindow reports the 1M window for glm-5.2", () => {
   assert.equal(getContextWindow("glm-5.2"), 1_000_000);
+});
+
+test("getContextWindow reports the routed window for de-listed aliases", () => {
+  // glm-5.1 is served by glm-5.3 (1M) and glm-4.5-air by glm-4.7 (200K).
+  // Reporting the old standalone windows would compact these sessions early.
+  assert.equal(getContextWindow("glm-5.1"), 1_000_000);
+  assert.equal(getContextWindow("glm-4.5-air"), 200_000);
 });
 
 test("ACP_GLM_AVAILABLE_MODELS env override still wins over the built-in list", () => {
@@ -238,6 +262,22 @@ test("streamChat auto-enables thinking for glm-5v-turbo", async () => {
   assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
 });
 
+test("streamChat sends reasoning_effort when level is set on glm-5.3", async () => {
+  const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+  let requestBody: Record<string, unknown> | undefined;
+  const c = makeClientWithCreate((body) => {
+    requestBody = body;
+    return Promise.resolve(stream);
+  });
+
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.3", reasoningEffort: "max" })) {
+    void chunk;
+  }
+
+  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+  assert.equal(requestBody?.["reasoning_effort"], "max");
+});
+
 test("streamChat sends reasoning_effort when level is set on glm-5.2", async () => {
   const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
   let requestBody: Record<string, unknown> | undefined;
@@ -254,7 +294,7 @@ test("streamChat sends reasoning_effort when level is set on glm-5.2", async () 
   assert.equal(requestBody?.["reasoning_effort"], "high");
 });
 
-test("streamChat does not send reasoning_effort for non-5.2 models", async () => {
+test("streamChat does not send reasoning_effort for models that ignore it", async () => {
   const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
   let requestBody: Record<string, unknown> | undefined;
   const c = makeClientWithCreate((body) => {
@@ -262,7 +302,7 @@ test("streamChat does not send reasoning_effort for non-5.2 models", async () =>
     return Promise.resolve(stream);
   });
 
-  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.1", reasoningEffort: "high" })) {
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-4.7", reasoningEffort: "high" })) {
     void chunk;
   }
 
@@ -278,7 +318,7 @@ test("streamChat disables thinking when effort is none", async () => {
     return Promise.resolve(stream);
   });
 
-  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.2", reasoningEffort: "none" })) {
+  for await (const chunk of c.streamChat([], undefined, { model: "glm-4.7", reasoningEffort: "none" })) {
     void chunk;
   }
 
@@ -286,23 +326,34 @@ test("streamChat disables thinking when effort is none", async () => {
   assert.equal(requestBody?.["reasoning_effort"], undefined);
 });
 
-test("getThoughtLevels returns none/high/max for glm-5.2", () => {
-  assert.deepEqual(getThoughtLevels("glm-5.2"), ["none", "high", "max"]);
+test("getThoughtLevels omits none for reasoning-effort models", () => {
+  // Thinking cannot be turned off on glm-5.3: the endpoint accepts
+  // `thinking: { type: "disabled" }` and `reasoning_effort: "none"` but keeps
+  // emitting reasoning either way, so offering an "Off" option would lie.
+  assert.deepEqual(getThoughtLevels("glm-5.3"), ["high", "max"]);
+  // glm-5.2 is served by glm-5.3, so it behaves identically.
+  assert.deepEqual(getThoughtLevels("glm-5.2"), ["high", "max"]);
 });
 
-test("getThoughtLevels returns none/on for non-5.2 models", () => {
-  assert.deepEqual(getThoughtLevels("glm-5.1"), ["none", "on"]);
+test("getThoughtLevels returns none/on for models without reasoning_effort", () => {
   assert.deepEqual(getThoughtLevels("glm-4.7"), ["none", "on"]);
   assert.deepEqual(getThoughtLevels("glm-5-turbo"), ["none", "on"]);
 });
 
 test("resolveThoughtLevel clamps invalid levels to the model default", () => {
-  // "high"/"max" are 5.2-only; other models fall back to "on".
-  assert.equal(resolveThoughtLevel("glm-5.1", "max"), "on");
+  // "high"/"max" only apply to the reasoning-effort models; others get "on".
+  assert.equal(resolveThoughtLevel("glm-4.7", "max"), "on");
   assert.equal(resolveThoughtLevel("glm-4.7", "high"), "on");
   // Valid levels are preserved.
-  assert.equal(resolveThoughtLevel("glm-5.2", "high"), "high");
-  assert.equal(resolveThoughtLevel("glm-5.1", "none"), "none");
+  assert.equal(resolveThoughtLevel("glm-5.3", "high"), "high");
+  assert.equal(resolveThoughtLevel("glm-4.7", "none"), "none");
+});
+
+test("resolveThoughtLevel clamps a persisted none up to max on glm-5.3", () => {
+  // A session saved on a model where "Off" was valid must still load cleanly
+  // when switched to glm-5.3, which has no "none" level.
+  assert.equal(resolveThoughtLevel("glm-5.3", "none"), "max");
+  assert.equal(resolveThoughtLevel("glm-5.3", "on"), "max");
 });
 
 test("buildThinkingParams omits fields for non-thinking models", () => {
@@ -320,6 +371,35 @@ test("buildThinkingParams defaults to enabled with no effort", () => {
   delete process.env["ACP_GLM_THINKING"];
   try {
     assert.deepEqual(buildThinkingParams("glm-5.2"), { thinking: { type: "enabled" } });
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams treats glm-5.3 as a thinking model", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  delete process.env["ACP_GLM_THINKING"];
+  try {
+    // Proves modelSupportsThinking() matches glm-5.3 — no reasoning_effort is
+    // attached without an explicit level, so the model default applies.
+    assert.deepEqual(buildThinkingParams("glm-5.3"), { thinking: { type: "enabled" } });
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams attaches reasoning_effort on glm-5.3", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  delete process.env["ACP_GLM_THINKING"];
+  try {
+    assert.deepEqual(buildThinkingParams("glm-5.3", "high"), {
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+    assert.deepEqual(buildThinkingParams("glm-5.3", "max"), {
+      thinking: { type: "enabled" },
+      reasoning_effort: "max",
+    });
   } finally {
     if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
   }

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -278,6 +278,23 @@ test("streamChat sends reasoning_effort when level is set on glm-5.3", async () 
   assert.equal(requestBody?.["reasoning_effort"], "max");
 });
 
+test("streamChat sends reasoning_effort on the de-listed aliases routed to 5.3", async () => {
+  for (const model of ["glm-5.2", "glm-5.1"]) {
+    const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
+    let requestBody: Record<string, unknown> | undefined;
+    const c = makeClientWithCreate((body) => {
+      requestBody = body;
+      return Promise.resolve(stream);
+    });
+
+    for await (const chunk of c.streamChat([], undefined, { model, reasoningEffort: "high" })) {
+      void chunk;
+    }
+
+    assert.equal(requestBody?.["reasoning_effort"], "high", `expected effort for ${model}`);
+  }
+});
+
 test("streamChat sends reasoning_effort when level is set on glm-5.2", async () => {
   const stream = fakeStream([{ choices: [{ delta: {}, finish_reason: "stop" }] }]);
   let requestBody: Record<string, unknown> | undefined;
@@ -331,8 +348,10 @@ test("getThoughtLevels omits none for reasoning-effort models", () => {
   // `thinking: { type: "disabled" }` and `reasoning_effort: "none"` but keeps
   // emitting reasoning either way, so offering an "Off" option would lie.
   assert.deepEqual(getThoughtLevels("glm-5.3"), ["high", "max"]);
-  // glm-5.2 is served by glm-5.3, so it behaves identically.
+  // glm-5.2 and glm-5.1 are both served by glm-5.3, so they behave identically
+  // — including the fact that "Off" would not actually turn thinking off.
   assert.deepEqual(getThoughtLevels("glm-5.2"), ["high", "max"]);
+  assert.deepEqual(getThoughtLevels("glm-5.1"), ["high", "max"]);
 });
 
 test("getThoughtLevels returns none/on for models without reasoning_effort", () => {


### PR DESCRIPTION
## Purpose

This feature adds GLM-5.3 to the model catalog, makes it the default, and corrects three problems the release created — one of them silent. Every design decision here was settled by probing the live Coding Plan endpoint rather than by reading the docs; the full write-up with response codes and token counts is [on the issue](https://github.com/stefandevo/glm-acp-agent/issues/74#issuecomment-5301762269).

The highest-impact fix is the reasoning-effort predicate. `isGlm52()` did not match `glm-5.3`, so the flagship model silently lost its `High` / `Max` thought levels and never received `reasoning_effort` at all — while a user left on the default `glm-5.2` id *did* get `reasoning_effort: "max"` attached to a request the server routed to 5.3 anyway.

## Key Changes

- **`glm-5.3` added and promoted to `DEFAULT_MODEL`.** Every default session was already being served by 5.3 through server-side routing while the ACP model picker reported `glm-5.2`. This makes the reported state honest rather than changing behaviour.
- **`isGlm52()` → `isReasoningEffortModel()`**, matching `glm-5.3` and the `glm-5.2` alias, so the flagship gets its thought levels and `reasoning_effort` back. Probes confirm the field is validated *and* honoured on 5.3 (a bogus value returns business code `1210`) but is neither validated nor effective on `glm-5-turbo` / `glm-4.7`, so the agent keeps omitting it there.
- **The `Off` thought level is gone for the 5.3 family.** `thinking: { type: "disabled" }` and `reasoning_effort: "none"` are both accepted without error and both ignored — 5.3 keeps emitting reasoning either way. `Off` was therefore already broken today on the shipped default, silently. `resolveThoughtLevel()` clamps a persisted `none` up to `max`, covered by a new load test.
- **Catalog reduced to the models served under their own name:** `glm-5.3`, `glm-5-turbo`, `glm-4.7`. Probes show `glm-5.2` and `glm-5.1` come back as `"model": "glm-5.3"`, `glm-4.5-air` comes back as `glm-4.7`, and `glm-5v-turbo` is rejected with code `1311`.
- **De-listed aliases now report the context window of the model that answers them** (`glm-5.1` → 1M, `glm-4.5-air` → 200K), so anyone forcing those ids via env no longer gets premature compaction.
- **The missing-API-key test is now hermetic.** It deleted the env var but still read the real credentials file, so it failed on any machine where `--setup` had been run.
- README, `--help` output, registry manifest and package description updated, including an explicit note that `ACP_GLM_THINKING=false` is a no-op on GLM-5.3.

## Breaking changes

`glm-5.2`, `glm-5.1`, `glm-4.5-air` and `glm-5v-turbo` are no longer advertised in the model picker. This affects clients that hardcode a model id in `session/set_model`. All four remain fully selectable via `ACP_GLM_AVAILABLE_MODELS`.

The native-vision path is deliberately **unchanged**: `isVisionNativeModel()` matches on model id rather than on the advertised list, so re-adding `glm-5v-turbo` via `ACP_GLM_AVAILABLE_MODELS` restores native `image_url` content parts with no code change. The `1311` error is worded per-subscription, so a higher plan tier may still have access.

## Checks

- [x] Build passes (`npm run build`)
- [x] Tests pass — 186/186 (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Behaviour verified against the live Coding Plan endpoint, not just docs
- [x] Persisted-session migration covered by a new test

## Follow-up

The endpoint exposes seven `reasoning_effort` values (`none | minimal | low | medium | high | xhigh | max`) and the agent still surfaces two. Since thinking cannot be disabled on 5.3, `High` is now the cheapest available setting, while `minimal` costs roughly a fifth of `max`'s completion tokens. Filed as #75 rather than widened into this change.

## Task

[#74](https://github.com/stefandevo/glm-acp-agent/issues/74)
