### PR TITLE
#96 - Advertise glm-5.3-flash with native vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,15 @@ The agent advertises a `thought_level` [SessionConfigOption](https://agentclient
 
 | Model | Levels | Mapping to the Z.AI request |
 |-------|--------|-----------------------------|
-| `glm-5.3` / `glm-5.3-flash` (and `glm-5.2` / `glm-5.1`, which route to 5.3) | `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort` set to the matching value |
+| `glm-5.3` (and `glm-5.2` / `glm-5.1`, which route to 5.3) | `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort` set to the matching value |
+| `glm-5.3-flash` | `Low` / `High` / `Max` | Same mapping; Z.AI only documents these three levels for Flash |
 | other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
 
 **GLM-5.3 and GLM-5.3-Flash have no `Off` level, because thinking cannot be turned off on them.** Sending `thinking: { type: "disabled" }` now errors (it is no longer a silent no-op), so `ACP_GLM_THINKING=false` leaves thinking enabled rather than sending `disabled`. Use `glm-4.7` if you need non-reasoning completions — with the caveat that if Coding Plan really routes turbo/4.7 to Flash, a session that picks `glm-4.7` + thought level `Off` may 4xx.
 
-`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (an effort-ladder selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3 / Flash) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (an effort-ladder selection reverts to `On` when you move to GLM-4.7; an `Off` selection becomes `Max` on GLM-5.3 / Flash; switching from GLM-5.3 onto Flash maps `minimal`→`low`, `medium`→`high`, `xhigh`→`max`) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
 
-The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent exposes every one of those values as a thought level except `none`, which the GLM-5.3 family rejects (see above).
+The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max` on GLM-5.3. GLM-5.3-Flash's documented values are only `low | high | max`, so the agent advertises that shorter ladder for Flash. `none` is never offered on either model.
 
 `ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, clients should not offer image attachments at all.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glm-acp-agent
 
-An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.3, GLM-5 Turbo, GLM-4.7) as its reasoning core.
+An [Agent Client Protocol (ACP)](https://agentclientprotocol.com) agent written in TypeScript that uses the **Z.AI / Zhipu AI GLM** model family (GLM-5.3, GLM-5.3 Flash, GLM-5 Turbo, GLM-4.7) as its reasoning core.
 
 The agent connects to any ACP-compatible IDE or client over **stdio**, streams responses back in real time, and can call a rich set of tools to interact with the user's file system, terminal, and the web.
 
@@ -30,7 +30,7 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
 - **Session permission modes** – supports `default`, `accept_edits`, and `bypass_permissions` via `session/set_mode`. Clients like DevFlow can use this to toggle between prompting for every edit, auto-approving edits while prompting for commands, or bypassing permissions entirely.
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
-- **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; the advertised coding models route pasted ACP image blocks through Z.AI Vision MCP (`@z_ai/mcp-server`), while `glm-5v-turbo` sessions — opt-in via `ACP_GLM_AVAILABLE_MODELS`, since it is no longer on the Coding Plan allowlist — send supported image parts directly to the model. Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
+- **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; `glm-5.3-flash` sends supported pasted ACP image blocks directly as native `image_url` content parts, while the other advertised coding models (including default `glm-5.3`) route them through Z.AI Vision MCP (`@z_ai/mcp-server`). `glm-5v-turbo` keeps the same native-vision path when re-added via `ACP_GLM_AVAILABLE_MODELS` — it is no longer on the Coding Plan allowlist. Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Seven built-in tools** (see below)
 - **Self-sufficient local tools** – file reads/writes, directory listings, and shell commands run in the agent process, so they do not depend on ACP client `fs` or `terminal` capabilities
@@ -171,17 +171,18 @@ The agent advertises only the models on the current Z.AI Coding Plan allowlist:
 
 | Model | Notes |
 |-------|-------|
-| `glm-5.3` | **Default.** Newest 1M-context coding model; thinking mode always on |
+| `glm-5.3` | **Default.** Newest 1M-context coding model; thinking mode always on; text-only (images go through Vision MCP) |
+| `glm-5.3-flash` | Native-vision 1M-context model; cheaper Coding Plan quota |
 | `glm-5-turbo` | Faster Coding Plan reasoning model; 128K context |
 | `glm-4.7` | 200K-context reasoning model |
 
-Only models the Coding Plan endpoint serves **under their own name** are advertised. Several ids that used to be listed are now aliases: a request for `glm-5.2` or `glm-5.1` comes back with `"model": "glm-5.3"`, and `glm-4.5-air` comes back as `glm-4.7`. They still work, but advertising them would report a model you are not actually talking to. `glm-5v-turbo` is no longer on the Coding Plan allowlist — selecting it fails with business code `1311` ("subscription plan does not yet include access").
+Only models the Coding Plan endpoint serves **under their own name** are advertised. Several ids that used to be listed are now aliases: a request for `glm-5.2` or `glm-5.1` comes back with `"model": "glm-5.3"`, and `glm-4.5-air` comes back as `glm-4.7`. They still work, but advertising them would report a model you are not actually talking to. Z.AI's Coding Plan overview currently also claims `glm-5-turbo` and `glm-4.7` requests are routed to GLM-5.3-Flash; that has not been confirmed by a live probe here, so both ids stay in the picker. `glm-5v-turbo` is no longer on the Coding Plan allowlist — selecting it fails with business code `1311` ("subscription plan does not yet include access").
 
 `ACP_GLM_AVAILABLE_MODELS` lets you advertise any id you like, including the ones above. Custom ids sit outside the supported Coding Plan list — the endpoint rejects any model code Z.AI hasn't whitelisted (business code `1211`). The native-vision path is unchanged, so if your plan does include `glm-5v-turbo`, add it back with `ACP_GLM_AVAILABLE_MODELS` and image blocks still reach it as native `image_url` content parts.
 
-Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. Every built-in advertised model uses the [Vision MCP](#vision-mcp) path for image analysis; `glm-5v-turbo`, when re-added via the override above, is the one exception and keeps native `image_url` handling.
+Vision-only chat models (`glm-4v-plus` etc.) are **not** advertised. `glm-5.3-flash` is the built-in native-vision Coding Plan model (`image_url` content parts). Default `glm-5.3`, `glm-5-turbo`, and `glm-4.7` still use the [Vision MCP](#vision-mcp) path. `glm-5v-turbo`, when re-added via the override above, keeps native `image_url` handling as an opt-in exception.
 
-When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5v-turbo`. `ACP_GLM_THINKING=false` asks for plain completions instead — but note it has no effect on GLM-5.3, which ignores every attempt to turn thinking off (see [Thought level](#thought-level-reasoning-effort) below).
+When the model name matches `glm-4.5`, `glm-4.6`, `glm-4.7`, or the `glm-5` family, the agent enables Z.AI's `thinking: { type: "enabled" }` extension and forwards reasoning tokens to the client as `agent_thought_chunk` blocks. This includes `glm-5.3-flash` and `glm-5v-turbo`. `ACP_GLM_THINKING=false` asks for plain completions on models that still accept `thinking.type: "disabled"` (GLM-4.7, GLM-5 Turbo). On GLM-5.3 and GLM-5.3-Flash the flag is a no-op: those models reject `disabled`, so the agent leaves thinking enabled rather than sending it (see [Thought level](#thought-level-reasoning-effort) below).
 
 #### Thought level (reasoning effort)
 
@@ -189,22 +190,22 @@ The agent advertises a `thought_level` [SessionConfigOption](https://agentclient
 
 | Model | Levels | Mapping to the Z.AI request |
 |-------|--------|-----------------------------|
-| `glm-5.3` (and `glm-5.2` / `glm-5.1`, which route to it) | `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort` set to the matching value |
+| `glm-5.3` / `glm-5.3-flash` (and `glm-5.2` / `glm-5.1`, which route to 5.3) | `Minimal` / `Low` / `Medium` / `High` / `X-High` / `Max` | `thinking: { type: "enabled" }` + `reasoning_effort` set to the matching value |
 | other thinking-capable models | `Off` / `On` | `Off` → `thinking: { type: "disabled" }`; `On` → `thinking: { type: "enabled" }` |
 
-**GLM-5.3 has no `Off` level, because thinking cannot be turned off on it.** The endpoint accepts both `thinking: { type: "disabled" }` and `reasoning_effort: "none"` without error, but keeps emitting reasoning either way — so `ACP_GLM_THINKING=false` is a no-op on GLM-5.3. Use `glm-4.7` if you need non-reasoning completions.
+**GLM-5.3 and GLM-5.3-Flash have no `Off` level, because thinking cannot be turned off on them.** Sending `thinking: { type: "disabled" }` now errors (it is no longer a silent no-op), so `ACP_GLM_THINKING=false` leaves thinking enabled rather than sending `disabled`. Use `glm-4.7` if you need non-reasoning completions — with the caveat that if Coding Plan really routes turbo/4.7 to Flash, a session that picks `glm-4.7` + thought level `Off` may 4xx.
 
-`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (an effort-ladder selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
+`reasoning_effort` only takes effect on the GLM-5.3 family; `glm-5-turbo` and `glm-4.7` accept the field without validating it and answer identically either way, so the agent omits it for them. New sessions default to `Max`, which is also Z.AI's default when the field is omitted, so out-of-the-box behaviour is unchanged. Switching models re-clamps the level (an effort-ladder selection reverts to `On` when you move to GLM-4.7, and an `Off` selection becomes `Max` when you move to GLM-5.3 / Flash) and pushes a `config_option_update`. Clients that don't support config options simply ignore the advertised option and get the default behaviour.
 
-The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent exposes every one of those values as a thought level except `none`, which GLM-5.3 ignores (see above).
+The endpoint validates `reasoning_effort` against `none | minimal | low | medium | high | xhigh | max`; the agent exposes every one of those values as a thought level except `none`, which the GLM-5.3 family rejects (see above).
 
 `ACP_GLM_PROMPT_IMAGES=false` still hides the image-attachment capability at session startup. With that flag set, clients should not offer image attachments at all.
 
 ### Vision MCP
 
-For `glm-5v-turbo`, pasted ACP image blocks with `image/jpeg`, `image/jpg`, or `image/png` are sent directly to chat completions as `image_url` content parts. HTTPS image URLs are forwarded as URLs; inline base64 data is sent as a `data:<mime>;base64,...` URI. Unsupported image MIME types are rejected client-side with an inline `<image_unsupported_format>` annotation so the prompt can continue without a provider 4xx.
+For `glm-5.3-flash` (built-in) and `glm-5v-turbo` (opt-in via `ACP_GLM_AVAILABLE_MODELS`), pasted ACP image blocks with `image/jpeg`, `image/jpg`, or `image/png` are sent directly to chat completions as `image_url` content parts. HTTPS image URLs are forwarded as URLs; inline base64 data is sent as a `data:<mime>;base64,...` URI. Unsupported image MIME types are rejected client-side with an inline `<image_unsupported_format>` annotation so the prompt can continue without a provider 4xx.
 
-For non-native models, pasted ACP image blocks are not sent to the chat-completions endpoint. Instead, the agent boots `@z_ai/mcp-server` over stdio (via `npx -y @z_ai/mcp-server@latest`) and calls its `image_analysis` tool. The text result is spliced into the user message as `<image_analysis index="N">…</image_analysis>` so the regular Coding Plan model can reason about it.
+For non-native models (including default `glm-5.3`), pasted ACP image blocks are not sent to the chat-completions endpoint. Instead, the agent boots `@z_ai/mcp-server` over stdio (via `npx -y @z_ai/mcp-server@latest`) and calls its `image_analysis` tool. The text result is spliced into the user message as `<image_analysis index="N">…</image_analysis>` so the regular Coding Plan model can reason about it.
 
 Prerequisites:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glm-acp-agent",
   "version": "1.6.1",
-  "description": "ACP agent in TypeScript that uses the Z.AI / Zhipu AI GLM Coding Plan models (GLM-5.3, GLM-5 Turbo, GLM-4.7) as the reasoning core",
+  "description": "ACP agent in TypeScript that uses the Z.AI / Zhipu AI GLM Coding Plan models (GLM-5.3, GLM-5.3 Flash, GLM-5 Turbo, GLM-4.7) as the reasoning core",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/registry/glm-acp-agent/agent.json
+++ b/registry/glm-acp-agent/agent.json
@@ -2,7 +2,7 @@
   "id": "glm-acp-agent",
   "name": "GLM Agent",
   "version": "1.6.1",
-  "description": "ACP agent powered by Z.AI / Zhipu AI GLM Coding Plan models (glm-5.3, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
+  "description": "ACP agent powered by Z.AI / Zhipu AI GLM Coding Plan models (glm-5.3, glm-5.3-flash, glm-5-turbo, glm-4.7). Supports streaming, tool calls, mid-session model switching, thought_level config for reasoning effort, image input via native vision (glm-5.3-flash) or Z.AI Coding Plan Vision MCP, and session load/fork/resume with on-disk persistence.",
   "repository": "https://github.com/stefandevo/glm-acp-agent",
   "authors": [
     "Stefan de Vogelaere"

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -10,10 +10,11 @@ import { debug, error } from "./logger.js";
  * SessionConfigOption. These map onto Z.AI's `thinking` / `reasoning_effort`
  * request parameters (see {@link buildThinkingParams}).
  *
- * GLM-5.3 (and GLM-5.2, which the Coding Plan endpoint serves with 5.3)
- * supports the full effort ladder: `minimal | low | medium | high | xhigh |
- * max`. Other thinking-capable models (5-turbo, 4.7, …) only distinguish
- * thinking on vs. off, so they use `none` and `on`.
+ * GLM-5.3 (and GLM-5.2 / GLM-5.1, which the Coding Plan endpoint serves with
+ * 5.3) supports the full effort ladder: `minimal | low | medium | high |
+ * xhigh | max`. GLM-5.3-Flash only honours `low | high | max`. Other
+ * thinking-capable models (5-turbo, 4.7, …) only distinguish thinking on vs.
+ * off, so they use `none` and `on`.
  */
 export type ThoughtLevel =
   | "none"
@@ -42,6 +43,13 @@ const LEVELS_REASONING_EFFORT: ThoughtLevel[] = [
   "max",
 ];
 
+/**
+ * GLM-5.3-Flash's advertised ladder. Z.AI's Chat Completions schema for
+ * vision models only accepts `low | high | max`; other values do not provide
+ * the requested effort.
+ */
+const LEVELS_FLASH: ThoughtLevel[] = ["low", "high", "max"];
+
 /** Levels shown for every other thinking-capable model. */
 const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
 
@@ -58,6 +66,10 @@ const LEVELS_DEFAULT: ThoughtLevel[] = ["none", "on"];
 function isReasoningEffortModel(model: string): boolean {
   const id = model.toLowerCase();
   return id.startsWith("glm-5.3") || id.startsWith("glm-5.2") || id.startsWith("glm-5.1");
+}
+
+function isFlashModel(model: string): boolean {
+  return model.toLowerCase() === "glm-5.3-flash";
 }
 
 /** The complete set of thought levels the agent understands. */
@@ -78,8 +90,10 @@ export function isThoughtLevel(value: string): value is ThoughtLevel {
  * Only the GLM-5.3 family honours `reasoning_effort`; on `glm-5-turbo` and
  * `glm-4.7` the endpoint accepts the field without validating it and the
  * response depth does not change, so those models only get on/off.
+ * GLM-5.3-Flash is a 5.3-family model but only the three documented levels.
  */
 export function getThoughtLevels(model: string): ThoughtLevel[] {
+  if (isFlashModel(model)) return LEVELS_FLASH;
   return isReasoningEffortModel(model) ? LEVELS_REASONING_EFFORT : LEVELS_DEFAULT;
 }
 
@@ -87,11 +101,20 @@ export function getThoughtLevels(model: string): ThoughtLevel[] {
  * Resolve a stored ThoughtLevel to one that's valid for the given model.
  * Used when switching models or restoring a persisted session: if the old
  * level isn't in the new model's option list, fall back to the model's
- * default (max on 5.3, on for everything else — the last entry in the list).
+ * default (max on 5.3 / Flash, on for everything else — the last entry in
+ * the list). Switching from GLM-5.3 onto Flash maps the six-rung ladder
+ * onto Flash's three documented values rather than collapsing everything
+ * to max.
  */
 export function resolveThoughtLevel(model: string, level: ThoughtLevel): ThoughtLevel {
   const valid = getThoughtLevels(model);
-  return valid.includes(level) ? level : valid[valid.length - 1]!;
+  if (valid.includes(level)) return level;
+  if (isFlashModel(model)) {
+    if (level === "minimal") return "low";
+    if (level === "medium") return "high";
+    return "max";
+  }
+  return valid[valid.length - 1]!;
 }
 
 /**
@@ -504,9 +527,15 @@ export function buildThinkingParams(
 
   // reasoning_effort is only meaningful for the GLM-5.3 family — glm-5-turbo
   // and glm-4.7 accept it without validating it and answer identically either
-  // way. The remaining levels ("on", and "none" when thinking is force-enabled
-  // via the env override) carry no valid effort, so we omit the field.
-  if (effort !== undefined && LEVELS_REASONING_EFFORT.includes(effort) && isReasoningEffortModel(model)) {
+  // way. Flash only honours low/high/max, so we send the advertised ladder
+  // rather than the full 5.3 set. The remaining levels ("on", and "none"
+  // when thinking is force-enabled via the env override) carry no valid
+  // effort, so we omit the field.
+  if (
+    effort !== undefined &&
+    isReasoningEffortModel(model) &&
+    getThoughtLevels(model).includes(effort)
+  ) {
     params["reasoning_effort"] = effort;
   }
 

--- a/src/llm/glm-client.ts
+++ b/src/llm/glm-client.ts
@@ -29,10 +29,9 @@ export type ThoughtLevel =
  * Levels shown for the models that honour `reasoning_effort` — the endpoint's
  * full validated ladder minus `none`.
  *
- * Deliberately has no `none`: probing the Coding Plan endpoint on 2026-08-15
- * showed GLM-5.3 keeps emitting `reasoning_content` whether you send
- * `thinking: { type: "disabled" }` or `reasoning_effort: "none"`, so an "Off"
- * option would advertise something the model does not do.
+ * Deliberately has no `none`: Z.AI docs say GLM-5.3 / GLM-5.3-Flash only
+ * accept `thinking.type: "enabled"` — sending `"disabled"` errors — so an
+ * "Off" option would advertise something the model cannot do.
  */
 const LEVELS_REASONING_EFFORT: ThoughtLevel[] = [
   "minimal",
@@ -160,6 +159,11 @@ const BUILTIN_AVAILABLE_MODELS: ModelInfo[] = [
     description: "Newest 1M-context coding model with thinking mode",
   },
   {
+    modelId: "glm-5.3-flash",
+    name: "GLM-5.3 Flash",
+    description: "Native-vision 1M-context model; cheaper Coding Plan quota",
+  },
+  {
     modelId: "glm-5-turbo",
     name: "GLM-5 Turbo",
     description: "Faster Coding Plan reasoning model",
@@ -186,6 +190,7 @@ export const ERR_CONTEXT_OVERFLOW = 1261;
  */
 const MODEL_METADATA: Record<string, { contextWindow: number }> = {
   "glm-5.3": { contextWindow: 1_000_000 },
+  "glm-5.3-flash": { contextWindow: 1_000_000 },
   "glm-5-turbo": { contextWindow: 128_000 },
   "glm-4.7": { contextWindow: 200_000 },
   // Routed to glm-5.3 by the Coding Plan endpoint.
@@ -198,7 +203,7 @@ const MODEL_METADATA: Record<string, { contextWindow: number }> = {
 };
 
 /** Models that accept image content parts directly through chat completions. */
-const VISION_NATIVE_MODELS = new Set(["glm-5v-turbo"]);
+const VISION_NATIVE_MODELS = new Set(["glm-5.3-flash", "glm-5v-turbo"]);
 
 export function isVisionNativeModel(modelId: string): boolean {
   return VISION_NATIVE_MODELS.has(modelId.toLowerCase());
@@ -456,15 +461,16 @@ function thinkingOverride(): boolean | undefined {
  * - `minimal` … `max` → thinking enabled + reasoning_effort=<level>
  *   (5.3 family only)
  *
- * Caveat: GLM-5.3 ignores every attempt to turn thinking off — it keeps
- * emitting `reasoning_content` for `thinking: { type: "disabled" }` and for
- * `reasoning_effort: "none"` alike. `none` is therefore not offered as a level
- * for those models (see {@link getThoughtLevels}), and the `ACP_GLM_THINKING=false`
- * override below is a no-op there even though the request is still sent.
+ * Caveat: GLM-5.3 and GLM-5.3-Flash reject `thinking: { type: "disabled" }`
+ * (it is no longer a silent no-op). `none` is therefore not offered as a
+ * level for those models (see {@link getThoughtLevels}), and
+ * `ACP_GLM_THINKING=false` leaves thinking enabled rather than sending
+ * `disabled`.
  *
- * The `ACP_GLM_THINKING` env override still wins: `false` forces thinking off,
- * `true` forces it on (ignoring a `none` level). When `effort` is unset the
- * model defaults are used, preserving the pre-thought-level behaviour.
+ * The `ACP_GLM_THINKING` env override still wins for models that accept it:
+ * `false` forces thinking off, `true` forces it on (ignoring a `none` level).
+ * When `effort` is unset the model defaults are used, preserving the
+ * pre-thought-level behaviour.
  */
 export function buildThinkingParams(
   model: string,
@@ -474,17 +480,20 @@ export function buildThinkingParams(
 
   const override = thinkingOverride();
   const modelCanThink = modelSupportsThinking(model);
+  // GLM-5.3 / Flash (and aliases routed to them) error on thinking.type=disabled.
+  const thinkingLockedOn = isReasoningEffortModel(model);
 
-  // Explicit env override to disable wins over everything.
-  if (override === false) {
+  // Explicit env override to disable wins, except on models that reject it.
+  if (override === false && !thinkingLockedOn) {
     if (modelCanThink) params["thinking"] = { type: "disabled" };
     return params;
   }
 
   const canThink = override === true || modelCanThink;
 
-  // A `none` level disables thinking, unless the env override forces it on.
-  if (effort === "none" && override !== true) {
+  // A `none` level disables thinking, unless the env override forces it on
+  // or the model rejects disabled.
+  if (effort === "none" && override !== true && !thinkingLockedOn) {
     if (canThink) params["thinking"] = { type: "disabled" };
     return params;
   }

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -997,7 +997,7 @@ test("newSession advertises the model as a config option next to thought_level a
   const options = (model as { options: Array<{ value: string; name: string }> }).options;
   assert.deepEqual(
     options.map((o) => o.value),
-    ["glm-5.3", "glm-5-turbo", "glm-4.7"]
+    ["glm-5.3", "glm-5.3-flash", "glm-5-turbo", "glm-4.7"]
   );
   // Names must match the models state so both surfaces read the same.
   assert.deepEqual(
@@ -1867,49 +1867,51 @@ test("prompt with image block runs Vision MCP preprocessing and feeds text into 
   assert.match(capturedUser as string, /<image_analysis index="1">[\s\S]*It is a kitten\.[\s\S]*<\/image_analysis>/);
 });
 
-test("prompt with image block on vision-native model sends native image_url content", async () => {
-  const conn = createConnectionStub();
-  let capturedUser: unknown;
-  const glm = {
-    async *streamChat(
-      messages: ReadonlyArray<{ role: string; content?: unknown }>,
-      _signal?: AbortSignal,
-      options?: { model?: string }
-    ): AsyncGenerator<GlmStreamChunk> {
-      assert.equal(options?.model, "glm-5v-turbo");
-      const userMsg = [...messages].reverse().find((m) => m.role === "user");
-      capturedUser = userMsg?.content;
-      yield { text: "ok" };
-      yield { done: true, stopReason: "stop" };
-    },
-  };
-  const visionCalls: Array<Record<string, unknown>> = [];
-  const visionClient = {
-    async callTool(_name: string, args: Record<string, unknown>) {
-      visionCalls.push(args);
-      return { content: [{ type: "text", text: "should not be used" }] };
-    },
-    async dispose() {},
-  };
-  const agent = new GlmAcpAgent(conn as never, { glm, visionClient, sessionStore: null });
-  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
-  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
-  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5v-turbo" });
+for (const visionModel of ["glm-5v-turbo", "glm-5.3-flash"] as const) {
+  test(`prompt with image block on ${visionModel} sends native image_url content`, async () => {
+    const conn = createConnectionStub();
+    let capturedUser: unknown;
+    const glm = {
+      async *streamChat(
+        messages: ReadonlyArray<{ role: string; content?: unknown }>,
+        _signal?: AbortSignal,
+        options?: { model?: string }
+      ): AsyncGenerator<GlmStreamChunk> {
+        assert.equal(options?.model, visionModel);
+        const userMsg = [...messages].reverse().find((m) => m.role === "user");
+        capturedUser = userMsg?.content;
+        yield { text: "ok" };
+        yield { done: true, stopReason: "stop" };
+      },
+    };
+    const visionCalls: Array<Record<string, unknown>> = [];
+    const visionClient = {
+      async callTool(_name: string, args: Record<string, unknown>) {
+        visionCalls.push(args);
+        return { content: [{ type: "text", text: "should not be used" }] };
+      },
+      async dispose() {},
+    };
+    const agent = new GlmAcpAgent(conn as never, { glm, visionClient, sessionStore: null });
+    await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.unstable_setSessionModel({ sessionId, modelId: visionModel });
 
-  await agent.prompt({
-    sessionId,
-    prompt: [
+    await agent.prompt({
+      sessionId,
+      prompt: [
+        { type: "text", text: "What is in this image?" },
+        { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
+      ],
+    });
+
+    assert.equal(visionCalls.length, 0);
+    assert.deepEqual(capturedUser, [
       { type: "text", text: "What is in this image?" },
-      { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
-    ],
+      { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
+    ]);
   });
-
-  assert.equal(visionCalls.length, 0);
-  assert.deepEqual(capturedUser, [
-    { type: "text", text: "What is in this image?" },
-    { type: "image_url", image_url: { url: "https://example.com/cat.png" } },
-  ]);
-});
+}
 
 test("prompt with inline image data on vision-native model sends a data URI", async () => {
   const conn = createConnectionStub();

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -358,11 +358,16 @@ test("getThoughtLevels omits none for reasoning-effort models", () => {
   // would lie. Everything else on the validated ladder is exposed, in order.
   const ladder = ["minimal", "low", "medium", "high", "xhigh", "max"];
   assert.deepEqual(getThoughtLevels("glm-5.3"), ladder);
-  assert.deepEqual(getThoughtLevels("glm-5.3-flash"), ladder);
   // glm-5.2 and glm-5.1 are both served by glm-5.3, so they behave identically
   // — including the fact that "Off" would not actually turn thinking off.
   assert.deepEqual(getThoughtLevels("glm-5.2"), ladder);
   assert.deepEqual(getThoughtLevels("glm-5.1"), ladder);
+});
+
+test("getThoughtLevels advertises only low/high/max for glm-5.3-flash", () => {
+  // Z.AI Chat Completions: GLM-5.3-Flash reasoning_effort is only low/high/max.
+  assert.deepEqual(getThoughtLevels("glm-5.3-flash"), ["low", "high", "max"]);
+  assert.deepEqual(getThoughtLevels("GLM-5.3-Flash"), ["low", "high", "max"]);
 });
 
 test("getThoughtLevels returns none/on for models without reasoning_effort", () => {
@@ -388,6 +393,17 @@ test("resolveThoughtLevel clamps a persisted none up to max on glm-5.3", () => {
   // when switched to glm-5.3, which has no "none" level.
   assert.equal(resolveThoughtLevel("glm-5.3", "none"), "max");
   assert.equal(resolveThoughtLevel("glm-5.3", "on"), "max");
+});
+
+test("resolveThoughtLevel maps the 5.3 ladder onto Flash's three levels", () => {
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "low"), "low");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "high"), "high");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "max"), "max");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "minimal"), "low");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "medium"), "high");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "xhigh"), "max");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "none"), "max");
+  assert.equal(resolveThoughtLevel("glm-5.3-flash", "on"), "max");
 });
 
 test("buildThinkingParams omits fields for non-thinking models", () => {
@@ -474,9 +490,21 @@ test("buildThinkingParams attaches reasoning_effort on glm-5.3-flash", () => {
   const old = process.env["ACP_GLM_THINKING"];
   delete process.env["ACP_GLM_THINKING"];
   try {
-    assert.deepEqual(buildThinkingParams("glm-5.3-flash", "max"), {
+    for (const level of ["low", "high", "max"] as const) {
+      assert.deepEqual(buildThinkingParams("glm-5.3-flash", level), {
+        thinking: { type: "enabled" },
+        reasoning_effort: level,
+      });
+    }
+    // Unadvertised 5.3-ladder values must not be forwarded as-is.
+    assert.deepEqual(buildThinkingParams("glm-5.3-flash", "minimal"), {
       thinking: { type: "enabled" },
-      reasoning_effort: "max",
+    });
+    assert.deepEqual(buildThinkingParams("glm-5.3-flash", "medium"), {
+      thinking: { type: "enabled" },
+    });
+    assert.deepEqual(buildThinkingParams("glm-5.3-flash", "xhigh"), {
+      thinking: { type: "enabled" },
     });
   } finally {
     if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;

--- a/src/tests/glm-client.test.ts
+++ b/src/tests/glm-client.test.ts
@@ -11,6 +11,7 @@ import {
   getThoughtLevels,
   resolveThoughtLevel,
   buildThinkingParams,
+  isVisionNativeModel,
 } from "../llm/glm-client.js";
 
 test("constructor uses the coding endpoint by default", () => {
@@ -191,7 +192,7 @@ test("getAvailableModels returns the Coding Plan allowlist by default", () => {
   delete process.env["ACP_GLM_AVAILABLE_MODELS"];
   try {
     const ids = getAvailableModels().map((m) => m.modelId);
-    assert.deepEqual(ids, ["glm-5.3", "glm-5-turbo", "glm-4.7"]);
+    assert.deepEqual(ids, ["glm-5.3", "glm-5.3-flash", "glm-5-turbo", "glm-4.7"]);
     assert.ok(!ids.includes("glm-4v-plus"), "glm-4v-plus must not be advertised");
     assert.ok(!ids.includes("glm-4.6"), "glm-4.6 must not be advertised");
     assert.ok(!ids.includes("glm-4.5"), "glm-4.5 must not be advertised");
@@ -220,6 +221,10 @@ test("getDefaultModel returns glm-5.3 without an env override", () => {
 
 test("getContextWindow reports the 1M window for glm-5.3", () => {
   assert.equal(getContextWindow("glm-5.3"), 1_000_000);
+});
+
+test("getContextWindow reports the 1M window for glm-5.3-flash", () => {
+  assert.equal(getContextWindow("glm-5.3-flash"), 1_000_000);
 });
 
 test("getContextWindow reports the 1M window for glm-5.2", () => {
@@ -348,12 +353,12 @@ test("streamChat disables thinking when effort is none", async () => {
 });
 
 test("getThoughtLevels omits none for reasoning-effort models", () => {
-  // Thinking cannot be turned off on glm-5.3: the endpoint accepts
-  // `thinking: { type: "disabled" }` and `reasoning_effort: "none"` but keeps
-  // emitting reasoning either way, so offering an "Off" option would lie.
-  // Everything else on the validated ladder is exposed, in ladder order.
+  // Thinking cannot be turned off on glm-5.3 / glm-5.3-flash: the endpoint
+  // errors on `thinking: { type: "disabled" }`, so offering an "Off" option
+  // would lie. Everything else on the validated ladder is exposed, in order.
   const ladder = ["minimal", "low", "medium", "high", "xhigh", "max"];
   assert.deepEqual(getThoughtLevels("glm-5.3"), ladder);
+  assert.deepEqual(getThoughtLevels("glm-5.3-flash"), ladder);
   // glm-5.2 and glm-5.1 are both served by glm-5.3, so they behave identically
   // — including the fact that "Off" would not actually turn thinking off.
   assert.deepEqual(getThoughtLevels("glm-5.2"), ladder);
@@ -455,12 +460,57 @@ test("buildThinkingParams honours ACP_GLM_THINKING=false override", () => {
   const old = process.env["ACP_GLM_THINKING"];
   process.env["ACP_GLM_THINKING"] = "false";
   try {
-    // Forced off even when a level requests thinking.
-    assert.deepEqual(buildThinkingParams("glm-5.2", "max"), { thinking: { type: "disabled" } });
+    // Forced off even when a level requests thinking — models that still
+    // accept thinking.type: "disabled" (not the GLM-5.3 family).
+    assert.deepEqual(buildThinkingParams("glm-4.7", "on"), { thinking: { type: "disabled" } });
+    assert.deepEqual(buildThinkingParams("glm-5-turbo", "on"), { thinking: { type: "disabled" } });
   } finally {
     if (old === undefined) delete process.env["ACP_GLM_THINKING"];
     else process.env["ACP_GLM_THINKING"] = old;
   }
+});
+
+test("buildThinkingParams attaches reasoning_effort on glm-5.3-flash", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  delete process.env["ACP_GLM_THINKING"];
+  try {
+    assert.deepEqual(buildThinkingParams("glm-5.3-flash", "max"), {
+      thinking: { type: "enabled" },
+      reasoning_effort: "max",
+    });
+  } finally {
+    if (old !== undefined) process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("buildThinkingParams does not send thinking.type=disabled on GLM-5.3 family", () => {
+  const old = process.env["ACP_GLM_THINKING"];
+  process.env["ACP_GLM_THINKING"] = "false";
+  try {
+    // Latest Z.AI docs: thinking.type: "disabled" errors on GLM-5.3 / Flash.
+    for (const model of ["glm-5.3", "glm-5.3-flash"]) {
+      const params = buildThinkingParams(model, "max");
+      assert.notDeepEqual(
+        params["thinking"],
+        { type: "disabled" },
+        `${model} must not send thinking.type: disabled`
+      );
+      assert.deepEqual(params["thinking"], { type: "enabled" });
+      assert.equal(params["reasoning_effort"], "max");
+    }
+  } finally {
+    if (old === undefined) delete process.env["ACP_GLM_THINKING"];
+    else process.env["ACP_GLM_THINKING"] = old;
+  }
+});
+
+test("isVisionNativeModel is true for Flash and glm-5v-turbo only", () => {
+  assert.equal(isVisionNativeModel("glm-5.3-flash"), true);
+  assert.equal(isVisionNativeModel("GLM-5.3-Flash"), true);
+  assert.equal(isVisionNativeModel("glm-5v-turbo"), true);
+  assert.equal(isVisionNativeModel("glm-5.3"), false);
+  assert.equal(isVisionNativeModel("glm-5-turbo"), false);
+  assert.equal(isVisionNativeModel("glm-4.7"), false);
 });
 
 test("streamChat does not flush partial tool calls (missing id or name)", async () => {


### PR DESCRIPTION
## Purpose

This feature advertises Z.AI's GLM-5.3-Flash as a built-in Coding Plan model so ACP clients can pick it, and routes pasted images on Flash sessions through native `image_url` parts instead of Vision MCP. Default new sessions stay on text-only `glm-5.3`.

## Key Changes

- Add `glm-5.3-flash` second in the built-in picker (1M context, native vision, cheaper Coding Plan quota); keep `glm-5.3` as the default
- Treat Flash as vision-native so JPEG/PNG image prompts emit `image_url` content and skip Vision MCP; `glm-5.3` still uses Vision MCP
- Stop sending `thinking.type: "disabled"` for GLM-5.3-family ids (`ACP_GLM_THINKING=false` included) because Z.AI now errors on it; turbo/4.7 on/off is unchanged
- Document Flash as the first built-in native-vision Coding Plan model, keep `glm-5v-turbo` as the opt-in exception, and note that Coding Plan docs currently claim turbo/4.7 may alias to Flash

## Checks

- [x] Type-check passes (`tsc` via `npm test`)
- [x] Tests pass (`npm test` — 251/251)
- [x] Lint passes (`npm run lint`)
- [x] Changes have been tested locally (unit tests; no live Coding Plan probe)

## Task

[#96](https://github.com/stefandevo/glm-acp-agent/issues/96)