### PR TITLE
#86 - Advertise session mode and model as config options

### DIFF
--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -77,6 +77,42 @@ const PROJECT_CONTEXT_CAP_CHARS = 8 * 1024;
 export type SessionModeId = "default" | "accept_edits" | "bypass_permissions";
 
 /**
+ * The session modes we advertise, in the order clients should display them.
+ *
+ * Single source of truth for both the ACP `modes` state (`session/set_mode`)
+ * and the `mode`-category SessionConfigOption. Clients like Zed suppress the
+ * legacy mode selector as soon as an agent advertises any config option, so
+ * the same list has to reach the UI through both channels.
+ */
+const SESSION_MODES: ReadonlyArray<{
+  id: SessionModeId;
+  name: string;
+  description: string;
+}> = [
+  {
+    id: "default",
+    name: "Ask for permission",
+    description: "Prompt before edits and commands.",
+  },
+  {
+    id: "accept_edits",
+    name: "Auto-approve edits",
+    description: "Edits run without prompting. Commands still prompt.",
+  },
+  {
+    id: "bypass_permissions",
+    name: "Bypass all permissions",
+    description: "Edits and commands run without prompting.",
+  },
+];
+
+const SESSION_MODE_IDS: SessionModeId[] = SESSION_MODES.map((mode) => mode.id);
+
+function isSessionModeId(value: unknown): value is SessionModeId {
+  return typeof value === "string" && SESSION_MODE_IDS.includes(value as SessionModeId);
+}
+
+/**
  * Display names for thought levels shown in client UIs. Kept as an exhaustive
  * map (not capitalize-first-letter) so `xhigh` renders as "X-High" and adding
  * a level forces a conscious naming decision here.
@@ -325,7 +361,7 @@ export class GlmAcpAgent implements Agent {
       sessionId,
       models: this.modelsState(model),
       modes: this.modesState("default"),
-      configOptions: this.configOptionsState(model, thoughtLevel),
+      configOptions: this.configOptionsState(model, thoughtLevel, "default"),
     };
   }
 
@@ -370,19 +406,31 @@ export class GlmAcpAgent implements Agent {
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "config_option_update",
-        configOptions: this.configOptionsState(session.model, session.thoughtLevel),
+        configOptions: this.configOptionsState(
+          session.model,
+          session.thoughtLevel,
+          session.mode
+        ),
       },
     });
     return {};
   }
 
   /**
-   * Build the `thought_level` SessionConfigOption for the given model. The
-   * available levels depend on the model (see {@link getThoughtLevels}).
+   * Build the SessionConfigOptions we advertise: `thought_level` (levels depend
+   * on the model, see {@link getThoughtLevels}) and `mode`.
+   *
+   * The `mode` option mirrors {@link modesState} as a `category: "mode"`
+   * selector. Clients that render config options (Zed) suppress the legacy mode
+   * selector once any config option is advertised, so the permission mode would
+   * otherwise be unreachable from their UI. `currentMode` is always read from
+   * the live session state, so a mode set through `session/set_mode` shows up
+   * here too.
    */
   private configOptionsState(
     model: string,
-    thoughtLevel: ThoughtLevel
+    thoughtLevel: ThoughtLevel,
+    currentMode: SessionModeId
   ): SessionConfigOption[] {
     const levels = getThoughtLevels(model);
     return [
@@ -398,6 +446,18 @@ export class GlmAcpAgent implements Agent {
           name: THOUGHT_LEVEL_NAMES[level],
         })),
       },
+      {
+        id: "mode",
+        name: "Mode",
+        description: "Tool permission mode",
+        category: "mode",
+        type: "select" as const,
+        currentValue: currentMode,
+        options: SESSION_MODES.map((mode) => ({
+          value: mode.id,
+          name: mode.name,
+        })),
+      },
     ];
   }
 
