### PR TITLE
#77 - Keep the registry manifest version in sync with the published npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check registry manifest version sync
+        run: node dist/registry/sync-manifest.js --check
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check registry manifest version sync
+        run: node dist/registry/sync-manifest.js --check
+
       - name: Publish
         run: npm publish --provenance --access public
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,20 +9,20 @@ no `NPM_TOKEN` secret is required.
 
 ### 1. Sync the local registry manifest (if needed)
 
-If the npm version is about to change, update the pinned version in
-`registry/glm-acp-agent/agent.json` — both `version` and
-`distribution.npx.package` must match the version you're about to publish:
+The pinned versions in `registry/glm-acp-agent/agent.json` stay in sync
+automatically: the `version` npm lifecycle script
+([`src/registry/sync-manifest.ts`](./src/registry/sync-manifest.ts)) rewrites
+both `version` and `distribution.npx.package` to match `package.json` and
+stages the file, so `npm version` (step 2) folds the manifest bump into the
+release commit. CI enforces the invariant — a `--check` step in
+[`ci.yml`](./.github/workflows/ci.yml) and
+[`publish.yml`](./.github/workflows/publish.yml) fails the build if the two
+ever drift apart.
 
-```bash
-# In your editor, update both occurrences of the old version:
-#   "version": "<old>"       →  "version": "<new>"
-#   "package": "glm-acp-agent@<old>"  →  "package": "glm-acp-agent@<new>"
-```
-
-Also update the `description` field if the model catalog, feature set, or
-capabilities have changed since the last registry update.
-
-Open a PR for this change and merge it to `main` before proceeding.
+Manual work is only needed when other fields in `agent.json` change — the
+`description` (model catalog, feature set, capabilities), `icon`, or
+distribution metadata. Open a PR for those and merge it to `main` before
+proceeding.
 
 > **Note:** After the initial registry submission is merged upstream, version
 > bumps are automatic — the registry runs an hourly cron that picks up the latest
@@ -39,9 +39,11 @@ npm version minor -m "chore(release): %s"   # or: patch / major / X.Y.Z
 git push --follow-tags
 ```
 
-`npm version` does three things atomically:
+`npm version` does four things atomically:
 - bumps `"version"` in `package.json` (and writes `package-lock.json`),
-- creates a `chore(release): vX.Y.Z` commit, and
+- runs the `version` lifecycle script, which syncs
+  `registry/glm-acp-agent/agent.json` to the new version and stages it,
+- creates a `chore(release): vX.Y.Z` commit that includes the manifest, and
 - tags it `vX.Y.Z`.
 
 After pushing, the tag and commit arrive on GitHub.
@@ -63,6 +65,9 @@ Watch the **Actions** tab. When `Publish to npm` goes green:
 npm view glm-acp-agent version    # should match the new tag
 ```
 
