### PR TITLE
#88 - Make maxTurns configurable (ACP_GLM_MAX_TURNS / --max-turns) and announce the turn limit when hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 
 - **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, `session/list`, `session/load`, `session/fork`, `session/resume`, and `session/set_model`
 - **Streaming** – assistant text and reasoning tokens are forwarded as incremental ACP chunks
-- **Tool calling** – agentic loop with up to 20 turns of GLM function calling
+- **Tool calling** – agentic loop with a configurable cap of GLM function-calling turns (default 20; see `ACP_GLM_MAX_TURNS` / `--max-turns`)
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
 - **Session permission modes** – supports `default`, `accept_edits`, and `bypass_permissions` via `session/set_mode`. Clients like DevFlow can use this to toggle between prompting for every edit, auto-approving edits while prompting for commands, or bypassing permissions entirely.
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The agent reads its configuration from environment variables, plus an optional c
 | `ACP_GLM_AVAILABLE_MODELS` | No | built-in list | Comma-separated list of model ids advertised in `session/set_model` |
 | `ACP_GLM_BASE_URL` | No | `https://api.z.ai/api/coding/paas/v4` | Override the API base URL |
 | `ACP_GLM_MAX_TOKENS` | No | `8192` | Cap on `max_tokens` for each completion |
+| `ACP_GLM_MAX_TURNS` | No | `20` | Max model/tool turns per prompt (also settable via `--max-turns`) |
 | `ACP_GLM_THINKING` | No | auto-detected | Force thinking mode `true` / `false` |
 | `ACP_GLM_SESSION_DIR` | No | `$XDG_STATE_HOME/glm-acp-agent/sessions` | Where session JSON files are persisted |
 | `ACP_GLM_DEBUG` | No | — | Set to `true` or `1` to enable verbose debug logging to stderr (shows model selection, API key resolution, tool calls, and usage stats) |

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_MAX_TURNS } from "./protocol/agent.js";
+
+/**
+ * Parse `--max-turns <n>` (or `--max-turns=<n>`) from CLI args.
+ * Returns `undefined` only when the flag is absent; invalid input selects the
+ * default (20), never `$ACP_GLM_MAX_TURNS` — explicit-but-bad CLI input must
+ * not silently fall through to the env var.
+ */
+export function parseMaxTurnsFlag(argv: string[]): number | undefined {
+  const idx = argv.indexOf("--max-turns");
+  if (idx !== -1) {
+    if (idx + 1 >= argv.length) {
+      process.stderr.write("glm-acp-agent: --max-turns requires a value\n");
+      return DEFAULT_MAX_TURNS;
+    }
+    const parsed = Number(argv[idx + 1]);
+    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
+      return Math.floor(parsed);
+    }
+    process.stderr.write(
+      `glm-acp-agent: ignoring invalid --max-turns "${argv[idx + 1]}"\n`
+    );
+    return DEFAULT_MAX_TURNS;
+  }
+  const eq = argv.find((a) => a.startsWith("--max-turns="));
+  if (eq !== undefined) {
+    const raw = eq.slice("--max-turns=".length);
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
+      return Math.floor(parsed);
+    }
+    process.stderr.write(`glm-acp-agent: ignoring invalid --max-turns "${raw}"\n`);
+    return DEFAULT_MAX_TURNS;
+  }
+  return undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,34 @@
  *   Z_AI_API_KEY      - API key for the Z.AI / Zhipu AI service. If unset,
  *                       falls back to the credentials file written by --setup.
  *   ACP_GLM_MODEL     - (optional) Override the default model (default: glm-5.3)
+ *   ACP_GLM_MAX_TURNS - (optional) Max model/tool turns per prompt (default: 20)
  */
 import { startConnection } from "./protocol/connection.js";
 import { runSetup } from "./setup.js";
 
 const args = process.argv.slice(2);
