### PR TITLE
fix: make Vision MCP startup reliable on Windows

### DIFF
--- a/src/tests/vision-mcp-client.test.ts
+++ b/src/tests/vision-mcp-client.test.ts
@@ -9,11 +9,19 @@ interface FakeChild extends EventEmitter {
   stdout: Readable;
   stderr: Readable;
   pid: number;
+  exitCode: number | null;
   kill: (signal?: string) => boolean;
 }
 
-function makeFakeChild(): { child: FakeChild; written: string[]; pushStdout: (line: string) => void } {
+function makeFakeChild(): {
+  child: FakeChild;
+  written: string[];
+  pushStdout: (line: string) => void;
+  pushStderr: (line: string) => void;
+  getKillCount: () => number;
+} {
   const written: string[] = [];
+  let killCount = 0;
   const stdin = new Writable({
     write(chunk, _enc, cb) {
       written.push(chunk.toString("utf8"));
@@ -27,10 +35,15 @@ function makeFakeChild(): { child: FakeChild; written: string[]; pushStdout: (li
     stdout,
     stderr,
     pid: 4242,
-    kill: () => true,
+    exitCode: null,
+    kill: () => {
+      killCount += 1;
+      return true;
+    },
   }) as FakeChild;
   const pushStdout = (line: string) => stdout.push(line);
-  return { child, written, pushStdout };
+  const pushStderr = (line: string) => stderr.push(line);
+  return { child, written, pushStdout, pushStderr, getKillCount: () => killCount };
 }
 
 test("StdioVisionMcpClient initializes once and forwards tools/call", async () => {
@@ -107,6 +120,191 @@ test("StdioVisionMcpClient explains a missing npx as an actionable error", async
     () => client.callTool("image_analysis", { image_source: "x" }),
     /npx.*not found/i
   );
+});
+
+test("StdioVisionMcpClient rejects an asynchronous spawn error instead of hanging", async () => {
+  const { child } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+  const callPromise = client.callTool("image_analysis", { image_source: "x" });
+
+  await new Promise((r) => setImmediate(r));
+  child.emit("error", Object.assign(new Error("spawn npx ENOENT"), { code: "ENOENT" }));
+
+  await assert.rejects(callPromise, /could not launch npx/i);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient times out initialization and terminates the child", async () => {
+  const { child, getKillCount } = makeFakeChild();
+  const client = new StdioVisionMcpClient({
+    apiKey: "k",
+    spawn: () => child as never,
+    initializationTimeoutMs: 50,
+  });
+
+  await assert.rejects(
+    () => client.callTool("image_analysis", { image_source: "x" }),
+    /timed out after \d+ms/i,
+  );
+  assert.equal(getKillCount(), 1);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient aborts initialization and terminates the child", async () => {
+  const { child, getKillCount } = makeFakeChild();
+  const controller = new AbortController();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+  const callPromise = client.callTool("image_analysis", { image_source: "x" }, controller.signal);
+
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+
+  await assert.rejects(callPromise, /Vision MCP call cancelled/i);
+  assert.equal(getKillCount(), 1);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient keeps shared initialization alive for another caller", async () => {
+  const { child, written, pushStdout, getKillCount } = makeFakeChild();
+  const controller = new AbortController();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+  const cancelledCall = client.callTool("image_analysis", { image_source: "cancelled" }, controller.signal);
+  const survivingCall = client.callTool("image_analysis", { image_source: "surviving" });
+
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+  await assert.rejects(cancelledCall, /Vision MCP call cancelled/i);
+  assert.equal(getKillCount(), 0);
+
+  const initBody = JSON.parse(written[0]?.trim() ?? "{}") as { id: number };
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: initBody.id, result: { protocolVersion: "2025-06-18" } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  const toolsListBody = JSON.parse(written[2]?.trim() ?? "{}") as { id: number };
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: toolsListBody.id, result: { tools: [{ name: "image_analysis" }] } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  const callBody = JSON.parse(written[3]?.trim() ?? "{}") as { id: number; params: { arguments: { image_source: string } } };
+  assert.equal(callBody.params.arguments.image_source, "surviving");
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: callBody.id, result: { content: [{ type: "text", text: "ok" }] } }) + "\n");
+
+  await assert.doesNotReject(survivingCall);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient does not kill an initialized server when a caller aborts", async () => {
+  const { child, written, pushStdout, getKillCount } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey: "k", spawn: () => child as never });
+  const firstCall = client.callTool("image_analysis", { image_source: "first" });
+
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18" } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { tools: [{ name: "image_analysis" }] } }) + "\n");
+  await new Promise((r) => setImmediate(r));
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: 3, result: { content: [{ type: "text", text: "first ok" }] } }) + "\n");
+  await assert.doesNotReject(firstCall);
+
+  const controller = new AbortController();
+  const cancelledCall = client.callTool("image_analysis", { image_source: "cancelled" }, controller.signal);
+  controller.abort();
+  await assert.rejects(cancelledCall, /Vision MCP call cancelled|aborted/i);
+  assert.equal(getKillCount(), 0);
+
+  const survivingCall = client.callTool("image_analysis", { image_source: "surviving" });
+  await new Promise((r) => setImmediate(r));
+  const callBody = JSON.parse(written.at(-1)?.trim() ?? "{}") as { id: number; params: { arguments: { image_source: string } } };
+  assert.equal(callBody.params.arguments.image_source, "surviving");
+  pushStdout(JSON.stringify({ jsonrpc: "2.0", id: callBody.id, result: { content: [{ type: "text", text: "still ok" }] } }) + "\n");
+  await assert.doesNotReject(survivingCall);
+
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient launches npx through cmd.exe on Windows", async () => {
+  const { child } = makeFakeChild();
+  let command = "";
+  let args: string[] = [];
+  let windowsHide = false;
+  const client = new StdioVisionMcpClient({
+    apiKey: "k",
+    platform: "win32",
+    comSpec: "C:\\Windows\\System32\\cmd.exe",
+    spawn: (capturedCommand, capturedArgs, options) => {
+      command = capturedCommand;
+      args = capturedArgs;
+      windowsHide = options.windowsHide === true;
+      return child as never;
+    },
+  });
+  const callPromise = client.callTool("image_analysis", { image_source: "x" });
+
+  await new Promise((r) => setImmediate(r));
+  child.emit("error", new Error("test stop"));
+  await assert.rejects(callPromise, /test stop/i);
+
+  assert.equal(command, "C:\\Windows\\System32\\cmd.exe");
+  assert.deepEqual(args.slice(0, 5), ["/d", "/s", "/c", "npx", "-y"]);
+  assert.equal(windowsHide, true);
+  await client.dispose();
+});
+
+test("StdioVisionMcpClient rejects unsafe Windows package specs before spawning", async () => {
+  let spawned = false;
+  const client = new StdioVisionMcpClient({
+    apiKey: "k",
+    platform: "win32",
+    packageSpec: "@z_ai/mcp-server@latest & echo injected",
+    spawn: () => {
+      spawned = true;
+      return makeFakeChild().child as never;
+    },
+  });
+
+  await assert.rejects(
+    () => client.callTool("image_analysis", { image_source: "x" }),
+    /unsafe npm package spec/i,
+  );
+  assert.equal(spawned, false);
+});
+
+test("StdioVisionMcpClient terminates the Windows process tree on dispose", async () => {
+  const { child, getKillCount } = makeFakeChild();
+  let terminatedPid: number | undefined;
+  const client = new StdioVisionMcpClient({
+    apiKey: "k",
+    platform: "win32",
+    spawn: () => child as never,
+    killProcessTree: (pid) => {
+      terminatedPid = pid;
+      return true;
+    },
+  });
+  const callPromise = client.callTool("image_analysis", { image_source: "x" });
+
+  await new Promise((r) => setImmediate(r));
+  await client.dispose();
+
+  await assert.rejects(callPromise, /client disposed/i);
+  assert.equal(terminatedPid, 4242);
+  assert.equal(getKillCount(), 0);
+});
+
+test("StdioVisionMcpClient drains and redacts stderr on failure", async () => {
+  const apiKey = "secret-vision-key";
+  const { child, pushStderr } = makeFakeChild();
+  const client = new StdioVisionMcpClient({ apiKey, spawn: () => child as never });
+  const callPromise = client.callTool("image_analysis", { image_source: "x" });
+
+  await new Promise((r) => setImmediate(r));
+  pushStderr(`provider failed for ${apiKey}\n`);
+  child.emit("exit", 1, null);
+
+  await assert.rejects(callPromise, (error: Error) => {
+    assert.match(error.message, /stderr: provider failed/);
+    assert.match(error.message, /\[REDACTED\]/);
+    assert.doesNotMatch(error.message, new RegExp(apiKey));
+    return true;
+  });
+  await client.dispose();
 });
 
 test("StdioVisionMcpClient resolves tool name via keyword fallback when server uses a different name", async () => {

--- a/src/tools/vision-mcp-client.ts
+++ b/src/tools/vision-mcp-client.ts
@@ -1,7 +1,10 @@
-import { spawn as nodeSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn as nodeSpawn, spawnSync as nodeSpawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { remapArguments, resolveToolName, type DiscoveredTool } from "./mcp-arg-remap.js";
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
+const DEFAULT_INITIALIZATION_TIMEOUT_MS = 30_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+const STDERR_TAIL_LIMIT = 16_384;
 
 export interface VisionMcpClient {
   callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown>;
@@ -12,8 +15,18 @@ interface StdioVisionMcpClientOptions {
   apiKey: string;
   /** Override the package spec for tests/pinning. Defaults to `@z_ai/mcp-server@latest`. */
   packageSpec?: string;
+  /** Maximum time for Vision MCP initialization and tool discovery. */
+  initializationTimeoutMs?: number;
+  /** Maximum time for an individual Vision MCP request. */
+  requestTimeoutMs?: number;
+  /** Platform override for tests. */
+  platform?: NodeJS.Platform;
+  /** Windows command interpreter override for tests. */
+  comSpec?: string;
+  /** Windows process-tree terminator override for tests. */
+  killProcessTree?: (pid: number) => boolean;
   /** Override the spawn function for tests. */
-  spawn?: (command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => ChildProcessWithoutNullStreams;
+  spawn?: (command: string, args: string[], options: { env: NodeJS.ProcessEnv; windowsHide?: boolean }) => ChildProcessWithoutNullStreams;
 }
 
 interface PendingRequest {
@@ -25,18 +38,34 @@ interface PendingRequest {
 export class StdioVisionMcpClient implements VisionMcpClient {
   private child: ChildProcessWithoutNullStreams | null = null;
   private initialized: Promise<void> | null = null;
+  private initializingChild: ChildProcessWithoutNullStreams | null = null;
+  private initializationWaiters = 0;
   private nextId = 1;
   private pending = new Map<number, PendingRequest>();
   private buffer = "";
   private exited = false;
   private exitReason: string | null = null;
   private discoveredTools: DiscoveredTool[] = [];
+  private stderrTail = "";
 
   constructor(private opts: StdioVisionMcpClientOptions) {}
 
   async callTool(toolName: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
     if (signal?.aborted) throw new Error("Vision MCP call cancelled");
-    await this.ensureInitialized();
+    const initialization = this.ensureInitialized();
+    const waitingForInitialization = this.initializingChild !== null;
+    if (waitingForInitialization) this.initializationWaiters += 1;
+    try {
+      await waitForAbort(initialization, signal, "Vision MCP call cancelled");
+    } catch (err) {
+      const child = this.initializingChild;
+      if (signal?.aborted && waitingForInitialization && this.initializationWaiters === 1 && child) {
+        this.failConnection(new Error("initialization aborted"), child, true);
+      }
+      throw err;
+    } finally {
+      if (waitingForInitialization) this.initializationWaiters -= 1;
+    }
     return this.callToolInternal(toolName, args, signal);
   }
 
@@ -59,8 +88,8 @@ export class StdioVisionMcpClient implements VisionMcpClient {
     return { name: resolvedName, args: remapArguments(args, toolSchema?.properties ?? []) };
   }
 
-  private async rediscoverTools(signal?: AbortSignal): Promise<void> {
-    const result = await this.request("tools/list", {}, "Vision MCP tools/list", signal) as
+  private async rediscoverTools(signal?: AbortSignal, timeoutMs?: number): Promise<void> {
+    const result = await this.request("tools/list", {}, "Vision MCP tools/list", signal, timeoutMs) as
       | { tools?: { name: string; inputSchema?: { properties?: Record<string, unknown> } }[] }
       | undefined;
     const tools = result?.tools ?? [];
@@ -73,40 +102,50 @@ export class StdioVisionMcpClient implements VisionMcpClient {
   }
 
   async dispose(): Promise<void> {
-    if (this.child && !this.exited) {
-      try {
-        this.child.kill();
-      } catch {
-        // ignore
-      }
-    }
+    const child = this.child;
     this.child = null;
     this.initialized = null;
+    this.initializingChild = null;
     this.discoveredTools = [];
-    for (const [, p] of this.pending) {
-      p.reject(new Error(`cancelled (client disposed)`));
+    this.exited = true;
+    this.exitReason = "client disposed";
+    if (child) {
+      this.terminateChild(child);
     }
-    this.pending.clear();
+    this.rejectAllPending(new Error("cancelled (client disposed)"));
   }
 
-  private async ensureInitialized(): Promise<void> {
-    if (this.initialized) return this.initialized;
-    this.initialized = this.startAndInitialize();
-    try {
-      await this.initialized;
-    } catch (err) {
-      this.initialized = null;
-      throw err;
-    }
+  private ensureInitialized(): Promise<void> {
+    if (this.initialized && this.child && !this.exited) return this.initialized;
+    const initialization = this.startAndInitialize();
+    this.initialized = initialization;
+    void initialization.catch(() => {
+      if (this.initialized === initialization) this.initialized = null;
+    });
+    return initialization;
   }
 
   private async startAndInitialize(): Promise<void> {
     const packageSpec = this.opts.packageSpec ?? "@z_ai/mcp-server@latest";
     const spawnFn = this.opts.spawn ?? nodeSpawn;
+    const platform = this.opts.platform ?? process.platform;
+    const isWindows = platform === "win32";
+    if (isWindows && !isSafeNpmPackageSpec(packageSpec)) {
+      throw new Error(`Vision MCP startup failed: unsafe npm package spec for Windows: ${packageSpec}`);
+    }
+    const command = isWindows ? (this.opts.comSpec ?? process.env.ComSpec ?? "cmd.exe") : "npx";
+    const args = isWindows
+      ? ["/d", "/s", "/c", "npx", "-y", packageSpec]
+      : ["-y", packageSpec];
+    this.exited = false;
+    this.exitReason = null;
+    this.buffer = "";
+    this.stderrTail = "";
     let child: ChildProcessWithoutNullStreams;
     try {
-      child = spawnFn("npx", ["-y", packageSpec], {
+      child = spawnFn(command, args, {
         env: { ...process.env, Z_AI_API_KEY: this.opts.apiKey, Z_AI_MODE: "ZAI" },
+        windowsHide: true,
       });
     } catch (err) {
       const code = (err as { code?: string }).code;
@@ -120,38 +159,54 @@ export class StdioVisionMcpClient implements VisionMcpClient {
       });
     }
     this.child = child;
+    this.initializingChild = child;
     child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
+    child.stdout.on("data", (chunk: string) => {
+      if (this.child === child) this.handleStdout(chunk);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      if (this.child === child) this.handleStderr(chunk);
+    });
     child.on("exit", (code, sig) => {
-      this.exited = true;
-      this.exitReason = `exit code=${code} signal=${sig ?? "(none)"}`;
-      for (const [, p] of this.pending) {
-        p.reject(new Error(`server exited (${this.exitReason}).`));
-      }
-      this.pending.clear();
+      const reason = `exit code=${code} signal=${sig ?? "(none)"}`;
+      this.failConnection(new Error(`server exited (${reason}).`), child, false);
     });
     child.on("error", (err) => {
-      this.exited = true;
-      this.exitReason = err.message;
+      const startupError = (err as NodeJS.ErrnoException).code === "ENOENT"
+        ? new Error("Vision MCP startup failed: could not launch npx. Ensure Node.js/npm are installed and npx is on PATH.", { cause: err })
+        : new Error(`Vision MCP startup failed: ${err.message}`, { cause: err });
+      this.failConnection(startupError, child, true);
     });
 
-    await this.request("initialize", {
-      protocolVersion: MCP_PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
-    }, "Vision MCP initialize");
-    this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
-    await this.rediscoverTools();
+    const initializationTimeoutMs = this.opts.initializationTimeoutMs ?? DEFAULT_INITIALIZATION_TIMEOUT_MS;
+    const deadline = Date.now() + initializationTimeoutMs;
+    const remaining = () => Math.max(1, deadline - Date.now());
+    try {
+      await this.request("initialize", {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "glm-acp-agent", version: "1.0.0" },
+      }, "Vision MCP initialize", undefined, remaining());
+      this.send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      await this.rediscoverTools(undefined, remaining());
+      if (this.initializingChild === child) this.initializingChild = null;
+    } catch (err) {
+      this.failConnection(err instanceof Error ? err : new Error(String(err)), child, true);
+      throw err;
+    }
   }
 
-  private request(method: string, params: Record<string, unknown>, label: string, signal?: AbortSignal): Promise<unknown> {
+  private request(
+    method: string,
+    params: Record<string, unknown>,
+    label: string,
+    signal?: AbortSignal,
+    timeoutMs = this.opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const id = this.nextId++;
-      this.pending.set(id, {
-        method: label,
-        resolve,
-        reject: (err) => reject(new Error(`${label} failed: ${err.message}`)),
-      });
+      let settled = false;
       const onAbort = () => {
         const pending = this.pending.get(id);
         if (pending) {
@@ -159,14 +214,93 @@ export class StdioVisionMcpClient implements VisionMcpClient {
           pending.reject(new Error("aborted"));
         }
       };
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const settle = (fn: (value: unknown) => void, value: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        fn(value);
+      };
+      this.pending.set(id, {
+        method: label,
+        resolve: (value) => settle(resolve, value),
+        reject: (err) => settle(reject, new Error(`${label} failed: ${this.withStderr(err.message)}`)),
+      });
+      const timer = setTimeout(() => {
+        const child = this.child;
+        if (child && this.pending.has(id)) {
+          this.failConnection(new Error(`request timed out after ${timeoutMs}ms`), child, true);
+        }
+      }, timeoutMs);
       signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
       try {
         this.send({ jsonrpc: "2.0", id, method, params });
       } catch (err) {
+        const pending = this.pending.get(id);
         this.pending.delete(id);
-        reject(new Error(`${label} failed: ${(err as Error).message}`));
+        pending?.reject(err instanceof Error ? err : new Error(String(err)));
       }
     });
+  }
+
+  private rejectAllPending(error: Error): void {
+    const pending = [...this.pending.values()];
+    this.pending.clear();
+    for (const request of pending) request.reject(error);
+  }
+
+  private failConnection(error: Error, child: ChildProcessWithoutNullStreams, kill: boolean): void {
+    if (this.child !== child || this.exited) return;
+    this.child = null;
+    if (this.initializingChild === child) this.initializingChild = null;
+    this.exited = true;
+    this.exitReason = error.message;
+    this.initialized = null;
+    this.rejectAllPending(error);
+    if (kill) {
+      this.terminateChild(child);
+    }
+  }
+
+  private terminateChild(child: ChildProcessWithoutNullStreams): void {
+    const platform = this.opts.platform ?? process.platform;
+    if (platform === "win32" && child.pid && child.exitCode === null && (!this.opts.spawn || this.opts.killProcessTree)) {
+      try {
+        const killed = this.opts.killProcessTree
+          ? this.opts.killProcessTree(child.pid)
+          : nodeSpawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+              stdio: "ignore",
+              windowsHide: true,
+            }).status === 0;
+        if (killed) return;
+      } catch {
+        // fall back to the direct child below
+      }
+    }
+    try {
+      child.kill();
+    } catch {
+      // ignore
+    }
+  }
+
+  private handleStderr(chunk: string): void {
+    const tail = chunk.length >= STDERR_TAIL_LIMIT ? chunk.slice(-STDERR_TAIL_LIMIT) : this.stderrTail + chunk;
+    this.stderrTail = tail.slice(-STDERR_TAIL_LIMIT);
+  }
+
+  private withStderr(message: string): string {
+    let stderr = this.stderrTail.trim();
+    if (this.opts.apiKey) stderr = stderr.split(this.opts.apiKey).join("[REDACTED]");
+    stderr = stderr.replace(/\s+/g, " ").slice(-2_000);
+    return stderr ? `${message}; stderr: ${stderr}` : message;
   }
 
   private send(message: Record<string, unknown>): void {
@@ -200,6 +334,40 @@ export class StdioVisionMcpClient implements VisionMcpClient {
       }
     }
   }
+}
+
+function waitForAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined, message: string): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new Error(message));
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(message));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function isSafeNpmPackageSpec(packageSpec: string): boolean {
+  return /^(?:@[a-z0-9._-]+\/)?[a-z0-9._-]+(?:@[a-z0-9._-]+)?$/i.test(packageSpec);
 }
 
 function isVisionRetryableError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Fix Vision MCP startup and request lifecycle handling on Windows.

On Windows 11 with Node.js 26.5.0 / npm 11.17.0, the current `spawn("npx", ...)` path emits `ENOENT` (`spawn("npx.cmd", ...)` throws `EINVAL`). Because the asynchronous child error did not reject the pending MCP `initialize` request and requests had no deadline, pasted ACP images could remain pending indefinitely.

## What changed

- Launch `npx` through `ComSpec` on Windows without `shell: true`.
- Reject unsafe Windows package specs before they reach `cmd.exe`.
- Add bounded initialization and per-request timeouts.
- Propagate asynchronous child errors to pending JSON-RPC requests.
- Drain bounded stderr diagnostics and redact the API key before surfacing errors.
- Isolate stale child events and shared-initialization cancellation across concurrent sessions.
- Terminate the Windows process tree on timeout/dispose to avoid orphaned MCP children.
- Add regression tests for Windows launch, async spawn errors, timeouts, cancellation races, stderr redaction, injection rejection, and process-tree cleanup.

## Reproduction

```text
spawn("npx", ["--version"])      -> asynchronous ENOENT
spawn("npx.cmd", ["--version"])  -> synchronous EINVAL
cmd.exe /d /s /c npx --version     -> succeeds
```

In an ACP client, a PNG image block was received and materialized, but the Vision MCP `initialize` request never reached a terminal state until the user cancelled it.

## Validation

- `npm run lint` ✅
- `npm run build` ✅
- `node --test dist/tests/vision-mcp-client.test.js` — 14/14 passed ✅
- Real `image_analysis` call against a local PNG — completed with a non-empty text result in 8.4s ✅
- Verified no `@z_ai/mcp-server` process remained after dispose ✅

Windows full-suite note: `npm test` currently reaches 225 passing tests and 3 existing path-format assertion failures in `credentials.test` / `executor.test` (`C:\...` expected while the configured `sh` reports `/tmp/...`). Those failures are unrelated to this diff.