### PR TITLE
#75 - Expose the full GLM-5.3 reasoning_effort ladder as thought levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,14 @@ The agent advertises a `thought_level` [SessionConfigOption](https://agentclient
 
 | Model | Levels | Mapping to the Z.AI request |
 |-------|--------|-----------------------------|
-| `glm-5.3` (and `glm-5.2` / `glm-5.1`, which route to it) | `High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort: "high"` / `"max"` |
+| `glm-5.3` (and `glm-5.2` / `glm-5.1`, which route to it) | `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort` set to the matching value |
 | other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
 
 **GLM-5.3 has no `Off` level, because thinking cannot be turned off on it.** The endpoint accepts both `thinking: { type: "disabled" }` and `reasoning_effort: "none"` without error, but keeps emitting reasoning either way — so `ACP_GLM_THINKING=false` is a no-op on GLM-5.3. Use `glm-4.7` if you need non-reasoning completions.
 
-`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (a `High` selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (an effort-ladder selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
 
-The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent currently exposes only `high` and `max` as thought levels.
+The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent exposes every one of those values as a thought level except `none`, which GLM-5.3 ignores (see above).
 
 `ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, clients should not offer image attachments at all.
 

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -11,20 +11,37 @@ import { debug, error } from "./logger.js";
  * request parameters (see {@link buildThinkingParams}).
  *
  * GLM-5.3 (and GLM-5.2, which the Coding Plan endpoint serves with 5.3)
- * supports `high` and `max`. Other thinking-capable models (5-turbo, 4.7, …)
- * only distinguish thinking on vs. off, so they use `none` and `on`.
+ * supports the full effort ladder: `minimal | low | medium | high | xhigh |
+ * max`. Other thinking-capable models (5-turbo, 4.7, …) only distinguish
+ * thinking on vs. off, so they use `none` and `on`.
  */
-export type ThoughtLevel = "none" | "on" | "high" | "max";
+export type ThoughtLevel =
+  | "none"
+  | "on"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max";
 
 /**
- * Levels shown for the models that honour `reasoning_effort`.
+ * Levels shown for the models that honour `reasoning_effort` — the endpoint's
+ * full validated ladder minus `none`.
  *
  * Deliberately has no `none`: probing the Coding Plan endpoint on 2026-08-15
  * showed GLM-5.3 keeps emitting `reasoning_content` whether you send
  * `thinking: { type: "disabled" }` or `reasoning_effort: "none"`, so an "Off"
  * option would advertise something the model does not do.
  */
-const LEVELS_REASONING_EFFORT: ThoughtLevel[] = ["high", "max"];
+const LEVELS_REASONING_EFFORT: ThoughtLevel[] = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
 
 /** Levels shown for every other thinking-capable model. */
 const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
@@ -45,7 +62,11 @@ function isReasoningEffortModel(model: string): boolean {
 }
 
 /** The complete set of thought levels the agent understands. */
