### PR TITLE
docs: sync package description and tool count with the advertised models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
 - **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; the advertised coding models route pasted ACP image blocks through Z.AI Vision MCP (`@z_ai/mcp-server`), while `glm-5v-turbo` sessions — opt-in via `ACP_GLM_AVAILABLE_MODELS`, since it is no longer on the Coding Plan allowlist — send supported image parts directly to the model. Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
-- **Six built-in tools** (see below)
+- **Seven built-in tools** (see below)
 - **Self-sufficient local tools** – file reads/writes, directory listings, and shell commands run in the agent process, so they do not depend on ACP client `fs` or `terminal` capabilities
 - **Configurable permissions** – `write_file` and `run_command` behavior depends on the active session mode (prompts by default)
 - **Protocol-correct stop reasons** – maps model and runtime conditions to ACP `end_turn`, `max_tokens`, `max_turn_requests`, `refusal`, and `cancelled`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glm-acp-agent",
   "version": "1.6.0",
-  "description": "ACP agent in TypeScript that uses the Zhipu AI GLM series (specifically GLM-5.3 and GLM-4.7) as the reasoning core",
+  "description": "ACP agent in TypeScript that uses the Z.AI / Zhipu AI GLM Coding Plan models (GLM-5.3, GLM-5 Turbo, GLM-4.7) as the reasoning core",
   "type": "module",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
The GitHub About text and `package.json` description both named a stale model set. The advertised list in `src/llm/glm-client.ts:158-170` is `glm-5.3`, `glm-5-turbo`, and `glm-4.7` — `glm-5.1` is only an alias the Coding Plan endpoint routes to 5.3, so it should not appear as a headline model.

The README feature bullet still said "Six built-in tools" even though `src/tools/definitions.ts` defines seven; the tools table and the architecture diagram already listed `image_analysis`.

Repo metadata updated separately on GitHub: About description now matches, homepage points at the npm package, and topics were added (`acp`, `agent-client-protocol`, `glm`, `zhipu`, `zai`, `typescript`, `ai-agent`, `coding-agent`).