@@ -407,6 +467,31 @@ export class GlmAcpAgent implements Agent {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
+    }
+    if (params.configId === "mode") {
+      // Same reject-don't-coerce policy as thought_level below.
+      if (!isSessionModeId(params.value)) {
+        throw new Error(`Invalid mode value: ${String(params.value)}`);
+      }
+      session.mode = params.value;
+      session.updatedAt = new Date().toISOString();
+      this.persistSession(params.sessionId, session);
+      // Mirror setSessionMode so clients tracking the ACP mode state (rather
+      // than the config option) stay in sync with the dropdown.
+      await safeSessionUpdate(this.connection, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "current_mode_update",
+          currentModeId: session.mode,
+        },
+      });
+      return {
+        configOptions: this.configOptionsState(
+          session.model,
+          session.thoughtLevel,
+          session.mode
+        ),
+      };
     }
     if (params.configId !== "thought_level") {
       throw new Error(`Unknown config option: ${params.configId}`);
@@ -424,7 +509,11 @@ export class GlmAcpAgent implements Agent {
     session.updatedAt = new Date().toISOString();
     this.persistSession(params.sessionId, session);
     return {
-      configOptions: this.configOptionsState(session.model, session.thoughtLevel),
+      configOptions: this.configOptionsState(
+        session.model,
+        session.thoughtLevel,
+        session.mode
+      ),
     };
   }
 
@@ -458,23 +547,7 @@ export class GlmAcpAgent implements Agent {
     currentModeId: SessionModeId;
   } {
     return {
-      availableModes: [
-        {
-          id: "default",
-          name: "Ask for permission",
-          description: "Prompt before edits and commands.",
-        },
-        {
-          id: "accept_edits",
-          name: "Auto-approve edits",
-          description: "Edits run without prompting. Commands still prompt.",
-        },
-        {
-          id: "bypass_permissions",
-          name: "Bypass all permissions",
-          description: "Edits and commands run without prompting.",
-        },
-      ],
+      availableModes: SESSION_MODES.map((mode) => ({ ...mode })),
       currentModeId,
     };
   }
@@ -486,13 +559,12 @@ export class GlmAcpAgent implements Agent {
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
-    const validModeIds: SessionModeId[] = ["default", "accept_edits", "bypass_permissions"];
-    if (!validModeIds.includes(params.modeId as SessionModeId)) {
+    if (!isSessionModeId(params.modeId)) {
       throw new Error(
-        `Invalid modeId: ${params.modeId}. Valid modes are: ${validModeIds.join(", ")}`
+        `Invalid modeId: ${params.modeId}. Valid modes are: ${SESSION_MODE_IDS.join(", ")}`
       );
     }
-    const newMode = params.modeId as SessionModeId;
+    const newMode = params.modeId;
     session.mode = newMode;
     session.updatedAt = new Date().toISOString();
     this.persistSession(params.sessionId, session);
@@ -745,7 +817,11 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
-      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
+      configOptions: this.configOptionsState(
+        restored.model,
+        restored.thoughtLevel,
+        restored.mode
+      ),
     };
   }
 
@@ -783,7 +859,11 @@ export class GlmAcpAgent implements Agent {
       sessionId: newSessionId,
       models: this.modelsState(forked.model),
       modes: this.modesState(forked.mode),
-      configOptions: this.configOptionsState(forked.model, forked.thoughtLevel),
+      configOptions: this.configOptionsState(
+        forked.model,
+        forked.thoughtLevel,
+        forked.mode
+      ),
     };
   }
 
@@ -815,7 +895,11 @@ export class GlmAcpAgent implements Agent {
     return {
       models: this.modelsState(persisted.model),
       modes: this.modesState(persisted.mode),
-      configOptions: this.configOptionsState(restored.model, restored.thoughtLevel),
+      configOptions: this.configOptionsState(
+        restored.model,
+        restored.thoughtLevel,
+        restored.mode
+      ),
     };
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -575,6 +575,20 @@ export class GlmAcpAgent implements Agent {
         currentModeId: newMode,
       },
     });
