### PR TITLE
#82 - Stop the test suite flakily cancelling executor subtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Test
+        run: npm test
+
       - name: Check registry manifest version sync
         run: node dist/registry/sync-manifest.js --check
 

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { writeCredentials } from "../llm/credentials.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { VisionMcpClient } from "../tools/vision-mcp-client.js";
@@ -415,6 +417,74 @@ test(
 
     const last = conn.updates.at(-1) as { update: { status?: string } };
     assert.equal(last.update.status, "completed");
+  }
+);
+
+// Runs inside a bare node process whose only pending work is a sequence of
+// run_command calls: with an unref'd child the event loop can drain mid-await
+// on fast commands and the process exits with the promise still unsettled.
+const LOOP_PROBE_HELPER = `
+import { pathToFileURL } from "node:url";
+const [executorModule, cwd] = process.argv.slice(2);
+const { ToolExecutor } = await import(pathToFileURL(executorModule).href);
+const connection = {
+  async sessionUpdate() {},
+  async requestPermission() {
+    return { outcome: { outcome: "selected", optionId: "allow" } };
+  },
+};
+const exec = new ToolExecutor(connection, "s1", { fs: {} }, undefined, null, null, cwd);
+for (let i = 1; i <= 15; i++) {
+  const result = await exec.execute(
+    "tc" + i,
+    "run_command",
+    JSON.stringify({ command: "echo loop-alive-" + i })
+  );
+  if (!result.content.includes("loop-alive-" + i)) {
+    process.stdout.write("BAD OUTPUT AT " + i + "\\n");
+    process.exit(1);
+  }
+}
+process.stdout.write("SETTLED 15\\n");
+`;
+
+test(
+  "run_command keeps the event loop alive until the command settles (#82)",
+  { timeout: 10_000 },
+  async () => {
+    // Regression test for #82. runShellCommand unref()ed the sh -c child, so a
+    // node:test file process with no other pending work could drain its event
+    // loop while a fast run_command was still in flight. The runner then
+    // cancelled every remaining test in the file with "Promise resolution is
+    // still pending but the event loop has already resolved" — flaky,
+    // load-dependent blocks of 6–30 cancelled subtests per run. The unfixed
+    // race is per command (~40% observed), so several bare helper processes
+    // are probed; each must settle all of its tool calls rather than exit
+    // early. With the child ref'd every process settles deterministically.
+    const dir = mkdtempSync(join(tmpdir(), "glm-executor-loop-"));
+    try {
+      const helperPath = join(dir, "loop-probe.mjs");
+      writeFileSync(helperPath, LOOP_PROBE_HELPER, "utf8");
+      const executorModule = fileURLToPath(new URL("../tools/executor.js", import.meta.url));
+      const attempts = 8;
+      for (let attempt = 1; attempt <= attempts; attempt++) {
+        let stdout = "";
+        try {
+          stdout = execFileSync(process.execPath, [helperPath, executorModule, dir], {
+            encoding: "utf8",
+            timeout: 8_000,
+          });
+        } catch (err) {
+          assert.fail(
+            `helper ${attempt}/${attempts} exited before the tool calls settled: ` +
+              `${(err as Error).message}`
+          );
+        }
+        assert.match(stdout, /SETTLED 15/, `helper ${attempt}/${attempts} output`);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   }
 );
 

--- a/src/tests/executor.test.ts
+++ b/src/tests/executor.test.ts
@@ -420,6 +420,12 @@ test(
   }
 );
 
+// The helpers run serially inside one test, so the test timeout must exceed
+// attempts × per-helper budget — otherwise a loaded runner can kill the test
+// while every helper is still individually within budget (greptile, PR #85).
+const PROBE_ATTEMPTS = 8;
+const PROBE_HELPER_TIMEOUT_MS = 8_000;
+
 // Runs inside a bare node process whose only pending work is a sequence of
 // run_command calls: with an unref'd child the event loop can drain mid-await
 // on fast commands and the process exits with the promise still unsettled.
@@ -450,7 +456,7 @@ process.stdout.write("SETTLED 15\\n");
 
 test(
   "run_command keeps the event loop alive until the command settles (#82)",
-  { timeout: 10_000 },
+  { timeout: PROBE_ATTEMPTS * PROBE_HELPER_TIMEOUT_MS + 5_000 },
   async () => {
     // Regression test for #82. runShellCommand unref()ed the sh -c child, so a
     // node:test file process with no other pending work could drain its event
@@ -466,21 +472,20 @@ test(
       const helperPath = join(dir, "loop-probe.mjs");
       writeFileSync(helperPath, LOOP_PROBE_HELPER, "utf8");
       const executorModule = fileURLToPath(new URL("../tools/executor.js", import.meta.url));
-      const attempts = 8;
-      for (let attempt = 1; attempt <= attempts; attempt++) {
+      for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
         let stdout = "";
         try {
           stdout = execFileSync(process.execPath, [helperPath, executorModule, dir], {
             encoding: "utf8",
-            timeout: 8_000,
+            timeout: PROBE_HELPER_TIMEOUT_MS,
           });
         } catch (err) {
           assert.fail(
-            `helper ${attempt}/${attempts} exited before the tool calls settled: ` +
+            `helper ${attempt}/${PROBE_ATTEMPTS} exited before the tool calls settled: ` +
               `${(err as Error).message}`
           );
         }
-        assert.match(stdout, /SETTLED 15/, `helper ${attempt}/${attempts} output`);
+        assert.match(stdout, /SETTLED 15/, `helper ${attempt}/${PROBE_ATTEMPTS} output`);
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -831,15 +831,17 @@ function runShellCommand(
     const child = spawn("sh", ["-c", command], {
       cwd,
       signal,
+      // Run the shell in its own process group so that background processes
+      // (nohup, disown, &) survive after the main sh -c exits and don't
+      // receive signals aimed at this agent. The child must stay ref'd: while
+      // the tool call is in flight it is real pending work, and an unref'd
+      // child let the event loop drain mid-await whenever nothing else was
+      // pending (#82). Combined with the post-"exit" stream destroy below,
+      // daemons that inherit the pipes still can't keep this process alive
+      // after the shell exits.
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    // Detach the child process group from this agent's event loop so that
-    // background processes (nohup, disown, &) don't keep the Node process
-    // alive after the main sh -c exits. Combined with "exit" (not "close")
-    // this lets run_command return immediately for scripts that spawn
-    // long-running daemons (e.g. llama-server, mcp-bridges).
-    child.unref();
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
     let settled = false;


### PR DESCRIPTION
## Purpose

`npm test` flakily cancelled contiguous blocks of 6–30 executor subtests per run (`fail 0`, only `cancelled` climbing). Root cause: `runShellCommand` called `child.unref()` on the `sh -c` child, so a Node process with no other pending work could drain its event loop mid-await on fast commands — node:test then cancelled every remaining test in the file with "Promise resolution is still pending but the event loop has already resolved". Reproduced in isolation: a bare node process whose only pending work is a `run_command` exits with code 13 (unsettled top-level await) in ~40% of runs, pre-fix.

## Key Changes

- **`src/tools/executor.ts`** — remove `child.unref()`. `detached: true` alone already provides the #67 daemon-survival behavior (own process group); the post-`exit` stream destroy still guarantees prompt return when daemons inherit the pipes. Abort wiring is unchanged, so user-cancel / connection-close still kills in-flight commands — no new hang path.
- **`src/tests/executor.test.ts`** — regression test (#82): 8 bare helper processes drive 15 instant `run_command` calls each through the real executor; every process must settle rather than exit early. Failed reliably pre-fix, passes deterministically post-fix.
- **`.github/workflows/ci.yml`** — add a `Test` step. CI previously never ran the suite (lint/build/manifest/smoke only), so cancellations had nowhere to be seen; `node --test` already exits non-zero on cancellations.

## Checks

- 10 back-to-back full-suite runs: `202 pass / 0 fail / cancelled 0 / exit 0` every time (pre-fix, a single run produced 30 cancelled)
- `npm test` end-to-end green; `npm run lint` clean; `npm run build` clean
- #67 prompt-return regression test still passes (< 2s with a 3s background `sleep`)

## Task

https://github.com/stefandevo/glm-acp-agent/issues/82