### PR TITLE
docs(registry): align manifest description branding

### DIFF
--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.6.1",
-  "description": "ACP agent powered by Zhipu AI's GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Z.AI / Zhipu AI GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": [
     "Stefan de Vogelaere"


### PR DESCRIPTION
The GitHub About text and `package.json` both say "Z.AI / Zhipu AI"; `registry/glm-acp-agent/agent.json` still said "Zhipu AI's". Same product, one spelling.

Version fields are untouched, so the `sync-manifest --check` CI step stays green.