### PR TITLE
#78 - Sync the ACP registry manifest to v1.4.0

### DIFF
--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "glm-acp-agent",
   "name": "GLM Agent",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
@@ -9,7 +9,7 @@
   "icon": "icon.svg",
   "distribution": {
     "npx": {
-      "package": "glm-acp-agent@1.0.0"
+      "package": "glm-acp-agent@1.4.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose

Cut the v1.4.0 release and bring the local ACP registry manifest snapshot in line with it. v1.4.0 ships the GLM-5.3 catalog refresh (#74) and the Apache-2.0 license (#71); the manifest pins still pointed at 1.0.0.

## Key Changes

- `registry/glm-acp-agent/agent.json`: bump `version` and `distribution.npx.package` from `1.0.0` → `1.4.0`.
- The description already matches the v1.4.0 advertised catalog (`glm-5.3`, `glm-5-turbo`, `glm-4.7`, `thought_level`) — no wording change needed.
- After this merges, `v1.4.0` is tagged and published via GitHub Release (npm Trusted Publishing).

## Checks

- [x] `npm test` — 189/189 pass
- [x] `npm run lint` — clean

## Task

#78