+    // Config options are a separate state channel: re-publish them so a mode
+    // dropdown (category "mode") doesn't keep a stale currentValue when the
+    // mode changes through the classic ACP path.
+    await safeSessionUpdate(this.connection, {
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: this.configOptionsState(
+          session.model,
+          session.thoughtLevel,
+          session.mode
+        ),
+      },
+    });
     return {};
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -372,38 +372,49 @@ export class GlmAcpAgent implements Agent {
     if (!session) {
       throw new Error(`Session not found: ${params.sessionId}`);
     }
+    await this.applySessionModel(params.sessionId, session, params.modelId);
+    return {};
+  }
+
+  /**
+   * Switch a session to a new model id — shared by `session/set_model` and the
+   * `model` config option. Uncatalogued ids are allowed on purpose (Z.AI may
+   * offer models we haven't catalogued), but log a stderr hint. Persists,
+   * notifies clients via `session_info_update`, and pushes a
+   * `config_option_update` because the valid thought levels may differ between
+   * models (e.g. switching from 5.3 to 4.7 drops the effort ladder).
+   */
+  private async applySessionModel(
+    sessionId: string,
+    session: SessionState,
+    modelId: string
+  ): Promise<void> {
     const available = getAvailableModels();
-    const known = available.find((m) => m.modelId === params.modelId);
+    const known = available.find((m) => m.modelId === modelId);
     if (!known) {
-      // Allow the caller to pick any model id even if not in the curated list
-      // (Z.AI may offer models we haven't catalogued), but log a stderr hint.
       process.stderr.write(
-        `[glm-acp-agent] warning: model "${params.modelId}" is not in the advertised list; using as-is.\n`
+        `[glm-acp-agent] warning: model "${modelId}" is not in the advertised list; using as-is.\n`
       );
     }
-    session.model = params.modelId;
-    // The valid thought levels differ per model (e.g. 5.3 offers the full
-    // effort ladder while others only offer none/on), so clamp the current
-    // level to what the new model supports.
-    session.thoughtLevel = resolveThoughtLevel(params.modelId, session.thoughtLevel);
+    session.model = modelId;
+    // The valid thought levels differ per model, so clamp the current level to
+    // what the new model supports.
+    session.thoughtLevel = resolveThoughtLevel(modelId, session.thoughtLevel);
     session.updatedAt = new Date().toISOString();
     // Persist immediately so a fork/reload before the next prompt doesn't
-    // resurrect the previous model or thought level (matches setSessionConfigOption).
-    this.persistSession(params.sessionId, session);
+    // resurrect the previous model or thought level.
+    this.persistSession(sessionId, session);
     // Notify clients so any UI that displays the active model refreshes
     // immediately, instead of waiting for the next prompt to complete.
     await safeSessionUpdate(this.connection, {
-      sessionId: params.sessionId,
+      sessionId,
       update: {
         sessionUpdate: "session_info_update",
         updatedAt: session.updatedAt,
       },
     });
-    // Push updated thought_level options — the set of valid levels may
-    // differ between models (e.g. switching from 5.3 to 4.7 drops the
-    // effort ladder).
     await safeSessionUpdate(this.connection, {
-      sessionId: params.sessionId,
+      sessionId,
       update: {
         sessionUpdate: "config_option_update",
         configOptions: this.configOptionsState(
@@ -413,7 +424,6 @@ export class GlmAcpAgent implements Agent {
         ),
       },
     });
-    return {};
   }
 
   /**
@@ -439,12 +449,7 @@ export class GlmAcpAgent implements Agent {
     currentMode: SessionModeId
   ): SessionConfigOption[] {
     const levels = getThoughtLevels(model);
-    const models = getAvailableModels();
-    // A restored session can be pinned to a de-listed id (see modelsState);
-    // keep it selectable so the dropdown represents the model actually in use.
-    const modelOptions = models.some((m) => m.modelId === model)
-      ? models
-      : [...models, { modelId: model, name: model }];
+    const modelOptions = availableModelsWith(model);
     return [
       {
         id: "thought_level",
@@ -524,41 +529,7 @@ export class GlmAcpAgent implements Agent {
       if (typeof params.value !== "string" || params.value.length === 0) {
         throw new Error(`Invalid model value: ${String(params.value)}`);
       }
-      const known = getAvailableModels().find((m) => m.modelId === params.value);
-      if (!known) {
-        process.stderr.write(
-          `[glm-acp-agent] warning: model "${params.value}" is not in the advertised list; using as-is.\n`
-        );
-      }
-      session.model = params.value;
-      // The valid thought levels differ per model (the 5.3 family offers the
-      // full effort ladder, others only none/on), so clamp like set_model.
-      session.thoughtLevel = resolveThoughtLevel(params.value, session.thoughtLevel);
-      session.updatedAt = new Date().toISOString();
-      this.persistSession(params.sessionId, session);
-      // Mirror unstable_setSessionModel so clients tracking the ACP model
-      // state (rather than the config option) stay in sync with the dropdown.
-      await safeSessionUpdate(this.connection, {
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "session_info_update",
-          updatedAt: session.updatedAt,
-        },
-      });
-      // The thought-level set may have changed with the model — push the
-      // updated config options so the effort dropdown doesn't keep showing
-      // a level the new model doesn't offer.
-      await safeSessionUpdate(this.connection, {
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "config_option_update",
-          configOptions: this.configOptionsState(
-            session.model,
-            session.thoughtLevel,
-            session.mode
-          ),
-        },
-      });
+      await this.applySessionModel(params.sessionId, session, params.value);
       return {
         configOptions: this.configOptionsState(
           session.model,
@@ -605,14 +576,7 @@ export class GlmAcpAgent implements Agent {
     availableModels: ModelInfo[];
     currentModelId: string;
   } {
-    const available = getAvailableModels();
-    if (available.some((m) => m.modelId === currentModelId)) {
-      return { availableModels: available, currentModelId };
-    }
-    return {
-      availableModels: [...available, { modelId: currentModelId, name: currentModelId }],
-      currentModelId,
-    };
+    return { availableModels: availableModelsWith(currentModelId), currentModelId };
   }
 
   /** Build the SessionModeState we advertise on session create/load/resume/fork. */
@@ -1435,6 +1399,20 @@ function stringifyUserMessage(content: unknown): string {
     })
     .filter((text) => text.length > 0)
     .join("\n");