-const ALL_THOUGHT_LEVELS: readonly ThoughtLevel[] = ["none", "on", "high", "max"];
+const ALL_THOUGHT_LEVELS: readonly ThoughtLevel[] = [
+  "none",
+  "on",
+  ...LEVELS_REASONING_EFFORT,
+];
 
 /** Type guard: whether an arbitrary string is a known ThoughtLevel. */
 export function isThoughtLevel(value: string): value is ThoughtLevel {
@@ -432,8 +453,8 @@ function thinkingOverride(): boolean | undefined {
  * {@link ThoughtLevel} values map as follows:
  * - `none` → thinking disabled
  * - `on`   → thinking enabled (no reasoning_effort)
- * - `high` → thinking enabled + reasoning_effort=high (5.3 family only)
- * - `max`  → thinking enabled + reasoning_effort=max (5.3 family only)
+ * - `minimal` … `max` → thinking enabled + reasoning_effort=<level>
+ *   (5.3 family only)
  *
  * Caveat: GLM-5.3 ignores every attempt to turn thinking off — it keeps
  * emitting `reasoning_content` for `thinking: { type: "disabled" }` and for
@@ -476,7 +497,7 @@ export function buildThinkingParams(
   // and glm-4.7 accept it without validating it and answer identically either
   // way. The remaining levels ("on", and "none" when thinking is force-enabled
   // via the env override) carry no valid effort, so we omit the field.
-  if ((effort === "high" || effort === "max") && isReasoningEffortModel(model)) {
+  if (effort !== undefined && LEVELS_REASONING_EFFORT.includes(effort) && isReasoningEffortModel(model)) {
     params["reasoning_effort"] = effort;
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -76,6 +76,22 @@ const PROJECT_CONTEXT_CAP_CHARS = 8 * 1024;
  */
 export type SessionModeId = "default" | "accept_edits" | "bypass_permissions";
 
+/**
+ * Display names for thought levels shown in client UIs. Kept as an exhaustive
+ * map (not capitalize-first-letter) so `xhigh` renders as "X-High" and adding
+ * a level forces a conscious naming decision here.
+ */
+const THOUGHT_LEVEL_NAMES: Record<ThoughtLevel, string> = {
+  none: "Off",
+  on: "On",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "X-High",
+  max: "Max",
+};
+
 /** Per-session state */
 interface SessionState {
   cwd: string;
@@ -330,9 +346,9 @@ export class GlmAcpAgent implements Agent {
       );
     }
     session.model = params.modelId;
-    // The valid thought levels differ per model (e.g. 5.3 offers high/max
-    // while others only offer none/on), so clamp the current level to what
-    // the new model supports.
+    // The valid thought levels differ per model (e.g. 5.3 offers the full
+    // effort ladder while others only offer none/on), so clamp the current
+    // level to what the new model supports.
     session.thoughtLevel = resolveThoughtLevel(params.modelId, session.thoughtLevel);
     session.updatedAt = new Date().toISOString();
     // Persist immediately so a fork/reload before the next prompt doesn't
@@ -348,7 +364,8 @@ export class GlmAcpAgent implements Agent {
       },
     });
     // Push updated thought_level options — the set of valid levels may
-    // differ between models (e.g. switching from 5.2 to 4.7 drops "high").
+    // differ between models (e.g. switching from 5.3 to 4.7 drops the
+    // effort ladder).
     await safeSessionUpdate(this.connection, {
       sessionId: params.sessionId,
       update: {
@@ -378,12 +395,7 @@ export class GlmAcpAgent implements Agent {
         currentValue: thoughtLevel,
         options: levels.map((level) => ({
           value: level,
-          name:
-            level === "none"
-              ? "Off"
-              : level === "on"
-                ? "On"
-                : level.charAt(0).toUpperCase() + level.slice(1),
+          name: THOUGHT_LEVEL_NAMES[level],
         })),
       },
     ];

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -871,11 +871,18 @@ test("newSession returns configOptions with thought_level selector for default m
   const tl = result.configOptions!.find((o) => o.category === "thought_level");
   assert.ok(tl, "thought_level option should exist");
   assert.equal(tl!.type, "select");
-  // Default model is glm-5.3 → high/max, defaulting to max. There is no "Off"
-  // level because thinking cannot be disabled on 5.3.
+  // Default model is glm-5.3 → the full effort ladder, defaulting to max.
+  // There is no "Off" level because thinking cannot be disabled on 5.3.
   assert.equal(tl!.currentValue, "max");
-  const values = (tl as { options: Array<{ value: string }> }).options.map((o) => o.value);
-  assert.deepEqual(values, ["high", "max"]);
+  const options = (tl as { options: Array<{ value: string; name: string }> }).options;
+  assert.deepEqual(
+    options.map((o) => o.value),
+    ["minimal", "low", "medium", "high", "xhigh", "max"]
+  );
+  assert.deepEqual(
+    options.map((o) => o.name),
+    ["Minimal", "Low", "Medium", "High", "X-High", "Max"]
+  );
 });
 
 test("setSessionConfigOption updates thoughtLevel and returns updated options", async () => {
@@ -932,18 +939,18 @@ test("setSessionConfigOption rejects values that aren't a known thought level", 
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
-  // "medium" is not a ThoughtLevel at all — reject rather than silently coerce.
+  // "ultra" is not a ThoughtLevel at all — reject rather than silently coerce.
   await assert.rejects(
-    agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "medium" }),
+    agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "ultra" }),
     /Invalid thought_level value/
   );
-  // A cross-model-but-known value ("max" while on the default glm-5.3) is fine.
+  // A mid-ladder value is valid on the default glm-5.3 and sticks.
   const ok = await agent.setSessionConfigOption({
     sessionId,
     configId: "thought_level",
-    value: "max",
+    value: "medium",
   });
-  assert.equal(ok.configOptions.find((o) => o.id === "thought_level")!.currentValue, "max");
+  assert.equal(ok.configOptions.find((o) => o.id === "thought_level")!.currentValue, "medium");
 });
 
 test("switching model updates thought_level options via config_option_update", async () => {
@@ -952,7 +959,7 @@ test("switching model updates thought_level options via config_option_update", a
   await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
   const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
 
-  // Start with glm-5.3 (default) → max, options high/max.
+  // Start with glm-5.3 (default) → max, options = the full effort ladder.
   // Switch to glm-4.7 → thoughtLevel should resolve to "on".
   await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
 
@@ -1152,7 +1159,7 @@ test("a persisted 'none' level clamps up to max when the session is on glm-5.3",
     assert.equal(tl!.currentValue, "max");
     assert.deepEqual(
       (tl as { options: Array<{ value: string }> }).options.map((o) => o.value),
-      ["high", "max"]
+      ["minimal", "low", "medium", "high", "xhigh", "max"]
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1008,11 +1008,13 @@ test("thoughtLevel round-trips through fork via persistence", async () => {
     const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
     await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
     const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
-    await agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "high" });
+    // "medium" is a new-ladder value: proves it survives persist → fork →
+    // resolveThoughtLevel, not just the pre-existing high/max levels.
+    await agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "medium" });
 
     const forked = await agent.unstable_forkSession({ sessionId, cwd: "/tmp", mcpServers: [] });
     const tl = forked.configOptions!.find((o) => o.id === "thought_level");
-    assert.equal(tl!.currentValue, "high");
+    assert.equal(tl!.currentValue, "medium");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1008,11 +1008,16 @@ test("thoughtLevel round-trips through fork via persistence", async () => {
     const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
     await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
     const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
-    // "medium" is a new-ladder value: proves it survives persist → fork →
+    // "medium" is a new-ladder value: prove it survives persist → fork →
     // resolveThoughtLevel, not just the pre-existing high/max levels.
     await agent.setSessionConfigOption({ sessionId, configId: "thought_level", value: "medium" });
 
-    const forked = await agent.unstable_forkSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    // Fork through a *fresh* agent over the same store so the fork reads the
+    // persisted record — forking the live agent would snapshot its in-memory
+    // SessionState and pass even if persistence dropped the level.
+    const reloaded = new GlmAcpAgent(createConnectionStub() as never, { sessionStore: store });
+    await reloaded.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const forked = await reloaded.unstable_forkSession({ sessionId, cwd: "/tmp", mcpServers: [] });
     const tl = forked.configOptions!.find((o) => o.id === "thought_level");
     assert.equal(tl!.currentValue, "medium");
   } finally {

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -270,12 +270,16 @@ test("streamChat sends reasoning_effort when level is set on glm-5.3", async () 
     return Promise.resolve(stream);
   });
 
-  for await (const chunk of c.streamChat([], undefined, { model: "glm-5.3", reasoningEffort: "max" })) {
-    void chunk;
-  }
+  // Spot-check across the ladder: endpoints, a middle level, and the one
+  // non-capitalized id ("xhigh") that would break on naive name mangling.
+  for (const effort of ["max", "medium", "minimal", "xhigh"] as const) {
+    for await (const chunk of c.streamChat([], undefined, { model: "glm-5.3", reasoningEffort: effort })) {
+      void chunk;
+    }
 
-  assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
-  assert.equal(requestBody?.["reasoning_effort"], "max");
+    assert.deepEqual(requestBody?.["thinking"], { type: "enabled" });
+    assert.equal(requestBody?.["reasoning_effort"], effort);
+  }
 });
 
 test("streamChat sends reasoning_effort on the de-listed aliases routed to 5.3", async () => {
@@ -347,11 +351,13 @@ test("getThoughtLevels omits none for reasoning-effort models", () => {
   // Thinking cannot be turned off on glm-5.3: the endpoint accepts
   // `thinking: { type: "disabled" }` and `reasoning_effort: "none"` but keeps
   // emitting reasoning either way, so offering an "Off" option would lie.
-  assert.deepEqual(getThoughtLevels("glm-5.3"), ["high", "max"]);
+  // Everything else on the validated ladder is exposed, in ladder order.
+  const ladder = ["minimal", "low", "medium", "high", "xhigh", "max"];
+  assert.deepEqual(getThoughtLevels("glm-5.3"), ladder);
   // glm-5.2 and glm-5.1 are both served by glm-5.3, so they behave identically
   // — including the fact that "Off" would not actually turn thinking off.
-  assert.deepEqual(getThoughtLevels("glm-5.2"), ["high", "max"]);
-  assert.deepEqual(getThoughtLevels("glm-5.1"), ["high", "max"]);
+  assert.deepEqual(getThoughtLevels("glm-5.2"), ladder);
+  assert.deepEqual(getThoughtLevels("glm-5.1"), ladder);
 });
 
 test("getThoughtLevels returns none/on for models without reasoning_effort", () => {
@@ -360,11 +366,15 @@ test("getThoughtLevels returns none/on for models without reasoning_effort", () 
 });
 
 test("resolveThoughtLevel clamps invalid levels to the model default", () => {
-  // "high"/"max" only apply to the reasoning-effort models; others get "on".
+  // Effort-ladder levels only apply to the reasoning-effort models; others
+  // get "on".
   assert.equal(resolveThoughtLevel("glm-4.7", "max"), "on");
   assert.equal(resolveThoughtLevel("glm-4.7", "high"), "on");
-  // Valid levels are preserved.
+  assert.equal(resolveThoughtLevel("glm-4.7", "xhigh"), "on");
+  // Valid levels are preserved, across the whole ladder.
   assert.equal(resolveThoughtLevel("glm-5.3", "high"), "high");
+  assert.equal(resolveThoughtLevel("glm-5.3", "minimal"), "minimal");
+  assert.equal(resolveThoughtLevel("glm-5.3", "xhigh"), "xhigh");
   assert.equal(resolveThoughtLevel("glm-4.7", "none"), "none");
 });
 
@@ -411,13 +421,16 @@ test("buildThinkingParams attaches reasoning_effort on glm-5.3", () => {
   const old = process.env["ACP_GLM_THINKING"];
   delete process.env["ACP_GLM_THINKING"];
   try {
-    assert.deepEqual(buildThinkingParams("glm-5.3", "high"), {
+    // Every level on the exposed ladder maps to its own reasoning_effort.
+    for (const level of ["minimal", "low", "medium", "high", "xhigh", "max"] as const) {
+      assert.deepEqual(buildThinkingParams("glm-5.3", level), {
+        thinking: { type: "enabled" },
+        reasoning_effort: level,
+      });
+    }
+    // "on" carries no effort, so it stays a plain thinking toggle.
+    assert.deepEqual(buildThinkingParams("glm-5.3", "on"), {
       thinking: { type: "enabled" },
-      reasoning_effort: "high",
-    });
-    assert.deepEqual(buildThinkingParams("glm-5.3", "max"), {
-      thinking: { type: "enabled" },
-      reasoning_effort: "max",
     });
   } finally {
     if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;


### PR DESCRIPTION
## Purpose

This feature widens the GLM-5.3 `thought_level` selector from two options (`High` / `Max`) to the endpoint's full validated `reasoning_effort` ladder — `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max`. Probing for #74 showed each rung is measurably distinct (`minimal` costs roughly a fifth of `max`'s completion tokens on the same prompt), so exposing them gives Coding Plan users a direct cost/latency lever — the current floor for GLM-5.3 was `High`, since thinking cannot be turned off on that model. `none` remains excluded: the probe showed it does **not** suppress reasoning (it emits more reasoning content than `max`).

## Key Changes

- `ThoughtLevel` widened with `minimal` / `low` / `medium` / `xhigh`; `LEVELS_REASONING_EFFORT` is now the endpoint's full validated ladder minus `none`
- `buildThinkingParams` forwards every ladder level as `reasoning_effort` on the GLM-5.3 family (including the `glm-5.2` / `glm-5.1` aliases routed to it); `on` / `none` stay plain thinking toggles and non-5.3 models are unchanged (`none` / `on`)
- `configOptionsState` labels come from an exhaustive `Record<ThoughtLevel, string>` map, so `xhigh` renders as "X-High" and adding a level without a display name is a compile error
- Persisted sessions keep schema v3: new values survive persist/fork/load, and an older agent build loading them clamps to `max` at the `resolveThoughtLevel` boundary
- Tests cover the ladder at unit level (`getThoughtLevels`, `resolveThoughtLevel`, `buildThinkingParams`), wire level (`streamChat` request body incl. `xhigh`), and agent level (option list + labels, invalid-value rejection, mid-ladder persistence round-trip); README thought-level table updated

## Checks

- [x] Tests pass (189/189)
- [x] Lint passes (eslint)
- [x] Build compiles without errors (tsc)
- [x] Changes have been tested locally

## Task

[#75](https://github.com/stefandevo/glm-acp-agent/issues/75)