+
+/** Parse `--max-turns <n>` (or `--max-turns=<n>`) from the CLI args. */
+function parseMaxTurnsFlag(argv: string[]): number | undefined {
+  const idx = argv.indexOf("--max-turns");
+  if (idx !== -1 && idx + 1 < argv.length) {
+    const parsed = Number(argv[idx + 1]);
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+    process.stderr.write(
+      `glm-acp-agent: ignoring invalid --max-turns "${argv[idx + 1]}"\n`
+    );
+    return undefined;
+  }
+  const eq = argv.find((a) => a.startsWith("--max-turns="));
+  if (eq !== undefined) {
+    const parsed = Number(eq.slice("--max-turns=".length));
+    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+    process.stderr.write(
+      `glm-acp-agent: ignoring invalid --max-turns "${eq.slice("--max-turns=".length)}"\n`
+    );
+  }
+  return undefined;
+}
 
 if (args.includes("--setup")) {
   runSetup()
@@ -32,11 +55,13 @@ if (args.includes("--setup")) {
       "Usage:",
       "  glm-acp-agent           Start the ACP stdio loop (run by an ACP client)",
       "  glm-acp-agent --setup   Interactively store your Z.AI API key on disk",
+      "  glm-acp-agent --max-turns <n>  Max model/tool turns per prompt",
       "  glm-acp-agent --help    Show this message",
       "",
       "Environment variables:",
       "  Z_AI_API_KEY                   API key (overrides the stored credentials)",
       "  ACP_GLM_MODEL                  Default model id (e.g. glm-5.3)",
+      "  ACP_GLM_MAX_TURNS              Max model/tool turns per prompt (default 20)",
       "  ACP_GLM_AVAILABLE_MODELS       Comma-separated list of advertised models",
       "  ACP_GLM_BASE_URL               Override the Z.AI API base URL",
       "  ACP_GLM_MAX_TOKENS             Per-call max output tokens (default 8192)",
@@ -49,7 +74,7 @@ if (args.includes("--setup")) {
   );
   process.exit(0);
 } else {
-  const connection = startConnection();
+  const connection = startConnection({ maxTurns: parseMaxTurnsFlag(args) });
 
   // Keep the process alive until the connection closes
   connection.closed

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,45 +13,10 @@
  *   ACP_GLM_MAX_TURNS - (optional) Max model/tool turns per prompt (default: 20)
  */
 import { startConnection } from "./protocol/connection.js";
-import { DEFAULT_MAX_TURNS } from "./protocol/agent.js";
+import { parseMaxTurnsFlag } from "./cli-args.js";
 import { runSetup } from "./setup.js";
 
 const args = process.argv.slice(2);
-
-/**
- * Parse `--max-turns <n>` (or `--max-turns=<n>`) from the CLI args.
- * Returns `undefined` only when the flag is absent; invalid input selects the
- * default (20), never `$ACP_GLM_MAX_TURNS` — explicit-but-bad CLI input must
- * not silently fall through to the env var.
- */
-function parseMaxTurnsFlag(argv: string[]): number | undefined {
-  const idx = argv.indexOf("--max-turns");
-  if (idx !== -1) {
-    if (idx + 1 >= argv.length) {
-      process.stderr.write("glm-acp-agent: --max-turns requires a value\n");
-      return DEFAULT_MAX_TURNS;
-    }
-    const parsed = Number(argv[idx + 1]);
-    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
-      return Math.floor(parsed);
-    }
-    process.stderr.write(
-      `glm-acp-agent: ignoring invalid --max-turns "${argv[idx + 1]}"\n`
-    );
-    return DEFAULT_MAX_TURNS;
-  }
-  const eq = argv.find((a) => a.startsWith("--max-turns="));
-  if (eq !== undefined) {
-    const raw = eq.slice("--max-turns=".length);
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
-      return Math.floor(parsed);
-    }
-    process.stderr.write(`glm-acp-agent: ignoring invalid --max-turns "${raw}"\n`);
-    return DEFAULT_MAX_TURNS;
-  }
-  return undefined;
-}
 
 if (args.includes("--setup")) {
   runSetup()

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,11 @@ const args = process.argv.slice(2);
 /** Parse `--max-turns <n>` (or `--max-turns=<n>`) from the CLI args. */
 function parseMaxTurnsFlag(argv: string[]): number | undefined {
   const idx = argv.indexOf("--max-turns");
-  if (idx !== -1 && idx + 1 < argv.length) {
+  if (idx !== -1) {
+    if (idx + 1 >= argv.length) {
+      process.stderr.write("glm-acp-agent: --max-turns requires a value\n");
+      return undefined;
+    }
     const parsed = Number(argv[idx + 1]);
     if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
     process.stderr.write(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,32 +13,42 @@
  *   ACP_GLM_MAX_TURNS - (optional) Max model/tool turns per prompt (default: 20)
  */
 import { startConnection } from "./protocol/connection.js";
+import { DEFAULT_MAX_TURNS } from "./protocol/agent.js";
 import { runSetup } from "./setup.js";
 
 const args = process.argv.slice(2);
 
-/** Parse `--max-turns <n>` (or `--max-turns=<n>`) from the CLI args. */
+/**
+ * Parse `--max-turns <n>` (or `--max-turns=<n>`) from the CLI args.
+ * Returns `undefined` only when the flag is absent; invalid input selects the
+ * default (20), never `$ACP_GLM_MAX_TURNS` — explicit-but-bad CLI input must
+ * not silently fall through to the env var.
+ */
 function parseMaxTurnsFlag(argv: string[]): number | undefined {
   const idx = argv.indexOf("--max-turns");
   if (idx !== -1) {
     if (idx + 1 >= argv.length) {
       process.stderr.write("glm-acp-agent: --max-turns requires a value\n");
-      return undefined;
+      return DEFAULT_MAX_TURNS;
     }
     const parsed = Number(argv[idx + 1]);
-    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
+      return Math.floor(parsed);
+    }
     process.stderr.write(
       `glm-acp-agent: ignoring invalid --max-turns "${argv[idx + 1]}"\n`
     );
-    return undefined;
+    return DEFAULT_MAX_TURNS;
   }
   const eq = argv.find((a) => a.startsWith("--max-turns="));
   if (eq !== undefined) {
-    const parsed = Number(eq.slice("--max-turns=".length));
-    if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
-    process.stderr.write(
-      `glm-acp-agent: ignoring invalid --max-turns "${eq.slice("--max-turns=".length)}"\n`
-    );
+    const raw = eq.slice("--max-turns=".length);
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && Math.floor(parsed) >= 1) {
+      return Math.floor(parsed);
+    }
+    process.stderr.write(`glm-acp-agent: ignoring invalid --max-turns "${raw}"\n`);
+    return DEFAULT_MAX_TURNS;
   }
   return undefined;
 }

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -132,7 +132,10 @@ export interface GlmAcpAgentOptions {
       options?: StreamChatOptions
     ) => AsyncIterable<GlmStreamChunk>;
   };
-  /** Maximum number of model/tool turns per single prompt. Default 20. */
+  /**
+   * Maximum number of model/tool turns per single prompt. Default 20,
+   * overridable via `$ACP_GLM_MAX_TURNS`.
+   */
   maxTurns?: number;
   /**
    * Override the session store (used in tests). When undefined the agent
@@ -157,6 +160,26 @@ export interface GlmAcpAgentOptions {
  * GLM series models (via `GlmClient`), providing a full prompt loop with
  * tool-calling and streaming support.
  */
+const DEFAULT_MAX_TURNS = 20;
+
+/**
+ * Resolve the fallback maxTurns from `$ACP_GLM_MAX_TURNS` when the caller did
+ * not pass an explicit value. Returns `undefined` when unset or invalid (the
+ * constructor then applies the default, and logs a warning on invalid input).
+ */
+function envMaxTurns(): number | undefined {
+  const raw = process.env["ACP_GLM_MAX_TURNS"];
+  if (raw === undefined || raw === "") return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    process.stderr.write(
+      `glm-acp-agent: ignoring invalid ACP_GLM_MAX_TURNS="${raw}"\n`
+    );
+    return undefined;
+  }
+  return Math.floor(parsed);
+}
+
 export class GlmAcpAgent implements Agent {
   private sessions: Map<string, SessionState> = new Map();
   private _glm: NonNullable<GlmAcpAgentOptions["glm"]> | null;
@@ -171,11 +194,11 @@ export class GlmAcpAgent implements Agent {
     options: GlmAcpAgentOptions = {}
   ) {
     this._glm = options.glm ?? null;
-    const candidateMaxTurns = options.maxTurns ?? 20;
+    const candidateMaxTurns = options.maxTurns ?? envMaxTurns() ?? DEFAULT_MAX_TURNS;
     this.maxTurns =
       Number.isFinite(candidateMaxTurns) && candidateMaxTurns > 0
         ? Math.floor(candidateMaxTurns)
-        : 20;
+        : DEFAULT_MAX_TURNS;
     this.sessionStore =
       options.sessionStore === null
         ? null
@@ -1064,7 +1087,18 @@ export class GlmAcpAgent implements Agent {
       // tool results.
     }
 
-    // Reached MAX_TURNS without resolution.
+    // Reached MAX_TURNS without resolution. Tell the user why we stopped —
+    // without this, hitting the cap is indistinguishable from a normal end.
+    await this.connection.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: `\n[stopped: reached the ${this.maxTurns}-turn limit — send a message to continue]`,
+        },
+      },
+    });
     return { stopReason: "max_turn_requests", usage: lastUsage };
   }
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -160,18 +160,20 @@ export interface GlmAcpAgentOptions {
  * GLM series models (via `GlmClient`), providing a full prompt loop with
  * tool-calling and streaming support.
  */
-const DEFAULT_MAX_TURNS = 20;
+export const DEFAULT_MAX_TURNS = 20;
 
 /**
  * Resolve the fallback maxTurns from `$ACP_GLM_MAX_TURNS` when the caller did
  * not pass an explicit value. Returns `undefined` when unset or invalid (the
  * constructor then applies the default, and logs a warning on invalid input).
+ * Values that floor below 1 (e.g. 0.5) count as invalid — flooring them to 0
+ * would just be silently replaced by the default in the constructor.
  */
 function envMaxTurns(): number | undefined {
   const raw = process.env["ACP_GLM_MAX_TURNS"];
   if (raw === undefined || raw === "") return undefined;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (!Number.isFinite(parsed) || Math.floor(parsed) < 1) {
     process.stderr.write(
       `glm-acp-agent: ignoring invalid ACP_GLM_MAX_TURNS="${raw}"\n`
     );
@@ -195,10 +197,9 @@ export class GlmAcpAgent implements Agent {
   ) {
     this._glm = options.glm ?? null;
     const candidateMaxTurns = options.maxTurns ?? envMaxTurns() ?? DEFAULT_MAX_TURNS;
+    const floored = Math.floor(candidateMaxTurns);
     this.maxTurns =
-      Number.isFinite(candidateMaxTurns) && candidateMaxTurns > 0
-        ? Math.floor(candidateMaxTurns)
-        : DEFAULT_MAX_TURNS;
+      Number.isFinite(floored) && floored >= 1 ? floored : DEFAULT_MAX_TURNS;
     this.sessionStore =
       options.sessionStore === null
         ? null

--- a/src/protocol/connection.ts
+++ b/src/protocol/connection.ts
@@ -1,6 +1,6 @@
 import { Readable, Writable } from "node:stream";
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
-import { GlmAcpAgent } from "./agent.js";
+import { GlmAcpAgent, type GlmAcpAgentOptions } from "./agent.js";
 
 /**
  * Sets up the ACP stdio connection and starts the agent.
@@ -8,7 +8,9 @@ import { GlmAcpAgent } from "./agent.js";
  * Uses `ndJsonStream` for newline-delimited JSON transport over stdin/stdout,
  * as specified in the ACP SDK documentation.
  */
-export function startConnection(): AgentSideConnection {
+export function startConnection(
+  agentOptions: GlmAcpAgentOptions = {}
+): AgentSideConnection {
   // Convert Node.js streams to Web Streams API
   const output = Writable.toWeb(process.stdout) as WritableStream<Uint8Array>;
   const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
@@ -16,7 +18,7 @@ export function startConnection(): AgentSideConnection {
   const stream = ndJsonStream(output, input);
 
   const connection = new AgentSideConnection(
-    (conn) => new GlmAcpAgent(conn),
+    (conn) => new GlmAcpAgent(conn, agentOptions),
     stream
   );
 

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1273,6 +1273,15 @@ test("prompt loop returns max_turn_requests after exhausting tool turns", async 
     prompt: [{ type: "text", text: "do things" }],
   });
   assert.equal(result.stopReason, "max_turn_requests");
+
+  // The loop emits a notice so the user can tell "hit the cap" from "done".
+  const notice = (conn as unknown as ConnectionStub).updates.some(
+    (u) =>
+      (u as { update?: { content?: { text?: string } } }).update?.content?.text?.includes(
+        "reached the 2-turn limit"
+      )
+  );
+  assert.equal(notice, true);
 });
 
 test("prompt cancellation returns cancelled stop reason", async () => {
@@ -1779,6 +1788,30 @@ test("invalid maxTurns falls back to the default", async () => {
   for (const bad of [0, -1, NaN, Number.POSITIVE_INFINITY]) {
     const agent = new GlmAcpAgent(conn as never, { glm: { ...glm }, maxTurns: bad, sessionStore: null });
     assert.equal((agent as unknown as { maxTurns: number }).maxTurns, 20);
+  }
+});
+
+test("maxTurns falls back to $ACP_GLM_MAX_TURNS and the default", async () => {
+  const conn = createConnectionStub();
+  const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
+
+  const prev = process.env["ACP_GLM_MAX_TURNS"];
+  try {
+    process.env["ACP_GLM_MAX_TURNS"] = "7";
+    const fromEnv = new GlmAcpAgent(conn as never, { glm: { ...glm }, sessionStore: null });
+    assert.equal((fromEnv as unknown as { maxTurns: number }).maxTurns, 7);
+
+    // An explicit option wins over the env var.
+    const explicit = new GlmAcpAgent(conn as never, { glm: { ...glm }, maxTurns: 3, sessionStore: null });
+    assert.equal((explicit as unknown as { maxTurns: number }).maxTurns, 3);
+
+    // Invalid env values are ignored (default applies).
+    process.env["ACP_GLM_MAX_TURNS"] = "not-a-number";
+    const invalid = new GlmAcpAgent(conn as never, { glm: { ...glm }, sessionStore: null });
+    assert.equal((invalid as unknown as { maxTurns: number }).maxTurns, 20);
+  } finally {
+    if (prev === undefined) delete process.env["ACP_GLM_MAX_TURNS"];
+    else process.env["ACP_GLM_MAX_TURNS"] = prev;
   }
 });
 

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1785,7 +1785,7 @@ test("invalid maxTurns falls back to the default", async () => {
   const conn = createConnectionStub();
   const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
 
-  for (const bad of [0, -1, NaN, Number.POSITIVE_INFINITY]) {
+  for (const bad of [0, -1, NaN, Number.POSITIVE_INFINITY, 0.5]) {
     const agent = new GlmAcpAgent(conn as never, { glm: { ...glm }, maxTurns: bad, sessionStore: null });
     assert.equal((agent as unknown as { maxTurns: number }).maxTurns, 20);
   }
@@ -1809,6 +1809,11 @@ test("maxTurns falls back to $ACP_GLM_MAX_TURNS and the default", async () => {
     process.env["ACP_GLM_MAX_TURNS"] = "not-a-number";
     const invalid = new GlmAcpAgent(conn as never, { glm: { ...glm }, sessionStore: null });
     assert.equal((invalid as unknown as { maxTurns: number }).maxTurns, 20);
+
+    // Fractional values that floor below 1 are invalid, not silently floored.
+    process.env["ACP_GLM_MAX_TURNS"] = "0.5";
+    const fractional = new GlmAcpAgent(conn as never, { glm: { ...glm }, sessionStore: null });
+    assert.equal((fractional as unknown as { maxTurns: number }).maxTurns, 20);
   } finally {
     if (prev === undefined) delete process.env["ACP_GLM_MAX_TURNS"];
     else process.env["ACP_GLM_MAX_TURNS"] = prev;

--- a/src/tests/cli-args.test.ts
+++ b/src/tests/cli-args.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseMaxTurnsFlag } from "../cli-args.js";
+
+/** Run the parser with stderr capture; returns [result, warnings]. */
+function parse(argv: string[]): [number | undefined, string[]] {
+  const warnings: string[] = [];
+  const original = process.stderr.write;
+  process.stderr.write = (chunk: unknown) => {
+    warnings.push(String(chunk));
+    return true;
+  };
+  try {
+    return [parseMaxTurnsFlag(argv), warnings];
+  } finally {
+    process.stderr.write = original;
+  }
+}
+
+test("--max-turns <n> space form parses a valid integer", () => {
+  const [result, warnings] = parse(["--max-turns", "150"]);
+  assert.equal(result, 150);
+  assert.equal(warnings.length, 0);
+});
+
+test("--max-turns=<n> equals form parses a valid integer", () => {
+  const [result, warnings] = parse(["--max-turns=7"]);
+  assert.equal(result, 7);
+  assert.equal(warnings.length, 0);
+});
+
+test("--max-turns floors a valid fraction to a whole turn count", () => {
+  const [result, warnings] = parse(["--max-turns", "2.9"]);
+  assert.equal(result, 2);
+  assert.equal(warnings.length, 0);
+});
+
+test("absent flag returns undefined so the env var can apply", () => {
+  const [result, warnings] = parse(["--setup"]);
+  assert.equal(result, undefined);
+  assert.equal(warnings.length, 0);
+});
+
+test("invalid value warns and selects the default, not undefined", () => {
+  for (const bad of ["nope", "-3", "0", "0.5"]) {
+    const [result, warnings] = parse(["--max-turns", bad]);
+    assert.equal(result, 20, `value ${bad}`);
+    assert.match(warnings.join(""), /ignoring invalid --max-turns/);
+  }
+});
+
+test("invalid value in equals form warns and selects the default", () => {
+  const [result, warnings] = parse(["--max-turns=banana"]);
+  assert.equal(result, 20);
+  assert.match(warnings.join(""), /ignoring invalid --max-turns/);
+});
+
+test("valueless flag warns and selects the default", () => {
+  const [result, warnings] = parse(["--setup", "--max-turns"]);
+  assert.equal(result, 20);
+  assert.match(warnings.join(""), /--max-turns requires a value/);
+});


### PR DESCRIPTION
## Purpose

This feature makes the agent's prompt-loop turn ceiling configurable, fixing #88. Previously `maxTurns` was hard-coded to 20 unless the agent was constructed programmatically (test-only), so long research/review tasks stopped silently mid-run with `stopReason: "max_turn_requests"` and no way for the user to tell a cap from a normal finish.

## Key Changes

- `maxTurns` resolution order is now: explicit constructor option → `--max-turns <n>` CLI flag → `$ACP_GLM_MAX_TURNS` env var → default 20
- Invalid values (non-numeric, ≤ 0) and a valueless `--max-turns` flag warn on stderr and fall back to the default instead of being silently ignored
- `startConnection()` accepts `GlmAcpAgentOptions` and forwards them to the agent, so the CLI can configure the loop
- When the loop exits on `max_turn_requests`, an `agent_message_chunk` notice is emitted ("stopped: reached the N-turn limit — send a message to continue") so clients can distinguish hitting the cap from a normal `end_turn`
- `--help`, the README env-var table, and the entry-point doc comment document the new knobs

## Checks

- [x] Type-check / build passes (`tsc`)
- [x] Tests pass (203/203)
- [x] Lint passes (`eslint src/**`)
- [x] Changes have been tested locally

## Task

[#88](https://github.com/stefandevo/glm-acp-agent/issues/88)