+}
+
+/**
+ * The advertised model list, always including `currentModelId` — a session
+ * restored from disk can be pinned to a de-listed id (`glm-5.2` was the
+ * previous default), and `ACP_GLM_MODEL` / `session/set_model` / the `model`
+ * config option all accept uncatalogued ids on purpose. Dropping the active id
+ * from the list would leave pickers unable to represent the selection in use.
+ */
+function availableModelsWith(currentModelId: string): ModelInfo[] {
+  const available = getAvailableModels();
+  return available.some((m) => m.modelId === currentModelId)
+    ? available
+    : [...available, { modelId: currentModelId, name: currentModelId }];
 }
 
 /**

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -418,7 +418,7 @@ export class GlmAcpAgent implements Agent {
 
   /**
    * Build the SessionConfigOptions we advertise: `thought_level` (levels depend
-   * on the model, see {@link getThoughtLevels}) and `mode`.
+   * on the model, see {@link getThoughtLevels}), `mode`, and `model`.
    *
    * The `mode` option mirrors {@link modesState} as a `category: "mode"`
    * selector. Clients that render config options (Zed) suppress the legacy mode
@@ -426,6 +426,12 @@ export class GlmAcpAgent implements Agent {
    * otherwise be unreachable from their UI. `currentMode` is always read from
    * the live session state, so a mode set through `session/set_mode` shows up
    * here too.
+   *
+   * The `model` option mirrors {@link modelsState} as a `category: "model"`
+   * selector for the same reason: clients that render config options suppress
+   * the legacy model selector too, so the active model would otherwise be
+   * unreachable. `currentModel` is read from the live session state, so a model
+   * set through `session/set_model` shows up here as well.
    */
   private configOptionsState(
     model: string,
@@ -433,6 +439,12 @@ export class GlmAcpAgent implements Agent {
     currentMode: SessionModeId
   ): SessionConfigOption[] {
     const levels = getThoughtLevels(model);
+    const models = getAvailableModels();
+    // A restored session can be pinned to a de-listed id (see modelsState);
+    // keep it selectable so the dropdown represents the model actually in use.
+    const modelOptions = models.some((m) => m.modelId === model)
+      ? models
+      : [...models, { modelId: model, name: model }];
     return [
       {
         id: "thought_level",
@@ -456,6 +468,18 @@ export class GlmAcpAgent implements Agent {
         options: SESSION_MODES.map((mode) => ({
           value: mode.id,
           name: mode.name,
+        })),
+      },
+      {
+        id: "model",
+        name: "Model",
+        description: "GLM model for this session",
+        category: "model",
+        type: "select" as const,
+        currentValue: model,
+        options: modelOptions.map((m) => ({
+          value: m.modelId,
+          name: m.name,
         })),
       },
     ];
@@ -483,6 +507,56 @@ export class GlmAcpAgent implements Agent {
         update: {
           sessionUpdate: "current_mode_update",
           currentModeId: session.mode,
+        },
+      });
+      return {
+        configOptions: this.configOptionsState(
+          session.model,
+          session.thoughtLevel,
+          session.mode
+        ),
+      };
+    }
+    if (params.configId === "model") {
+      // Same reject-don't-coerce policy as thought_level below, but only for
+      // values that aren't model ids at all. Uncatalogued ids are allowed on
+      // purpose, mirroring unstable_setSessionModel / ACP_GLM_MODEL.
+      if (typeof params.value !== "string" || params.value.length === 0) {
+        throw new Error(`Invalid model value: ${String(params.value)}`);
+      }
+      const known = getAvailableModels().find((m) => m.modelId === params.value);
+      if (!known) {
+        process.stderr.write(
+          `[glm-acp-agent] warning: model "${params.value}" is not in the advertised list; using as-is.\n`
+        );
+      }
+      session.model = params.value;
+      // The valid thought levels differ per model (the 5.3 family offers the
+      // full effort ladder, others only none/on), so clamp like set_model.
+      session.thoughtLevel = resolveThoughtLevel(params.value, session.thoughtLevel);
+      session.updatedAt = new Date().toISOString();
+      this.persistSession(params.sessionId, session);
+      // Mirror unstable_setSessionModel so clients tracking the ACP model
+      // state (rather than the config option) stay in sync with the dropdown.
+      await safeSessionUpdate(this.connection, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "session_info_update",
+          updatedAt: session.updatedAt,
+        },
+      });
+      // The thought-level set may have changed with the model — push the
+      // updated config options so the effort dropdown doesn't keep showing
+      // a level the new model doesn't offer.
+      await safeSessionUpdate(this.connection, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "config_option_update",
+          configOptions: this.configOptionsState(
+            session.model,
+            session.thoughtLevel,
+            session.mode
+          ),
         },
       });
       return {

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -976,6 +976,128 @@ test("switching model updates thought_level options via config_option_update", a
   assert.deepEqual(values, ["none", "on"]);
 });
 
