### PR TITLE
#78 - Release v1.4.0 and sync the ACP registry manifest

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,31 +1,71 @@
 # Releasing
 
-Publishing to npm is automated via [`.github/workflows/publish.yml`](./.github/workflows/publish.yml),
-which fires when a GitHub Release is published. Auth uses npm Trusted Publishing
-(OIDC) — no `NPM_TOKEN` secret is required.
+Publishing to npm is automated via
+[`.github/workflows/publish.yml`](./.github/workflows/publish.yml), which fires
+when a GitHub Release is published. Auth uses npm Trusted Publishing (OIDC) —
+no `NPM_TOKEN` secret is required.
 
-## Cut a release
+## Full release procedure
+
+### 1. Sync the local registry manifest (if needed)
+
+If the npm version is about to change, update the pinned version in
+`registry/glm-acp-agent/agent.json` — both `version` and
+`distribution.npx.package` must match the version you're about to publish:
 
 ```bash
-# Bump version + create a git tag (creates a "chore(release): vX.Y.Z" commit)
-npm version patch -m "chore(release): %s"   # or: minor / major / X.Y.Z
+# In your editor, update both occurrences of the old version:
+#   "version": "<old>"       →  "version": "<new>"
+#   "package": "glm-acp-agent@<old>"  →  "package": "glm-acp-agent@<new>"
+```
 
-# Push the commit and the new tag
+Also update the `description` field if the model catalog, feature set, or
+capabilities have changed since the last registry update.
+
+Open a PR for this change and merge it to `main` before proceeding.
+
+> **Note:** After the initial registry submission is merged upstream, version
+> bumps are automatic — the registry runs an hourly cron that picks up the latest
+> npm version and commits it directly. So this step is only needed when other
+> fields in `agent.json` change (description, icon, distribution metadata).
+
+### 2. Cut the release
+
+From `main`, run:
+
+```bash
+git pull                          # make sure main is up to date
+npm version minor -m "chore(release): %s"   # or: patch / major / X.Y.Z
 git push --follow-tags
 ```
 
-Then on GitHub:
+`npm version` does three things atomically:
+- bumps `"version"` in `package.json` (and writes `package-lock.json`),
+- creates a `chore(release): vX.Y.Z` commit, and
+- tags it `vX.Y.Z`.
+
+After pushing, the tag and commit arrive on GitHub.
+
+### 3. Publish the GitHub Release
 
 1. Go to **Releases** → **Draft a new release**.
-2. Pick the tag you just pushed (e.g. `v1.0.1`).
+2. Pick the tag you just pushed (e.g. `v1.4.0`).
 3. Click **Generate release notes**.
 4. Click **Publish release**.
+
+Publishing the release triggers the **Publish to npm** workflow.
+
+### 4. Verify
 
 Watch the **Actions** tab. When `Publish to npm` goes green:
 
 ```bash
 npm view glm-acp-agent version    # should match the new tag
 ```
+
+The workflow also runs a post-publish `bun x` smoke test; see the
+[Troubleshooting](#troubleshooting-bun-x-verify-step-warns-after-publish)
+section below if it emits a warning.
 
 ## Notes
 

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "glm-acp-agent",
   "name": "GLM Agent",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": ["Stefan de Vogelaere"],
@@ -9,7 +9,7 @@
   "icon": "icon.svg",
   "distribution": {
     "npx": {
-      "package": "glm-acp-agent@1.0.0"
+      "package": "glm-acp-agent@1.4.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose
Type: chore. Cuts the v1.4.0 release for glm-acp-agent and brings the ACP registry manifest in line with it, closing the gap where a release could ship without the registry entry being updated. Also writes down the release procedure so the manifest sync is an explicit, repeatable step rather than tribal knowledge.

Task: [#78](https://github.com/stefandevo/glm-acp-agent/issues/78)

## Key Changes
- Bump the package version to v1.4.0 in `package.json`
- Update `package-lock.json` to match the new version
- Sync the ACP registry manifest to v1.4.0
- Document the full release procedure, including the registry manifest sync step

## Checks
- [ ] Type-check passes
- [ ] Tests pass