+`registry/glm-acp-agent/agent.json` should already show the same version — it
+rode along in the release commit (see step 2).
+
 The workflow also runs a post-publish `bun x` smoke test; see the
 [Troubleshooting](#troubleshooting-bun-x-verify-step-warns-after-publish)
 section below if it emits a warning.
@@ -71,6 +76,9 @@ section below if it emits a warning.
 
 - `package.json` version and the git tag must agree. `npm version` keeps them
   in sync; don't tag manually.
+- `package.json`, the git tag, and the registry manifest must all agree. The
+  first two are handled by `npm version`; the manifest is synced by the
+  `version` lifecycle script and guarded by the CI `--check` step.
 - Trusted Publisher is configured at
   https://www.npmjs.com/package/glm-acp-agent/access — if the workflow file
   is renamed or the repo moves, update it there.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "node dist/index.js",
     "dev": "tsc --watch",
     "test": "npm run build && node --test dist/tests/*.test.js",
-    "lint": "eslint src/**"
+    "lint": "eslint src/**",
+    "version": "npm run build --silent && node dist/registry/sync-manifest.js"
   },
   "keywords": [
     "acp",

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -4,7 +4,9 @@
   "version": "1.4.0",
   "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
-  "authors": ["Stefan de Vogelaere"],
+  "authors": [
+    "Stefan de Vogelaere"
+  ],
   "license": "Apache-2.0",
   "icon": "icon.svg",
   "distribution": {

--- a/src/registry/sync-manifest.ts
+++ b/src/registry/sync-manifest.ts
@@ -1,0 +1,142 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const MANIFEST_PATH = "registry/glm-acp-agent/agent.json";
+
+/** The npm identity the registry manifest must mirror. */
+export interface PackageIdentity {
+  name: string;
+  version: string;
+}
+
+interface AgentManifest {
+  version?: unknown;
+  distribution?: { npx?: { package?: unknown } };
+}
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const VERSION_FIELD = /^(\s*"version"\s*:\s*")[^"]*(")/;
+
+/**
+ * Rewrite an agent.json manifest so both version pins match the package.
+ *
+ * The edit is surgical — only the `"version"` field and the
+ * `distribution.npx.package` pin change, so hand formatting (inline arrays,
+ * field order) survives and release diffs stay reviewable. Anything
+ * unexpected (unparseable JSON, missing fields, a pin that no longer targets
+ * this package) throws instead of shipping a half-synced manifest.
+ */
+export function syncManifestContent(
+  content: string,
+  pkg: PackageIdentity
+): string {
+  parseManifest(content);
+
+  const pin = new RegExp(
+    `^(\\s*"package"\\s*:\\s*")${escapeRegExp(pkg.name)}@[^"]*(")`
+  );
+  let versionRewritten = false;
+  let pinRewritten = false;
+  const rewritten = content
+    .split("\n")
+    .map((line) => {
+      if (!versionRewritten && VERSION_FIELD.test(line)) {
+        versionRewritten = true;
+        return line.replace(VERSION_FIELD, `$1${pkg.version}$2`);
+      }
+      if (!pinRewritten && pin.test(line)) {
+        pinRewritten = true;
+        return line.replace(pin, `$1${pkg.name}@${pkg.version}$2`);
+      }
+      return line;
+    })
+    .join("\n");
+
+  // Belt over the line matching above: verify the result semantically.
+  const updated = parseManifest(rewritten);
+  if (updated.version !== pkg.version || !versionRewritten) {
+    throw new Error(
+      `"version" field not found (or not rewritable) in ${MANIFEST_PATH} — ` +
+        `expected it to become ${pkg.version}`
+    );
+  }
+  if (
+    updated.distribution?.npx?.package !== `${pkg.name}@${pkg.version}` ||
+    !pinRewritten
+  ) {
+    throw new Error(
+      `distribution.npx.package pin not found (or not targeting ${pkg.name}) ` +
+        `in ${MANIFEST_PATH} — expected it to become ${pkg.name}@${pkg.version}`
+    );
+  }
+  return rewritten;
+}
+
+function parseManifest(content: string): AgentManifest {
+  try {
+    return JSON.parse(content) as AgentManifest;
+  } catch (error) {
+    throw new Error(
+      `${MANIFEST_PATH} could not be parsed: ${(error as Error).message}`,
+      { cause: error }
+    );
+  }
+}
+
+/**
+ * CLI entry. Default mode rewrites the manifest and `git add`s it so the
+ * `version` lifecycle hook can fold it into the `npm version` release commit;
+ * `--check` only verifies (used by CI) and never writes.
+ */
+function main(argv: string[]): number {
+  const check = argv.includes("--check");
+  const pkg = JSON.parse(
+    readFileSync("package.json", "utf8")
+  ) as PackageIdentity;
+  const content = readFileSync(MANIFEST_PATH, "utf8");
+  const updated = syncManifestContent(content, pkg);
+
+  if (updated === content) {
+    if (!check) {
+      console.log(`${MANIFEST_PATH} already at ${pkg.version} — nothing to do`);
+    }
+    return 0;
+  }
+  if (check) {
+    const manifest = JSON.parse(content) as AgentManifest;
+    console.error(`${MANIFEST_PATH} is out of sync with package.json:`);
+    console.error(`  version:        ${String(manifest.version)} (expected ${pkg.version})`);
+    console.error(
+      `  npx package:    ${String(manifest.distribution?.npx?.package)} (expected ${pkg.name}@${pkg.version})`
+    );
+    console.error(
+      `Fix: run \`npm run build && node dist/registry/sync-manifest.js\` and commit the result.`
+    );
+    return 1;
+  }
+
+  writeFileSync(MANIFEST_PATH, updated);
+  console.log(`${MANIFEST_PATH} synced to ${pkg.version}`);
+  const staged = spawnSync("git", ["add", MANIFEST_PATH]);
+  if (staged.status !== 0) {
+    console.error(
+      `synced ${MANIFEST_PATH} but \`git add\` failed — stage it manually`
+    );
+    return 1;
+  }
+  return 0;
+}
+
+const invokedDirectly =
+  import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (invokedDirectly) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exitCode = 1;
+  }
+}

--- a/src/registry/sync-manifest.ts
+++ b/src/registry/sync-manifest.ts
@@ -15,64 +15,42 @@ interface AgentManifest {
   distribution?: { npx?: { package?: unknown } };
 }
 
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-const VERSION_FIELD = /^(\s*"version"\s*:\s*")[^"]*(")/;
-
 /**
  * Rewrite an agent.json manifest so both version pins match the package.
  *
- * The edit is surgical — only the `"version"` field and the
- * `distribution.npx.package` pin change, so hand formatting (inline arrays,
- * field order) survives and release diffs stay reviewable. Anything
- * unexpected (unparseable JSON, missing fields, a pin that no longer targets
- * this package) throws instead of shipping a half-synced manifest.
+ * The pins are updated through the parsed object — `version` and
+ * `distribution.npx.package` by path — so a nested `"version"` field or a
+ * sibling distribution pin elsewhere in the manifest can neither be mistaken
+ * for the real pins nor silently clobbered. Anything unexpected —
+ * unparseable JSON, a missing field, or a pin no longer targeting this
+ * package — throws instead of shipping a half-synced manifest.
+ *
+ * Output uses normalized `JSON.stringify` formatting: an unnormalized input
+ * is rewritten once, and every later sync is byte-stable.
  */
 export function syncManifestContent(
   content: string,
   pkg: PackageIdentity
 ): string {
-  parseManifest(content);
-
-  const pin = new RegExp(
-    `^(\\s*"package"\\s*:\\s*")${escapeRegExp(pkg.name)}@[^"]*(")`
-  );
-  let versionRewritten = false;
-  let pinRewritten = false;
-  const rewritten = content
-    .split("\n")
-    .map((line) => {
-      if (!versionRewritten && VERSION_FIELD.test(line)) {
-        versionRewritten = true;
-        return line.replace(VERSION_FIELD, `$1${pkg.version}$2`);
-      }
-      if (!pinRewritten && pin.test(line)) {
-        pinRewritten = true;
-        return line.replace(pin, `$1${pkg.name}@${pkg.version}$2`);
-      }
-      return line;
-    })
-    .join("\n");
-
-  // Belt over the line matching above: verify the result semantically.
-  const updated = parseManifest(rewritten);
-  if (updated.version !== pkg.version || !versionRewritten) {
+  const manifest = parseManifest(content);
+  if (typeof manifest.version !== "string") {
     throw new Error(
-      `"version" field not found (or not rewritable) in ${MANIFEST_PATH} — ` +
-        `expected it to become ${pkg.version}`
+      `"version" field not found (or not a string) in ${MANIFEST_PATH}`
     );
   }
+  const npx = manifest.distribution?.npx;
   if (
-    updated.distribution?.npx?.package !== `${pkg.name}@${pkg.version}` ||
-    !pinRewritten
+    !npx ||
+    typeof npx.package !== "string" ||
+    !npx.package.startsWith(`${pkg.name}@`)
   ) {
     throw new Error(
-      `distribution.npx.package pin not found (or not targeting ${pkg.name}) ` +
-        `in ${MANIFEST_PATH} — expected it to become ${pkg.name}@${pkg.version}`
+      `distribution.npx.package pin not found (or not targeting ${pkg.name}) in ${MANIFEST_PATH}`
     );
   }
-  return rewritten;
+  manifest.version = pkg.version;
+  npx.package = `${pkg.name}@${pkg.version}`;
+  return `${JSON.stringify(manifest, null, 2)}\n`;
 }
 
 function parseManifest(content: string): AgentManifest {
@@ -86,10 +64,14 @@ function parseManifest(content: string): AgentManifest {
   }
 }
 
+const describeValue = (value: unknown) =>
+  typeof value === "string" ? value : "(missing)";
+
 /**
  * CLI entry. Default mode rewrites the manifest and `git add`s it so the
  * `version` lifecycle hook can fold it into the `npm version` release commit;
- * `--check` only verifies (used by CI) and never writes.
+ * `--check` only verifies (used by CI) and never writes. Both modes compare
+ * pin values, not file formatting.
  */
 function main(argv: string[]): number {
   const check = argv.includes("--check");
@@ -97,20 +79,22 @@ function main(argv: string[]): number {
     readFileSync("package.json", "utf8")
   ) as PackageIdentity;
   const content = readFileSync(MANIFEST_PATH, "utf8");
-  const updated = syncManifestContent(content, pkg);
 
-  if (updated === content) {
-    if (!check) {
-      console.log(`${MANIFEST_PATH} already at ${pkg.version} — nothing to do`);
-    }
-    return 0;
-  }
   if (check) {
-    const manifest = JSON.parse(content) as AgentManifest;
+    const manifest = parseManifest(content);
+    const pin = manifest.distribution?.npx?.package;
+    if (
+      manifest.version === pkg.version &&
+      pin === `${pkg.name}@${pkg.version}`
+    ) {
+      return 0;
+    }
     console.error(`${MANIFEST_PATH} is out of sync with package.json:`);
-    console.error(`  version:        ${String(manifest.version)} (expected ${pkg.version})`);
     console.error(
-      `  npx package:    ${String(manifest.distribution?.npx?.package)} (expected ${pkg.name}@${pkg.version})`
+      `  version:        ${describeValue(manifest.version)} (expected ${pkg.version})`
+    );
+    console.error(
+      `  npx package:    ${describeValue(pin)} (expected ${pkg.name}@${pkg.version})`
     );
     console.error(
       `Fix: run \`npm run build && node dist/registry/sync-manifest.js\` and commit the result.`
@@ -118,6 +102,11 @@ function main(argv: string[]): number {
     return 1;
   }
 
+  const updated = syncManifestContent(content, pkg);
+  if (updated === content) {
+    console.log(`${MANIFEST_PATH} already at ${pkg.version} — nothing to do`);
+    return 0;
+  }
   writeFileSync(MANIFEST_PATH, updated);
   console.log(`${MANIFEST_PATH} synced to ${pkg.version}`);
   const staged = spawnSync("git", ["add", MANIFEST_PATH]);

--- a/src/tests/sync-manifest.test.ts
+++ b/src/tests/sync-manifest.test.ts
@@ -1,0 +1,186 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
+import { fileURLToPath } from "node:url";
+import { syncManifestContent } from "../registry/sync-manifest.js";
+
+const PACKAGE = { name: "glm-acp-agent", version: "1.4.1" };
+
+/** Mirrors registry/glm-acp-agent/agent.json, including its hand formatting. */
+const MANIFEST = `{
+  "id": "glm-acp-agent",
+  "name": "GLM Agent",
+  "version": "1.3.0",
+  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models.",
+  "repository": "https://github.com/stefandevo/glm-acp-agent",
+  "authors": ["Stefan de Vogelaere"],
+  "license": "Apache-2.0",
+  "icon": "icon.svg",
+  "distribution": {
+    "npx": {
+      "package": "glm-acp-agent@1.3.0"
+    }
+  }
+}
+`;
+
+// ---------------------------------------------------------------------------
+// syncManifestContent
+// ---------------------------------------------------------------------------
+
+test("syncManifestContent: rewrites the top-level version field", () => {
+  const result = syncManifestContent(MANIFEST, PACKAGE);
+  assert.match(result, /"version": "1\.4\.1"/);
+});
+
+test("syncManifestContent: rewrites the npx distribution pin", () => {
+  const result = syncManifestContent(MANIFEST, PACKAGE);
+  assert.match(result, /"package": "glm-acp-agent@1\.4\.1"/);
+});
+
+test("syncManifestContent: preserves unrelated formatting (inline arrays, field order)", () => {
+  const result = syncManifestContent(MANIFEST, PACKAGE);
+  // The surgical rewrite must not reformat the whole file — only the two
+  // version occurrences may change.
+  assert.equal(
+    result,
+    MANIFEST.replaceAll("1.3.0", "1.4.1"),
+    "everything except the two version pins should be byte-identical"
+  );
+});
+
+test("syncManifestContent: is idempotent when already in sync", () => {
+  const synced = syncManifestContent(MANIFEST, PACKAGE);
+  assert.equal(syncManifestContent(synced, PACKAGE), synced);
+});
+
+test("syncManifestContent: throws on invalid JSON", () => {
+  assert.throws(
+    () => syncManifestContent("{ not json", PACKAGE),
+    /agent\.json[\s\S]*parse/u
+  );
+});
+
+test("syncManifestContent: throws when the version field is missing", () => {
+  const noVersion = MANIFEST.replace(/^ {2}"version": ".*",\n/m, "");
+  assert.throws(
+    () => syncManifestContent(noVersion, PACKAGE),
+    /"version"[\s\S]*not found/u
+  );
+});
+
+test("syncManifestContent: throws when the npx package pin is missing", () => {
+  const noPin = MANIFEST.replace(
+    /^(\s*)"package": ".*"\n/m,
+    '$1"package_placeholder": true\n'
+  );
+  assert.throws(
+    () => syncManifestContent(noPin, PACKAGE),
+    /distribution\.npx\.package[\s\S]*not found/u
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CLI (built script, run against a fixture package in a temp git repo)
+// ---------------------------------------------------------------------------
+
+const SCRIPT_PATH = fileURLToPath(
+  new URL("../registry/sync-manifest.js", import.meta.url)
+);
+
+interface Fixture {
+  dir: string;
+  manifestPath: string;
+}
+
+/** A temp directory shaped like the repo: package.json + registry manifest, git-initialised. */
+function makeFixture(manifestContent: string): Fixture {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-sync-test-"));
+  writeFileSync(
+    pathJoin(dir, "package.json"),
+    `${JSON.stringify({ name: PACKAGE.name, version: PACKAGE.version }, null, 2)}\n`
+  );
+  const manifestPath = pathJoin(dir, "registry", "glm-acp-agent", "agent.json");
+  mkdirSync(pathJoin(manifestPath, ".."), { recursive: true });
+  writeFileSync(manifestPath, manifestContent);
+  const git = (args: string[]) =>
+    spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+  git(["init", "--quiet"]);
+  git(["add", "package.json", "registry"]);
+  git([
+    "-c",
+    "user.name=test",
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "--quiet",
+    "-m",
+    "fixture",
+  ]);
+  return { dir, manifestPath };
+}
+
+function runScript(fixture: Fixture, args: string[]) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    cwd: fixture.dir,
+    encoding: "utf8",
+  });
+}
+
+test("CLI: default mode rewrites the manifest and stages it for the release commit", () => {
+  const fixture = makeFixture(MANIFEST);
+  try {
+    const run = runScript(fixture, []);
+    assert.equal(run.status, 0, `stderr: ${run.stderr}`);
+
+    const onDisk = readFileSync(fixture.manifestPath, "utf8");
+    assert.match(onDisk, /"version": "1\.4\.1"/);
+    assert.match(onDisk, /"package": "glm-acp-agent@1\.4\.1"/);
+
+    // The `version` lifecycle hook relies on the rewrite landing in the git
+    // index so `npm version` folds it into the release commit.
+    const status = spawnSync("git", ["status", "--porcelain"], {
+      cwd: fixture.dir,
+      encoding: "utf8",
+    }).stdout.trim();
+    assert.equal(status, "M  registry/glm-acp-agent/agent.json");
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI: --check passes (exit 0) and leaves the file untouched when in sync", () => {
+  const inSync = syncManifestContent(MANIFEST, PACKAGE);
+  const fixture = makeFixture(inSync);
+  try {
+    const run = runScript(fixture, ["--check"]);
+    assert.equal(run.status, 0, `stderr: ${run.stderr}`);
+    assert.equal(readFileSync(fixture.manifestPath, "utf8"), inSync);
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI: --check fails (exit 1) with a diagnostic when the manifest drifted", () => {
+  const fixture = makeFixture(MANIFEST);
+  try {
+    const run = runScript(fixture, ["--check"]);
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /1\.3\.0[\s\S]*1\.4\.1/);
+    // Check mode must never rewrite the file.
+    assert.equal(readFileSync(fixture.manifestPath, "utf8"), MANIFEST);
+  } finally {
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});

--- a/src/tests/sync-manifest.test.ts
+++ b/src/tests/sync-manifest.test.ts
@@ -47,15 +47,59 @@ test("syncManifestContent: rewrites the npx distribution pin", () => {
   assert.match(result, /"package": "glm-acp-agent@1\.4\.1"/);
 });
 
-test("syncManifestContent: preserves unrelated formatting (inline arrays, field order)", () => {
+test("syncManifestContent: preserves field order and unrelated values, normalizing formatting", () => {
   const result = syncManifestContent(MANIFEST, PACKAGE);
-  // The surgical rewrite must not reformat the whole file — only the two
-  // version occurrences may change.
-  assert.equal(
-    result,
-    MANIFEST.replaceAll("1.3.0", "1.4.1"),
-    "everything except the two version pins should be byte-identical"
+  const parsed = JSON.parse(result) as Record<string, unknown>;
+  // JSON.stringify keeps parse insertion order, so after the one-time
+  // normalization the field layout is stable and diffs stay reviewable.
+  assert.deepEqual(Object.keys(parsed), [
+    "id",
+    "name",
+    "version",
+    "description",
+    "repository",
+    "authors",
+    "license",
+    "icon",
+    "distribution",
+  ]);
+  assert.deepEqual(parsed.authors, ["Stefan de Vogelaere"]);
+  assert.equal(parsed.description, "ACP agent powered by Zhipu AI's GLM Coding Plan models.");
+  assert.equal(result, `${JSON.stringify(parsed, null, 2)}\n`);
+});
+
+test("syncManifestContent: leaves a nested version field alone even when the top-level pin is already current", () => {
+  // Regression (PR #83 review): a line-based rewrite hit the FIRST "version"
+  // line, so with the top-level field already current it silently rewrote
+  // unrelated nested metadata while validation still passed.
+  const nested = MANIFEST.replace(
+    /^ {2}"id": "glm-acp-agent",\n/m,
+    `  "metadata": { "version": "9.9.9" },\n  "id": "glm-acp-agent",\n`
+  ).replace(/^ {2}"version": "1\.3\.0",\n/m, `  "version": "1.4.1",\n`);
+  const parsed = JSON.parse(syncManifestContent(nested, PACKAGE)) as {
+    version: string;
+    metadata: { version: string };
+    distribution: { npx: { package: string } };
+  };
+  assert.equal(parsed.metadata.version, "9.9.9");
+  assert.equal(parsed.version, "1.4.1");
+  assert.equal(parsed.distribution.npx.package, "glm-acp-agent@1.4.1");
+});
+
+test("syncManifestContent: updates the npx pin without touching a sibling distribution's pin", () => {
+  // Regression (PR #83 review): a line-based rewrite hit the FIRST "package"
+  // line, so a sibling distribution carrying the same pin made the sync throw
+  // on an otherwise valid manifest and blocked CI / `npm version`.
+  const sibling = MANIFEST.replace(
+    /^ {4}"npx": \{\n/m,
+    `    "pip": {\n      "package": "glm-acp-agent@1.3.0"\n    },\n    "npx": {\n`
   );
+  const parsed = JSON.parse(syncManifestContent(sibling, PACKAGE)) as {
+    distribution: { pip: { package: string }; npx: { package: string } };
+  };
+  assert.equal(parsed.distribution.npx.package, "glm-acp-agent@1.4.1");
+  // Only the npx distribution is managed by this script.
+  assert.equal(parsed.distribution.pip.package, "glm-acp-agent@1.3.0");
 });
 
 test("syncManifestContent: is idempotent when already in sync", () => {


### PR DESCRIPTION
## Purpose

`registry/glm-acp-agent/agent.json` pinned `1.0.0` while the package shipped 1.4.0 — nothing in the release flow ever touched the manifest, so registry users installed a version without the GLM-5.2/5.3, `thought_level`, or vision work the manifest's own description advertised (#77, originally surfaced as a major finding on PR #76). #78 synced the pin to 1.4.0 by hand; this PR makes the sync automatic so it cannot drift again.

## Key Changes

- **`src/registry/sync-manifest.ts`** — syncs `agent.json`'s `version` and `distribution.npx.package` to `package.json` through the parsed object, so the rewrite is path-aware: a nested `"version"` field or a sibling distribution pin elsewhere in the manifest can neither be mistaken for the real pins nor silently clobbered (review findings from `devflowcr[bot]` and Greptile). Invalid JSON, missing fields, or a pin no longer targeting `glm-acp-agent` throw instead of shipping a half-synced manifest. `--check` verifies without writing and compares pin values, not file bytes. Output uses normalized `JSON.stringify` formatting; this PR includes the one-time normalization of `agent.json` so later release diffs are just the two pins.
- **`package.json`** — a `version` npm lifecycle script (build + sync + `git add`). `npm version` runs it after bumping `package.json` but before committing, so the release commit and tag carry the synced manifest with no manual step.
- **`ci.yml` / `publish.yml`** — `--check` guard after Build (and before Publish in the release workflow): drift fails the build.
- **`RELEASING.md`** — step 1 is now about description/icon changes only; version sync documented as automatic, plus a note in Verify and Notes.
- **`src/tests/sync-manifest.test.ts`** — 12 tests: the path-aware rewrite (both pins, field order/values preserved across normalization, nested `version` and sibling-distribution regression cases, idempotency, three error cases) and CLI modes (default rewrites + stages for the release commit; `--check` exits 0 in sync, 1 with a diagnostic on drift, never writes).

## Task

Closes #77

## Checks

- [x] `npm run lint` clean
- [x] `npm test` — 201 tests, 0 failures (all 12 new tests pass)
- [x] End-to-end release simulation in an isolated temp repo (re-run after the review fixes): `npm version patch -m "chore(release): %s"` bumped `package.json` to 1.4.1, the hook synced `agent.json`, and the release commit contained `package.json`, `package-lock.json`, and `agent.json`; tag `v1.4.1` created; `--check` exited 0 in sync and 1 after regressing the manifest
- Note: ~6–30 executor/integration subtests are flakily *cancelled* (never fail) on repeated runs — reproduced identically on clean `main`, pre-existing, filed as #82