+// ---------------------------------------------------------------------------
+// Session mode as a config option (category: "mode")
+// ---------------------------------------------------------------------------
+
+test("newSession advertises the session mode as a config option next to thought_level", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  assert.ok(result.configOptions, "configOptions should be present");
+  // Both selectors must ship together — clients that render config options
+  // suppress the legacy mode selector entirely.
+  assert.ok(
+    result.configOptions!.some((o) => o.id === "thought_level"),
+    "thought_level option should still exist"
+  );
+
+  const mode = result.configOptions!.find((o) => o.id === "mode");
+  assert.ok(mode, "mode option should exist");
+  assert.equal(mode!.category, "mode");
+  assert.equal(mode!.type, "select");
+  assert.equal(mode!.name, "Mode");
+  assert.equal(mode!.currentValue, "default");
+  const options = (mode as { options: Array<{ value: string; name: string }> }).options;
+  assert.deepEqual(
+    options.map((o) => o.value),
+    ["default", "accept_edits", "bypass_permissions"]
+  );
+  // Names must match the ACP `modes` state so both surfaces read the same.
+  assert.deepEqual(
+    options.map((o) => o.name),
+    result.modes!.availableModes.map((m) => m.name)
+  );
+});
+
+test("setSessionConfigOption('mode') switches the mode, persists it, and emits current_mode_update", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+    const before = conn.updates.length;
+    const result = await agent.setSessionConfigOption({
+      sessionId,
+      configId: "mode",
+      value: "accept_edits",
+    });
+
+    const mode = result.configOptions.find((o) => o.id === "mode");
+    assert.equal(mode!.currentValue, "accept_edits");
+    // The other option is returned unchanged.
+    const tl = result.configOptions.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "max");
+
+    assert.equal(store.load(sessionId)?.mode, "accept_edits");
+
+    const modeUpdates = conn.updates.slice(before).filter(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "current_mode_update"
+    );
+    assert.equal(modeUpdates.length, 1);
+    assert.equal(
+      (modeUpdates[0] as { update: { currentModeId?: string } }).update.currentModeId,
+      "accept_edits"
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("setSessionConfigOption rejects values that aren't a session mode", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "mode", value: "bogus" }),
+    /Invalid mode value: bogus/
+  );
+  // The rejected value must not have leaked into the session state.
+  const after = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "high",
+  });
+  assert.equal(after.configOptions.find((o) => o.id === "mode")!.currentValue, "default");
+});
+
+test("a mode set via session/set_mode shows up in the next configOptions payload", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // The classic ACP path and the config option share `session.mode`, so a
+  // set_mode call must not leave the dropdown showing a stale value.
+  await agent.setSessionMode({ sessionId, modeId: "bypass_permissions" });
+
+  const viaConfig = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "low",
+  });
+  assert.equal(
+    viaConfig.configOptions.find((o) => o.id === "mode")!.currentValue,
+    "bypass_permissions"
+  );
+
+  // …and on the push we emit when the model changes.
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-4.7" });
+  const configUpdates = conn.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+  );
+  const pushed = (configUpdates.at(-1)!.update as {
+    configOptions: Array<{ id: string; currentValue: string }>;
+  }).configOptions;
+  assert.equal(pushed.find((o) => o.id === "mode")!.currentValue, "bypass_permissions");
+});
+
 test("thoughtLevel is forwarded to streamChat as reasoningEffort", async () => {
   const conn = createConnectionStub();
   let seenEffort: string | undefined;

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1067,6 +1067,32 @@ test("setSessionConfigOption rejects values that aren't a session mode", async (
   assert.equal(after.configOptions.find((o) => o.id === "mode")!.currentValue, "default");
 });
 
+test("setSessionMode immediately pushes a config_option_update with the new mode", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  const updatesBefore = conn.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+  ).length;
+
+  await agent.setSessionMode({ sessionId, modeId: "bypass_permissions" });
+
+  const configUpdates = conn.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+  );
+  assert.equal(
+    configUpdates.length,
+    updatesBefore + 1,
+    "setSessionMode should emit exactly one config_option_update"
+  );
+  const pushed = (configUpdates.at(-1)!.update as {
+    configOptions: Array<{ id: string; currentValue: string }>;
+  }).configOptions;
+  assert.equal(pushed.find((o) => o.id === "mode")!.currentValue, "bypass_permissions");
+});
+
 test("a mode set via session/set_mode shows up in the next configOptions payload", async () => {
   const conn = createConnectionStub();
   const agent = new GlmAcpAgent(conn as never, { sessionStore: null });

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -977,6 +977,139 @@ test("switching model updates thought_level options via config_option_update", a
 });
 
 // ---------------------------------------------------------------------------
+// Model as a config option (category: "model")
+// ---------------------------------------------------------------------------
+
+test("newSession advertises the model as a config option next to thought_level and mode", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const result = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  assert.ok(result.configOptions, "configOptions should be present");
+  const model = result.configOptions!.find((o) => o.id === "model");
+  assert.ok(model, "model option should exist");
+  assert.equal(model!.category, "model");
+  assert.equal(model!.type, "select");
+  assert.equal(model!.name, "Model");
+  // Default model is glm-5.3.
+  assert.equal(model!.currentValue, "glm-5.3");
+  const options = (model as { options: Array<{ value: string; name: string }> }).options;
+  assert.deepEqual(
+    options.map((o) => o.value),
+    ["glm-5.3", "glm-5-turbo", "glm-4.7"]
+  );
+  // Names must match the models state so both surfaces read the same.
+  assert.deepEqual(
+    options.map((o) => o.name),
+    result.models!.availableModels.map((m) => m.name)
+  );
+});
+
+test("setSessionConfigOption('model') switches the model, re-clamps thought level, and pushes updates", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+    const before = conn.updates.length;
+    const result = await agent.setSessionConfigOption({
+      sessionId,
+      configId: "model",
+      value: "glm-4.7",
+    });
+
+    const model = result.configOptions.find((o) => o.id === "model");
+    assert.equal(model!.currentValue, "glm-4.7");
+    // 5.3-family "max" is invalid on 4.7 — must have been clamped to "on".
+    const tl = result.configOptions.find((o) => o.id === "thought_level");
+    assert.equal(tl!.currentValue, "on");
+    // The other options are returned unchanged.
+    const mode = result.configOptions.find((o) => o.id === "mode");
+    assert.equal(mode!.currentValue, "default");
+
+    assert.equal(store.load(sessionId)?.model, "glm-4.7");
+
+    // Exactly one config_option_update push with the new thought-level set.
+    const configUpdates = conn.updates.slice(before).filter(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "config_option_update"
+    );
+    assert.equal(configUpdates.length, 1);
+    const pushed = (configUpdates[0] as { update: { configOptions: Array<{ id: string; currentValue: string }> } }).update.configOptions;
+    assert.equal(pushed.find((o) => o.id === "model")!.currentValue, "glm-4.7");
+    assert.equal(pushed.find((o) => o.id === "thought_level")!.currentValue, "on");
+  } finally {
+    cleanup();
+  }
+});
+
+test("setSessionConfigOption rejects values that aren't a model id at all", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  await assert.rejects(
+    agent.setSessionConfigOption({ sessionId, configId: "model", value: 42 as unknown as string }),
+    /Invalid model value/
+  );
+  // The rejected value must not have leaked into the session state.
+  const after = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "high",
+  });
+  assert.equal(after.configOptions.find((o) => o.id === "model")!.currentValue, "glm-5.3");
+});
+
+test("a model set via session/set_model shows up in the next configOptions payload", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // The classic ACP path and the config option share `session.model`, so a
+  // set_model call must not leave the dropdown showing a stale value.
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5-turbo" });
+
+  const viaConfig = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "low",
+  });
+  assert.equal(
+    viaConfig.configOptions.find((o) => o.id === "model")!.currentValue,
+    "glm-5-turbo"
+  );
+});
+
+test("a session pinned to a de-listed model keeps it selectable in the model dropdown", async () => {
+  const conn = createConnectionStub();
+  const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+
+  // glm-5.2 is de-listed (the endpoint routes it to glm-5.3), but a restored
+  // session can still be pinned to it.
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5.2" });
+
+  const viaConfig = await agent.setSessionConfigOption({
+    sessionId,
+    configId: "thought_level",
+    value: "medium",
+  });
+  const model = viaConfig.configOptions.find((o) => o.id === "model")!;
+  assert.equal(model.currentValue, "glm-5.2");
+  const options = (model as unknown as { options: Array<{ value: string }> }).options;
+  assert.ok(
+    options.some((o) => o.value === "glm-5.2"),
+    "de-listed id stays selectable so the dropdown represents the model in use"
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Session mode as a config option (category: "mode")
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Zed suppresses its legacy mode/model selectors once an agent advertises `configOptions`, so with only `thought_level` advertised the session mode was unreachable from the UI (and the model selector was suppressed too). This advertises the session mode and model as additional config options so both render as dropdowns in the prompt bar next to the thinking-effort selector.

Closes #86. Implementation cherry-picked from #87 by @giang17 (verified working in Zed there).

## Key Changes

- Shared `SESSION_MODES` constant used by both the ACP `modes` state and a new `mode`-category select config option (`mode`, `accept_edits`, `bypass_permissions`).
- `setSessionConfigOption("mode")` validates the value, sets and persists `session.mode`, and emits `current_mode_update` — same visible behavior as `setSessionMode`.
- `setSessionMode` now also pushes a `config_option_update` so a mode dropdown never shows a stale value when the mode changes through the classic ACP path.
- New `model`-category config option mirroring `modelsState` (including keeping de-listed ids selectable for restored sessions); `setSessionConfigOption("model")` switches the model, re-clamps the thought level to the new model's valid set, and pushes updated options.
- No session-store schema change: `mode` and `model` are already part of `PersistedSession`.

## Checks

- `npm run lint` — clean
- `npm test` — 212/212 pass (16 new tests)

## Task

https://github.com/stefandevo/glm-acp-agent/issues/86