### PR TITLE
#100 - Advertise ACP slash commands via available_commands_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Built-in web tools use Coding Plan-compatible MCP endpoints, not the general `/a
 
 ## Features
 
-- **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, `session/list`, `session/load`, `session/fork`, `session/resume`, and `session/set_model`
+- **Full ACP compliance** – implements `initialize`, `authenticate`, `session/new`, `session/set_mode`, `session/prompt`, `session/cancel`, `session/close`, `session/list`, `session/load`, `session/fork`, `session/resume`, and `session/set_model`, and pushes `session_info_update`, `config_option_update`, `current_mode_update`, and `available_commands_update` notifications
 - **Streaming** – assistant text and reasoning tokens are forwarded as incremental ACP chunks
 - **Tool calling** – agentic loop with a configurable cap of GLM function-calling turns (default 20; see `ACP_GLM_MAX_TURNS` / `--max-turns`)
 - **Thinking mode** – GLM's `reasoning_content` tokens are surfaced as `agent_thought_chunk` blocks so the client can show the model's chain of thought
 - **Session permission modes** – supports `default`, `accept_edits`, and `bypass_permissions` via `session/set_mode`. Clients like DevFlow can use this to toggle between prompting for every edit, auto-approving edits while prompting for commands, or bypassing permissions entirely.
 - **Per-session model switching** – `session/set_model` lets clients change the active GLM model mid-conversation; `session/new` returns the curated `availableModels` list
+- **Slash commands** – commands and skills found under the session's `.claude/` directory are advertised to the client with `available_commands_update`, so `/` autocomplete is populated (see [Slash commands](#slash-commands))
 - **Image input via Coding Plan-native vision or Vision MCP** – `promptCapabilities.image` is advertised; `glm-5.3-flash` sends supported pasted ACP image blocks directly as native `image_url` content parts, while the other advertised coding models (including default `glm-5.3`) route them through Z.AI Vision MCP (`@z_ai/mcp-server`). `glm-5v-turbo` keeps the same native-vision path when re-added via `ACP_GLM_AVAILABLE_MODELS` — it is no longer on the Coding Plan allowlist. Direct chat-image-only models (e.g. `glm-4v-plus`) are intentionally not used.
 - **Session persistence** – conversations are written to `~/.local/state/glm-acp-agent/sessions/` and can be reloaded via `session/load`, branched via `session/fork`, or resumed without replay via `session/resume`
 - **Seven built-in tools** (see below)
@@ -87,6 +88,36 @@ Clients can use `session/set_mode` to drive the permission policy:
 | `bypass_permissions` | Bypass all permissions | Silent | Silent |
 
 Reads, listings, and MCP tool calls are always silent across all modes.
+
+---
+
+## Slash commands
+
+After `session/new`, `session/load`, `session/fork`, and `session/resume`, the agent
+sends an ACP [`available_commands_update`](https://agentclientprotocol.com/protocol/v2/slash-commands)
+notification. Clients such as Zed and Paseo use it to populate their `/` autocomplete.
+Each notification is a full snapshot that replaces the previous list.
+
+The snapshot is built from the same on-disk layout Claude Code uses, read from the
+session's working directory and from `~/.claude` for user-level definitions:
+
+| Path | Command name |
+|---|---|
+| `<cwd>/.claude/commands/commit.md` | `/commit` |
+| `<cwd>/.claude/commands/review/pr.md` | `/review:pr` |
+| `<cwd>/.claude/skills/audit/SKILL.md` | `/audit` |
+
+Project definitions shadow user-level ones with the same name. The `description`
+and `argument-hint` keys of a file's YAML frontmatter become the menu entry's
+description and input hint; without a `description`, the first heading (then the
+first line) of the body is used instead.
+
+Advertised names are sent **without** a leading slash — the client prepends it for
+display and invokes the command by sending `/name …` as ordinary prompt text. When
+that text names an advertised command, the agent injects the definition's body into
+the user message, substituting `$ARGUMENTS` where the file asks for it and otherwise
+appending the typed arguments. Unknown `/foo` is left untouched and reaches the model
+as prose, so typing a slash by accident never fails the turn.
 
 ---
 
@@ -386,6 +417,7 @@ src/
 ├── protocol/
 │   ├── connection.ts         # Sets up the ACP stdio connection
 │   ├── agent.ts              # GlmAcpAgent – ACP protocol implementation
+│   ├── slash-commands.ts     # Discovers .claude commands/skills; expands `/name`
 │   └── session-store.ts      # On-disk persistence for load/fork/resume
 ├── tools/
 │   ├── definitions.ts        # Tool JSON schemas (function-calling format)
@@ -395,6 +427,7 @@ src/
     ├── credentials.test.ts   # Credential resolution and --setup persistence
     ├── executor.test.ts      # Tests for ToolExecutor
     ├── glm-client.test.ts    # Tests for streaming / tool-call assembly
+    ├── slash-commands.test.ts # Command discovery and `/name` expansion
     └── integration.test.ts   # End-to-end tests over the real ACP ndjson transport
 ```
 

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -31,6 +31,7 @@ import type {
   SetSessionConfigOptionRequest,
   SetSessionConfigOptionResponse,
   SessionConfigOption,
+  AvailableCommand,
   ModelInfo,
   StopReason,
   Usage,
@@ -56,6 +57,12 @@ import { TOOL_DEFINITIONS, type ToolDefinition } from "../tools/definitions.js";
 import { connectSessionMcpServers, type SessionMcpTools } from "../tools/session-mcp-client.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
+import {
+  discoverSlashCommands,
+  parseSlashCommand,
+  renderSlashCommand,
+  type SlashCommand,
+} from "./slash-commands.js";
 import { preprocessImageBlocks, buildPromptBlockDiagnosticLines } from "./image-preprocessor.js";
 import { StdioVisionMcpClient, type VisionMcpClient } from "../tools/vision-mcp-client.js";
 import { resolveApiKey } from "../llm/credentials.js";
@@ -151,6 +158,8 @@ interface SessionState {
   mode: SessionModeId;
   /** Reasoning effort for this session, controlled via the `thought_level` config option. */
   thoughtLevel: ThoughtLevel;
+  /** Slash commands discovered under this session's cwd, advertised to the client. */
+  commands: SlashCommand[];
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -379,7 +388,10 @@ export class GlmAcpAgent implements Agent {
       mcpTools,
       mode: "default",
       thoughtLevel,
+      commands: discoverSlashCommands(params.cwd),
     });
+
+    this.scheduleAvailableCommands(sessionId);
 
     return {
       sessionId,
@@ -387,6 +399,35 @@ export class GlmAcpAgent implements Agent {
       modes: this.modesState("default"),
       configOptions: this.configOptionsState(model, thoughtLevel, "default"),
     };
+  }
+
+  /**
+   * Queue an `available_commands_update` snapshot for a session.
+   *
+   * The notification is the only channel ACP gives us for slash-command
+   * autocomplete — it is not part of any method's response — so every session
+   * entry point (create / load / fork / resume) has to send one.
+   *
+   * It is deliberately *deferred* rather than awaited inline: a client learns a
+   * session's id from the `session/new` / `session/fork` response, so a
+   * notification written ahead of that response arrives for a session the client
+   * has never heard of, and clients drop those. Sending on the next macrotask
+   * puts it behind the response the caller is about to return (and, on load,
+   * behind the replayed transcript), which is also when a client is ready to
+   * paint the menu. Each send replaces the previous list wholesale.
+   */
+  private scheduleAvailableCommands(sessionId: string): void {
+    setTimeout(() => {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+      void safeSessionUpdate(this.connection, {
+        sessionId,
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: availableCommandsState(session.commands),
+        },
+      });
+    }, 0);
   }
 
   async unstable_setSessionModel(
@@ -700,11 +741,18 @@ export class GlmAcpAgent implements Agent {
         debug(line);
       }
     }
+    // Clients invoke an advertised command by sending `/name …` as ordinary
+    // prompt text, so expand it here into the instructions its definition
+    // holds. Unknown `/foo` is left alone and reaches the model as prose.
+    const { blocks: promptBlocks, invocation } = expandPromptCommand(
+      params.prompt,
+      session.commands
+    );
     const visionNative = isVisionNativeModel(session.model);
     const preprocessed = visionNative
-      ? { blocks: params.prompt, cleanups: [] }
+      ? { blocks: promptBlocks, cleanups: [] }
       : await preprocessImageBlocks(
-          params.prompt,
+          promptBlocks,
           this.visionClient,
           abortController.signal
         );
@@ -737,7 +785,10 @@ export class GlmAcpAgent implements Agent {
       const titleUpdate: { title?: string | null } =
         session.title === null
           ? (() => {
-              const derived = userText.slice(0, 80).replace(/\s+/g, " ").trim();
+              const derived = (invocation ?? userText)
+                .slice(0, 80)
+                .replace(/\s+/g, " ")
+                .trim();
               session.title = derived.length > 0 ? derived : "New conversation";
               return { title: session.title };
             })()
@@ -882,6 +933,7 @@ export class GlmAcpAgent implements Agent {
       mcpTools,
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
+      commands: discoverSlashCommands(params.cwd),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -889,6 +941,8 @@ export class GlmAcpAgent implements Agent {
     // Tool / system messages are skipped — they're internal and the client
     // doesn't render them on its own.
     await this.replayMessages(params.sessionId, persisted.messages);
+
+    this.scheduleAvailableCommands(params.sessionId);
 
     return {
       models: this.modelsState(persisted.model),
@@ -927,9 +981,14 @@ export class GlmAcpAgent implements Agent {
       mcpTools,
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
+      commands: discoverSlashCommands(params.cwd),
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
+
+    // Notify on the *created* session id — the parent thread's command list is
+    // unchanged and a notify there would repaint the wrong menu.
+    this.scheduleAvailableCommands(newSessionId);
 
     return {
       sessionId: newSessionId,
@@ -963,8 +1022,11 @@ export class GlmAcpAgent implements Agent {
       mcpTools,
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
+      commands: discoverSlashCommands(params.cwd),
     };
     this.sessions.set(params.sessionId, restored);
+
+    this.scheduleAvailableCommands(params.sessionId);
 
     // Resume does NOT replay history — the client keeps its own UI state and
     // just wants the agent to pick up where it left off.
@@ -1448,6 +1510,48 @@ function availableModelsWith(currentModelId: string): ModelInfo[] {
   return available.some((m) => m.modelId === currentModelId)
     ? available
     : [...available, { modelId: currentModelId, name: currentModelId }];
+}
+
+/**
+ * Map discovered commands onto the ACP wire shape. Names are sent *without* a
+ * leading slash — the client prepends it for display and sends `/name …` back
+ * as prompt text. `input` is omitted for commands that declare no
+ * `argument-hint`, which is how a client learns the command takes no extra text.
+ */
+function availableCommandsState(
+  commands: ReadonlyArray<SlashCommand>
+): AvailableCommand[] {
+  return commands.map((command) => ({
+    name: command.name,
+    description: command.description,
+    ...(command.argumentHint !== undefined
+      ? { input: { hint: command.argumentHint } }
+      : {}),
+  }));
+}
+
+/**
+ * Expand a leading `/name` in the first prompt block into the command's body.
+ *
+ * Returns the blocks unchanged (and a null `invocation`) when the prompt does
+ * not start with an advertised command. `invocation` carries the text the user
+ * actually typed so the session title doesn't end up being the expanded body.
+ */
+function expandPromptCommand(
+  blocks: PromptRequest["prompt"],
+  commands: ReadonlyArray<SlashCommand>
+): { blocks: PromptRequest["prompt"]; invocation: string | null } {
+  const first = blocks[0];
+  if (first?.type !== "text") return { blocks, invocation: null };
+  const parsed = parseSlashCommand(first.text, commands);
+  if (!parsed) return { blocks, invocation: null };
+  return {
+    blocks: [{ ...first, text: renderSlashCommand(parsed) }, ...blocks.slice(1)],
+    invocation:
+      parsed.args.length > 0
+        ? `/${parsed.command.name} ${parsed.args}`
+        : `/${parsed.command.name}`,
+  };
 }
 
 /**

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -1531,9 +1531,14 @@ function availableCommandsState(
 }
 
 /**
- * Expand a leading `/name` in the first prompt block into the command's body.
+ * Expand a leading `/name` in the prompt's first written text into the
+ * command's body.
  *
- * Returns the blocks unchanged (and a null `invocation`) when the prompt does
+ * The target is the first text block that actually has content, not block 0:
+ * a client may place an image or resource block ahead of what the user typed,
+ * and the command would otherwise reach the model as a literal `/name`.
+ *
+ * Returns the blocks unchanged (and a null `invocation`) when that text does
  * not start with an advertised command. `invocation` carries the text the user
  * actually typed so the session title doesn't end up being the expanded body.
  */
@@ -1541,12 +1546,17 @@ function expandPromptCommand(
   blocks: PromptRequest["prompt"],
   commands: ReadonlyArray<SlashCommand>
 ): { blocks: PromptRequest["prompt"]; invocation: string | null } {
-  const first = blocks[0];
-  if (first?.type !== "text") return { blocks, invocation: null };
-  const parsed = parseSlashCommand(first.text, commands);
+  const index = blocks.findIndex(
+    (block) => block.type === "text" && block.text.trim().length > 0
+  );
+  const typed = blocks[index];
+  if (typed?.type !== "text") return { blocks, invocation: null };
+  const parsed = parseSlashCommand(typed.text, commands);
   if (!parsed) return { blocks, invocation: null };
+  const expanded = [...blocks];
+  expanded[index] = { ...typed, text: renderSlashCommand(parsed) };
   return {
-    blocks: [{ ...first, text: renderSlashCommand(parsed) }, ...blocks.slice(1)],
+    blocks: expanded,
     invocation:
       parsed.args.length > 0
         ? `/${parsed.command.name} ${parsed.args}`

--- a/src/protocol/slash-commands.ts
+++ b/src/protocol/slash-commands.ts
@@ -162,7 +162,8 @@ function splitFrontmatter(contents: string): {
   for (const line of match[1]!.split(/\r?\n/)) {
     const separator = line.indexOf(":");
     if (separator <= 0) continue;
-    const key = line.slice(0, separator).trim();
+    // Lower-cased so a hand-written `Description:` still resolves.
+    const key = line.slice(0, separator).trim().toLowerCase();
     const value = line
       .slice(separator + 1)
       .trim()

--- a/src/protocol/slash-commands.ts
+++ b/src/protocol/slash-commands.ts
@@ -20,7 +20,7 @@
  * All I/O errors are swallowed: having no commands at all is the common case,
  * and a broken command file should never fail `session/new`.
  */
-import { readdirSync, readFileSync, type Dirent } from "node:fs";
+import { closeSync, openSync, readSync, readdirSync, type Dirent } from "node:fs";
 import { homedir } from "node:os";
 import { join as pathJoin } from "node:path";
 
@@ -55,8 +55,21 @@ const MAX_COMMANDS = 200;
 /** How deep to walk `.claude/commands`; deeper files are ignored. */
 const MAX_COMMAND_DEPTH = 3;
 
-/** Descriptions are shown in a one-line menu entry, so keep them short. */
-const DESCRIPTION_CAP_CHARS = 200;
+/**
+ * Cap on the strings that reach the client's one-line menu entry — the
+ * description and the argument hint. Both are advertised verbatim, so neither
+ * may carry an unbounded frontmatter value through to the notification.
+ */
+const MENU_TEXT_CAP_CHARS = 200;
+
+/**
+ * Cap on how much of a command file is read. Discovery runs automatically at
+ * every session entry point over as many as {@link MAX_COMMANDS} files, so an
+ * oversized file in a cloned workspace must never be pulled into memory whole.
+ * A bounded prefix rather than a hard skip keeps frontmatter and the start of
+ * the body usable; {@link COMMAND_BODY_CAP_CHARS} still binds what we store.
+ */
+const MAX_COMMAND_FILE_BYTES = 64 * 1024;
 
 /**
  * Names have to survive being typed after a `/` and split on whitespace, and we
@@ -91,8 +104,9 @@ function collectCommandFiles(
   prefix: string[],
   found: Map<string, SlashCommand>
 ): void {
-  if (prefix.length >= MAX_COMMAND_DEPTH) return;
+  if (prefix.length >= MAX_COMMAND_DEPTH || found.size >= MAX_COMMANDS) return;
   for (const entry of readDirSafe(dir)) {
+    if (found.size >= MAX_COMMANDS) return;
     const path = pathJoin(dir, entry.name);
     if (entry.isDirectory()) {
       collectCommandFiles(path, [...prefix, entry.name], found);
@@ -105,7 +119,9 @@ function collectCommandFiles(
 
 /** Read `<skills>/<name>/SKILL.md` definitions; the directory name is the command name. */
 function collectSkillFiles(dir: string, found: Map<string, SlashCommand>): void {
+  if (found.size >= MAX_COMMANDS) return;
   for (const entry of readDirSafe(dir)) {
+    if (found.size >= MAX_COMMANDS) return;
     if (!entry.isDirectory()) continue;
     addCommand(found, entry.name, pathJoin(dir, entry.name, "SKILL.md"));
   }
@@ -119,26 +135,40 @@ function readDirSafe(dir: string): Dirent<string>[] {
   }
 }
 
+/**
+ * Read at most {@link MAX_COMMAND_FILE_BYTES} from a file, or `undefined` when
+ * it can't be read at all. A trailing multi-byte character can be cut at the
+ * boundary, which is harmless: the tail of a file that large is discarded by
+ * the body cap regardless.
+ */
+function readCappedFile(path: string): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(MAX_COMMAND_FILE_BYTES);
+    const bytes = readSync(fd, buffer, 0, MAX_COMMAND_FILE_BYTES, 0);
+    return buffer.toString("utf-8", 0, bytes);
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
 function addCommand(
   found: Map<string, SlashCommand>,
   name: string,
   path: string
 ): void {
-  if (found.size >= MAX_COMMANDS) return;
   if (!COMMAND_NAME_PATTERN.test(name) || found.has(name)) return;
-  let contents: string;
-  try {
-    contents = readFileSync(path, { encoding: "utf-8" });
-  } catch {
-    return;
-  }
+  const contents = readCappedFile(path);
+  if (contents === undefined) return;
   const { frontmatter, body } = splitFrontmatter(contents);
+  const argumentHint = frontmatter["argument-hint"]?.slice(0, MENU_TEXT_CAP_CHARS);
   found.set(name, {
     name,
     description: describe(frontmatter["description"], body, name),
-    ...(frontmatter["argument-hint"] !== undefined
-      ? { argumentHint: frontmatter["argument-hint"] }
-      : {}),
+    ...(argumentHint !== undefined ? { argumentHint } : {}),
     body: body.slice(0, COMMAND_BODY_CAP_CHARS).trim(),
     source: path,
   });
@@ -186,7 +216,7 @@ function describe(
   const candidates = [fromFrontmatter, firstHeading(body), firstProseLine(body)];
   for (const candidate of candidates) {
     const text = candidate?.replace(/\s+/g, " ").trim();
-    if (text) return text.slice(0, DESCRIPTION_CAP_CHARS);
+    if (text) return text.slice(0, MENU_TEXT_CAP_CHARS);
   }
   return `Run the /${name} command.`;
 }

--- a/src/protocol/slash-commands.ts
+++ b/src/protocol/slash-commands.ts
@@ -1,0 +1,257 @@
+/**
+ * Discovers the slash commands a session can offer and expands them when the
+ * user invokes one.
+ *
+ * ACP clients fill their `/` autocomplete from the `available_commands_update`
+ * notification an agent sends after `session/new` (and load / fork / resume).
+ * Commands are then invoked as ordinary prompt text — the client sends
+ * `"/commit group by feature"` as a text block and the agent is responsible for
+ * recognising the prefix.
+ *
+ * We read the same on-disk layout Claude Code uses, so a project that already
+ * ships commands or skills works without extra configuration:
+ *
+ *   <cwd>/.claude/commands/<name>.md     → `/name` (nested files become `/dir:name`)
+ *   <cwd>/.claude/skills/<name>/SKILL.md → `/name`
+ *
+ * plus the same two directories under `~/.claude` for user-level commands.
+ * Project definitions win over user-level ones with the same name.
+ *
+ * All I/O errors are swallowed: having no commands at all is the common case,
+ * and a broken command file should never fail `session/new`.
+ */
+import { readdirSync, readFileSync, type Dirent } from "node:fs";
+import { homedir } from "node:os";
+import { join as pathJoin } from "node:path";
+
+/** A command discovered on disk, ready to advertise and to expand. */
+export interface SlashCommand {
+  /** Command name *without* a leading slash — the client prepends it. */
+  name: string;
+  /** One-line description rendered in the client's slash menu. */
+  description: string;
+  /** Placeholder for the free text typed after the name; absent when the command takes none. */
+  argumentHint?: string;
+  /** Markdown body injected into the prompt when the command is invoked. */
+  body: string;
+  /** Absolute path the definition was read from, quoted back to the model. */
+  source: string;
+}
+
+/**
+ * Cap on a single command body embedded into a prompt. Command files are
+ * usually a screenful of instructions; this bounds the worst case for a project
+ * that keeps an entire playbook in one.
+ */
+const COMMAND_BODY_CAP_CHARS = 16 * 1024;
+
+/**
+ * Cap on the advertised list so a pathological tree can't flood the client — or
+ * make `session/new` read tens of thousands of files. Roots are visited in
+ * precedence order, so a truncated list keeps the project's own commands.
+ */
+const MAX_COMMANDS = 200;
+
+/** How deep to walk `.claude/commands`; deeper files are ignored. */
+const MAX_COMMAND_DEPTH = 3;
+
+/** Descriptions are shown in a one-line menu entry, so keep them short. */
+const DESCRIPTION_CAP_CHARS = 200;
+
+/**
+ * Names have to survive being typed after a `/` and split on whitespace, and we
+ * build some of them from path segments — so restrict to the characters Claude
+ * Code itself allows.
+ */
+const COMMAND_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_:.-]*$/;
+
+/**
+ * Collect the commands available to a session rooted at `cwd`, sorted by name.
+ *
+ * Project commands shadow user-level ones, and within a root a `commands/` file
+ * shadows a same-named skill — first writer wins, so roots are visited in
+ * precedence order.
+ */
+export function discoverSlashCommands(cwd: string): SlashCommand[] {
+  const found = new Map<string, SlashCommand>();
+  for (const root of [pathJoin(cwd, ".claude"), pathJoin(homedir(), ".claude")]) {
+    collectCommandFiles(pathJoin(root, "commands"), [], found);
+    collectSkillFiles(pathJoin(root, "skills"), found);
+  }
+  return [...found.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Recursively read `*.md` files under a `commands/` directory. Nested files are
+ * namespaced with `:` (`commands/review/pr.md` → `review:pr`), matching how
+ * Claude Code names subdirectory commands.
+ */
+function collectCommandFiles(
+  dir: string,
+  prefix: string[],
+  found: Map<string, SlashCommand>
+): void {
+  if (prefix.length >= MAX_COMMAND_DEPTH) return;
+  for (const entry of readDirSafe(dir)) {
+    const path = pathJoin(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectCommandFiles(path, [...prefix, entry.name], found);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    addCommand(found, [...prefix, entry.name.slice(0, -".md".length)].join(":"), path);
+  }
+}
+
+/** Read `<skills>/<name>/SKILL.md` definitions; the directory name is the command name. */
+function collectSkillFiles(dir: string, found: Map<string, SlashCommand>): void {
+  for (const entry of readDirSafe(dir)) {
+    if (!entry.isDirectory()) continue;
+    addCommand(found, entry.name, pathJoin(dir, entry.name, "SKILL.md"));
+  }
+}
+
+function readDirSafe(dir: string): Dirent<string>[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function addCommand(
+  found: Map<string, SlashCommand>,
+  name: string,
+  path: string
+): void {
+  if (found.size >= MAX_COMMANDS) return;
+  if (!COMMAND_NAME_PATTERN.test(name) || found.has(name)) return;
+  let contents: string;
+  try {
+    contents = readFileSync(path, { encoding: "utf-8" });
+  } catch {
+    return;
+  }
+  const { frontmatter, body } = splitFrontmatter(contents);
+  found.set(name, {
+    name,
+    description: describe(frontmatter["description"], body, name),
+    ...(frontmatter["argument-hint"] !== undefined
+      ? { argumentHint: frontmatter["argument-hint"] }
+      : {}),
+    body: body.slice(0, COMMAND_BODY_CAP_CHARS).trim(),
+    source: path,
+  });
+}
+
+/**
+ * Split a leading `---` YAML frontmatter block off a markdown file.
+ *
+ * Deliberately not a YAML parser: command frontmatter in the wild is flat
+ * `key: value` lines, and pulling in a dependency to read `description` and
+ * `argument-hint` would not pay for itself. Anything we can't parse is simply
+ * dropped, and the description falls back to the body.
+ */
+function splitFrontmatter(contents: string): {
+  frontmatter: Record<string, string>;
+  body: string;
+} {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(contents);
+  if (!match) return { frontmatter: {}, body: contents };
+  const frontmatter: Record<string, string> = {};
+  for (const line of match[1]!.split(/\r?\n/)) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line
+      .slice(separator + 1)
+      .trim()
+      .replace(/^["'](.*)["']$/, "$1")
+      .trim();
+    if (key.length > 0 && value.length > 0) frontmatter[key] = value;
+  }
+  return { frontmatter, body: contents.slice(match[0].length) };
+}
+
+/**
+ * ACP requires a non-empty description, so fall back through the body's first
+ * heading, then its first prose line, then the command name itself.
+ */
+function describe(
+  fromFrontmatter: string | undefined,
+  body: string,
+  name: string
+): string {
+  const candidates = [fromFrontmatter, firstHeading(body), firstProseLine(body)];
+  for (const candidate of candidates) {
+    const text = candidate?.replace(/\s+/g, " ").trim();
+    if (text) return text.slice(0, DESCRIPTION_CAP_CHARS);
+  }
+  return `Run the /${name} command.`;
+}
+
+function firstHeading(body: string): string | undefined {
+  return /^#{1,6}[ \t]+(.+)$/m.exec(body)?.[1];
+}
+
+function firstProseLine(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0 && !trimmed.startsWith("#")) return trimmed;
+  }
+  return undefined;
+}
+
+/** A parsed `/name rest` prompt. */
+export interface ParsedSlashCommand {
+  command: SlashCommand;
+  /** Everything typed after the command name, trimmed; `""` when nothing was. */
+  args: string;
+}
+
+/**
+ * Match a prompt against the known commands. Returns `undefined` for anything
+ * that isn't a leading `/name` we advertised, so prose that happens to start
+ * with a slash (and unknown commands) still reaches the model untouched.
+ */
+export function parseSlashCommand(
+  text: string,
+  commands: ReadonlyArray<SlashCommand>
+): ParsedSlashCommand | undefined {
+  // Any whitespace separates the name from its arguments: prompt editors let a
+  // user press shift-enter after `/name`, so the arguments can start on the
+  // next line rather than after a space.
+  const match = /^\/(\S+)(?:\s+([\s\S]*))?$/.exec(text.trim());
+  if (!match) return undefined;
+  const command = commands.find((c) => c.name === match[1]);
+  if (!command) return undefined;
+  return { command, args: match[2]?.trim() ?? "" };
+}
+
+/**
+ * Render an invoked command as the user message the model actually sees.
+ *
+ * The body is presented as instructions rather than as opaque data (unlike
+ * `<project_context>`): the user explicitly typed `/name`, so running what that
+ * file says *is* the request. `$ARGUMENTS` is substituted where the definition
+ * asks for it, which is the convention `.claude/commands` files are written
+ * against; otherwise the arguments are appended as their own line.
+ */
+export function renderSlashCommand(parsed: ParsedSlashCommand): string {
+  const { command, args } = parsed;
+  const usesPlaceholder = command.body.includes("$ARGUMENTS");
+  const body = usesPlaceholder
+    ? command.body.replaceAll("$ARGUMENTS", args)
+    : command.body;
+  const lines = [
+    `<slash_command name="${command.name}" source="${command.source}">`,
+    `The user invoked the /${command.name} command. Follow the instructions below.`,
+    "",
+    body,
+  ];
+  if (args.length > 0 && !usesPlaceholder) {
+    lines.push("", `Arguments: ${args}`);
+  }
+  lines.push("</slash_command>");
+  return lines.join("\n");
+}

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 import { GlmAcpAgent } from "../protocol/agent.js";
@@ -14,6 +14,11 @@ import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 process.env["ACP_GLM_SESSION_DIR"] = mkdtempSync(
   pathJoin(osTmpdir(), "glm-acp-test-default-")
 );
+
+// Slash-command discovery scans `~/.claude` as well as the session cwd. Point
+// HOME at an isolated tempdir so a developer's own commands can't leak into the
+// advertised snapshots asserted on below.
+process.env["HOME"] = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-home-"));
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -119,6 +124,14 @@ function captureSystemPrompt() {
   return { glm, ref };
 }
 
+/**
+ * Yield to the macrotask queue so deferred notifications — today only
+ * `available_commands_update` — have reached the connection stub.
+ */
+function flushNotifications(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 /** Create an isolated temp directory to use as a session cwd, optionally seeded with files. */
 function makeTempCwd(files: Record<string, string> = {}): {
   cwd: string;
@@ -126,7 +139,9 @@ function makeTempCwd(files: Record<string, string> = {}): {
 } {
   const cwd = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-cwd-"));
   for (const [name, content] of Object.entries(files)) {
-    writeFileSync(pathJoin(cwd, name), content);
+    const path = pathJoin(cwd, name);
+    mkdirSync(pathJoin(path, ".."), { recursive: true });
+    writeFileSync(path, content);
   }
   return {
     cwd,
@@ -2236,8 +2251,12 @@ test("resumeSession restores in-memory state without replaying messages", async 
     });
 
     assert.equal(result.models?.currentModelId, "glm-5.1");
-    // No replay updates expected.
-    assert.equal(conn.updates.length, 0);
+    await flushNotifications();
+    // No replay updates expected — only the slash-command advertisement.
+    assert.deepEqual(
+      conn.updates.map((u) => (u.update as { sessionUpdate: string }).sessionUpdate),
+      ["available_commands_update"]
+    );
   } finally {
     cleanup();
   }
@@ -2462,4 +2481,267 @@ test("prompt fails fast when context overflow persists after emergency compactio
   assert.equal(caught.message, "Context overflow persisted after emergency compaction");
   assert.equal(caught.cause, secondOverflow);
   assert.equal(errorMessages.length, 1, "expected an error message reporting persistent overflow");
+});
+
+// ---------------------------------------------------------------------------
+// Slash commands (available_commands_update)
+// ---------------------------------------------------------------------------
+
+/** Files that give a session cwd one discoverable `/deploy` command. */
+const COMMAND_FIXTURE = {
+  ".claude/commands/deploy.md":
+    "---\ndescription: Ship the current branch\nargument-hint: <environment>\n---\nRun the deploy playbook.\n",
+};
+
+interface AvailableCommandsEnvelope {
+  sessionId: string;
+  update: {
+    sessionUpdate: string;
+    availableCommands?: Array<{ name: string; description: string; input?: { hint: string } }>;
+  };
+}
+
+function commandUpdates(conn: ConnectionStub): AvailableCommandsEnvelope[] {
+  return (conn.updates as unknown as AvailableCommandsEnvelope[]).filter(
+    (u) => u.update.sessionUpdate === "available_commands_update"
+  );
+}
+
+/** Capture the last user message handed to the model on a prompt turn. */
+function captureUserMessage() {
+  const ref = { value: "" };
+  const glm = {
+    async *streamChat(
+      messages: ReadonlyArray<{ role: string; content?: unknown }>
+    ): AsyncGenerator<GlmStreamChunk> {
+      const users = messages.filter((m) => m.role === "user");
+      const last = users[users.length - 1];
+      ref.value = typeof last?.content === "string" ? last.content : "";
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+  return { glm, ref };
+}
+
+test("newSession advertises commands discovered under the session cwd", async () => {
+  const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await flushNotifications();
+
+    const updates = commandUpdates(conn);
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0]?.sessionId, sessionId);
+    const commands = updates[0]?.update.availableCommands ?? [];
+    assert.deepEqual(
+      commands.map((c) => c.name),
+      ["deploy"]
+    );
+    assert.equal(commands[0]?.description, "Ship the current branch");
+    assert.equal(commands[0]?.input?.hint, "<environment>");
+  } finally {
+    cleanup();
+  }
+});
+
+test("advertised command names carry no leading slash", async () => {
+  const { cwd, cleanup } = makeTempCwd({
+    ...COMMAND_FIXTURE,
+    ".claude/skills/audit/SKILL.md": "---\ndescription: Audit dependencies\n---\nCheck the lockfile.\n",
+  });
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    await agent.newSession({ cwd, mcpServers: [] });
+    await flushNotifications();
+
+    const commands = commandUpdates(conn)[0]?.update.availableCommands ?? [];
+    assert.deepEqual(
+      commands.map((c) => c.name),
+      ["audit", "deploy"]
+    );
+    for (const command of commands) {
+      assert.ok(!command.name.startsWith("/"), `${command.name} should not start with /`);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("newSession advertises an empty list when the cwd has no commands", async () => {
+  const { cwd, cleanup } = makeTempCwd({ "README.md": "hello" });
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: null });
+    await agent.newSession({ cwd, mcpServers: [] });
+    await flushNotifications();
+
+    assert.deepEqual(commandUpdates(conn)[0]?.update.availableCommands, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test("loadSession advertises commands after replaying history", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    store.save({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd,
+      messages: [
+        { role: "system", content: "system" },
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+      ],
+      title: "ping pong",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+      mode: "default",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.loadSession({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd,
+      mcpServers: [],
+    });
+    await flushNotifications();
+
+    const kinds = conn.updates.map(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate
+    );
+    // The snapshot lands last so the client has a hydrated transcript before it
+    // paints the slash menu.
+    assert.equal(kinds[kinds.length - 1], "available_commands_update");
+    assert.deepEqual(
+      commandUpdates(conn)[0]?.update.availableCommands?.map((c) => c.name),
+      ["deploy"]
+    );
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("unstable_forkSession advertises commands on the new session id", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await flushNotifications();
+    conn.updates.length = 0;
+
+    const fork = await agent.unstable_forkSession({ sessionId, cwd, mcpServers: [] });
+    await flushNotifications();
+
+    const updates = commandUpdates(conn);
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0]?.sessionId, fork.sessionId);
+    assert.notEqual(updates[0]?.sessionId, sessionId);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("resumeSession advertises commands for the resumed cwd", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    store.save({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd,
+      messages: [{ role: "system", content: "system" }],
+      title: null,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-5.1",
+      mode: "default",
+    });
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.resumeSession({
+      sessionId: "abcd1234-abcd-abcd-abcd-abcdabcd1234",
+      cwd,
+      mcpServers: [],
+    });
+    await flushNotifications();
+
+    assert.deepEqual(
+      commandUpdates(conn)[0]?.update.availableCommands?.map((c) => c.name),
+      ["deploy"]
+    );
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("prompt expands an advertised /command into its body", async () => {
+  const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const { glm, ref } = captureUserMessage();
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+
+    await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/deploy staging" }],
+    });
+
+    assert.match(ref.value, /The user invoked the \/deploy command/);
+    assert.match(ref.value, /Run the deploy playbook\./);
+    assert.match(ref.value, /Arguments: staging/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("prompt leaves an unknown /command as plain prose", async () => {
+  const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const { glm, ref } = captureUserMessage();
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+
+    await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/nope do something" }],
+    });
+
+    assert.equal(ref.value, "/nope do something");
+  } finally {
+    cleanup();
+  }
+});
+
+test("prompt titles the session with the typed command, not the expanded body", async () => {
+  const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const { glm } = captureUserMessage();
+    const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+
+    await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/deploy staging" }],
+    });
+
+    const info = conn.updates.find(
+      (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "session_info_update"
+    );
+    assert.equal((info?.update as { title?: string }).title, "/deploy staging");
+  } finally {
+    cleanup();
+  }
 });

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -2705,6 +2705,35 @@ test("prompt expands an advertised /command into its body", async () => {
   }
 });
 
+test("prompt expands a /command that follows a non-text block", async () => {
+  const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const conn = createConnectionStub();
+    const { glm, ref } = captureUserMessage();
+    const agent = new GlmAcpAgent(conn as never, {
+      glm,
+      sessionStore: null,
+      visionClient: null,
+    });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+
+    // A client may put a pasted image ahead of the typed text; the command is
+    // still what the user wrote.
+    await agent.prompt({
+      sessionId,
+      prompt: [
+        { type: "image", mimeType: "image/png", data: "aGk=" },
+        { type: "text", text: "/deploy staging" },
+      ],
+    });
+
+    assert.match(ref.value, /The user invoked the \/deploy command/);
+    assert.match(ref.value, /Run the deploy playbook\./);
+  } finally {
+    cleanup();
+  }
+});
+
 test("prompt leaves an unknown /command as plain prose", async () => {
   const { cwd, cleanup } = makeTempCwd(COMMAND_FIXTURE);
   try {

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 
@@ -10,6 +10,10 @@ import { join as pathJoin } from "node:path";
 process.env["ACP_GLM_SESSION_DIR"] = mkdtempSync(
   pathJoin(osTmpdir(), "glm-acp-integration-test-")
 );
+
+// Slash-command discovery scans `~/.claude`; isolate HOME so the developer's
+// own commands can't appear in the advertised snapshot asserted on below.
+process.env["HOME"] = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-integration-home-"));
 import {
   AgentSideConnection,
   ClientSideConnection,
@@ -303,5 +307,61 @@ test("end-to-end: session mode change mid-conversation affects permission prompt
     assert.equal(pathJoin(dir, "x.txt"), pathJoin(dir, "x.txt")); // sanity
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function commandSnapshots(stub: StubClient): Array<Record<string, unknown>> {
+  return stub.updates.filter(
+    (u) => (u.update as { sessionUpdate: string }).sessionUpdate === "available_commands_update"
+  );
+}
+
+test("end-to-end: the client receives an available_commands_update after session/new", async () => {
+  const { a, b } = pairedStreams();
+  const stub = new StubClient();
+  const cwd = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-integration-cmds-"));
+  mkdirSync(pathJoin(cwd, ".claude", "commands"), { recursive: true });
+  writeFileSync(
+    pathJoin(cwd, ".claude", "commands", "deploy.md"),
+    "---\ndescription: Ship the current branch\nargument-hint: <environment>\n---\nRun the deploy playbook.\n",
+    "utf8"
+  );
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _agentConn = new AgentSideConnection(
+      (conn) => new GlmAcpAgent(conn, { sessionStore: null }),
+      a
+    );
+    const clientConn = new ClientSideConnection(() => stub, b);
+
+    await clientConn.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+    });
+    const session = await clientConn.newSession({ cwd, mcpServers: [] });
+
+    // The snapshot is deferred until after the session/new response: a client
+    // only learns the session id from that response, so an update sent ahead of
+    // it would name a session the client has never heard of.
+    assert.equal(commandSnapshots(stub).length, 0);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const advertised = commandSnapshots(stub);
+    assert.equal(advertised.length, 1);
+    assert.equal(advertised[0]?.["sessionId"], session.sessionId);
+    const commands = (
+      advertised[0]?.update as {
+        availableCommands: Array<{ name: string; description: string; input?: { hint: string } }>;
+      }
+    ).availableCommands;
+    assert.deepEqual(
+      commands.map((c) => c.name),
+      ["deploy"]
+    );
+    assert.equal(commands[0]?.description, "Ship the current branch");
+    assert.equal(commands[0]?.input?.hint, "<environment>");
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
   }
 });

--- a/src/tests/slash-commands.test.ts
+++ b/src/tests/slash-commands.test.ts
@@ -140,6 +140,49 @@ test("discoverSlashCommands lets a project command shadow a same-named user comm
   }
 });
 
+test("discoverSlashCommands caps an oversized argument hint", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/huge.md":
+      `---\ndescription: Fine\nargument-hint: ${"x".repeat(5000)}\n---\nbody\n`,
+  });
+  try {
+    assert.equal(discoverSlashCommands(cwd)[0]?.argumentHint?.length, 200);
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands reads only a bounded prefix of an oversized file", () => {
+  // Discovery runs at every session entry point, so an oversized file must be
+  // truncated on read rather than pulled into memory whole. The heading sits
+  // past the read cap: it is only reachable if the whole file was read, so the
+  // description it would produce is the probe for an unbounded read.
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/big.md": `${"filler\n".repeat(600_000)}# Past the read cap\n`,
+  });
+  try {
+    const command = discoverSlashCommands(cwd)[0];
+    assert.equal(command?.name, "big");
+    assert.equal(command?.description, "filler");
+    assert.equal(command?.body.length, 16 * 1024);
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands stops traversing once the command cap is reached", () => {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 250; i++) {
+    files[`.claude/commands/c${String(i).padStart(3, "0")}.md`] = "body\n";
+  }
+  const { cwd, cleanup } = makeTree(files);
+  try {
+    assert.equal(discoverSlashCommands(cwd).length, 200);
+  } finally {
+    cleanup();
+  }
+});
+
 test("discoverSlashCommands returns nothing for a cwd with no .claude directory", () => {
   const { cwd, cleanup } = makeTree({ "README.md": "hello" });
   try {

--- a/src/tests/slash-commands.test.ts
+++ b/src/tests/slash-commands.test.ts
@@ -96,6 +96,20 @@ test("discoverSlashCommands falls back to the first heading, then the first line
   }
 });
 
+test("discoverSlashCommands matches frontmatter keys case-insensitively", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/ship.md":
+      "---\nDescription: Ship it\nArgument-Hint: <target>\n---\nDo the thing.\n",
+  });
+  try {
+    const commands = discoverSlashCommands(cwd);
+    assert.equal(commands[0]?.description, "Ship it");
+    assert.equal(commands[0]?.argumentHint, "<target>");
+  } finally {
+    cleanup();
+  }
+});
+
 test("discoverSlashCommands omits argumentHint when the definition declares none", () => {
   const { cwd, cleanup } = makeTree({
     ".claude/commands/status.md": "---\ndescription: Show status\n---\nRun git status.\n",

--- a/src/tests/slash-commands.test.ts
+++ b/src/tests/slash-commands.test.ts
@@ -1,0 +1,177 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir as osTmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
+
+// `discoverSlashCommands` also scans `~/.claude`, so point HOME at an isolated
+// tempdir before importing it: without this the developer's own commands would
+// leak into every assertion below.
+const fakeHome = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-home-"));
+process.env["HOME"] = fakeHome;
+
+const { discoverSlashCommands, parseSlashCommand, renderSlashCommand } =
+  await import("../protocol/slash-commands.js");
+
+/** Create a temp cwd seeded with files given as cwd-relative paths. */
+function makeTree(files: Record<string, string>): {
+  cwd: string;
+  cleanup: () => void;
+} {
+  const cwd = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-test-cmds-"));
+  writeTree(cwd, files);
+  return { cwd, cleanup: () => rmSync(cwd, { recursive: true, force: true }) };
+}
+
+function writeTree(root: string, files: Record<string, string>): void {
+  for (const [relative, content] of Object.entries(files)) {
+    const path = pathJoin(root, relative);
+    mkdirSync(pathJoin(path, ".."), { recursive: true });
+    writeFileSync(path, content);
+  }
+}
+
+test("discoverSlashCommands reads .claude/commands markdown files", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/commit.md":
+      "---\ndescription: Commit staged changes\nargument-hint: <message>\n---\nWrite a conventional commit.\n",
+  });
+  try {
+    const commands = discoverSlashCommands(cwd);
+    assert.equal(commands.length, 1);
+    assert.equal(commands[0]?.name, "commit");
+    assert.equal(commands[0]?.description, "Commit staged changes");
+    assert.equal(commands[0]?.argumentHint, "<message>");
+    assert.equal(commands[0]?.body, "Write a conventional commit.");
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands reads .claude/skills SKILL.md files", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/skills/review/SKILL.md":
+      "---\nname: review\ndescription: Review the working tree\n---\nLook for bugs.\n",
+  });
+  try {
+    const commands = discoverSlashCommands(cwd);
+    assert.deepEqual(
+      commands.map((c) => c.name),
+      ["review"]
+    );
+    assert.equal(commands[0]?.description, "Review the working tree");
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands namespaces nested command files with a colon", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/review/pr.md": "# Review a pull request\n",
+  });
+  try {
+    const commands = discoverSlashCommands(cwd);
+    assert.deepEqual(
+      commands.map((c) => c.name),
+      ["review:pr"]
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands falls back to the first heading, then the first line", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/headed.md": "# Ship the release\n\nDo the thing.\n",
+    ".claude/commands/prose.md": "Just do the thing.\n",
+    ".claude/commands/empty.md": "",
+  });
+  try {
+    const byName = new Map(discoverSlashCommands(cwd).map((c) => [c.name, c]));
+    assert.equal(byName.get("headed")?.description, "Ship the release");
+    assert.equal(byName.get("prose")?.description, "Just do the thing.");
+    assert.equal(byName.get("empty")?.description, "Run the /empty command.");
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands omits argumentHint when the definition declares none", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/status.md": "---\ndescription: Show status\n---\nRun git status.\n",
+  });
+  try {
+    assert.equal(discoverSlashCommands(cwd)[0]?.argumentHint, undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands lets a project command shadow a same-named user command", () => {
+  const { cwd, cleanup } = makeTree({
+    ".claude/commands/commit.md": "---\ndescription: Project commit\n---\nproject body\n",
+  });
+  writeTree(fakeHome, {
+    ".claude/commands/commit.md": "---\ndescription: User commit\n---\nuser body\n",
+    ".claude/commands/publish.md": "---\ndescription: User publish\n---\nuser body\n",
+  });
+  try {
+    const byName = new Map(discoverSlashCommands(cwd).map((c) => [c.name, c]));
+    assert.equal(byName.get("commit")?.description, "Project commit");
+    // User-level commands the project doesn't shadow still show up.
+    assert.equal(byName.get("publish")?.description, "User publish");
+  } finally {
+    rmSync(pathJoin(fakeHome, ".claude"), { recursive: true, force: true });
+    cleanup();
+  }
+});
+
+test("discoverSlashCommands returns nothing for a cwd with no .claude directory", () => {
+  const { cwd, cleanup } = makeTree({ "README.md": "hello" });
+  try {
+    assert.deepEqual(discoverSlashCommands(cwd), []);
+  } finally {
+    cleanup();
+  }
+});
+
+test("parseSlashCommand matches known names and ignores everything else", () => {
+  const commands = [
+    { name: "commit", description: "d", body: "b", source: "/s" },
+    { name: "review:pr", description: "d", body: "b", source: "/s" },
+  ];
+  assert.equal(parseSlashCommand("/commit", commands)?.command.name, "commit");
+  assert.equal(parseSlashCommand("/commit group by feature", commands)?.args, "group by feature");
+  assert.equal(parseSlashCommand("/review:pr", commands)?.command.name, "review:pr");
+  assert.equal(parseSlashCommand("/commit", commands)?.args, "");
+  assert.equal(parseSlashCommand("/commit\nspanning a newline", commands)?.args, "spanning a newline");
+  assert.equal(parseSlashCommand("/unknown do a thing", commands), undefined);
+  assert.equal(parseSlashCommand("what does /commit do?", commands), undefined);
+  assert.equal(parseSlashCommand("plain prose", commands), undefined);
+});
+
+test("renderSlashCommand injects the body and appends free-form arguments", () => {
+  const command = {
+    name: "commit",
+    description: "d",
+    body: "Write a conventional commit.",
+    source: "/tmp/.claude/commands/commit.md",
+  };
+  const rendered = renderSlashCommand({ command, args: "group by feature" });
+  assert.match(rendered, /The user invoked the \/commit command/);
+  assert.match(rendered, /Write a conventional commit\./);
+  assert.match(rendered, /Arguments: group by feature/);
+});
+
+test("renderSlashCommand substitutes $ARGUMENTS instead of appending them", () => {
+  const command = {
+    name: "fix",
+    description: "d",
+    body: "Fix the bug described as: $ARGUMENTS",
+    source: "/tmp/.claude/commands/fix.md",
+  };
+  const rendered = renderSlashCommand({ command, args: "flaky login test" });
+  assert.match(rendered, /Fix the bug described as: flaky login test/);
+  assert.doesNotMatch(rendered, /Arguments:/);
+  assert.doesNotMatch(rendered, /\$ARGUMENTS/);
+});


### PR DESCRIPTION
## Task

- https://github.com/stefandevo/glm-acp-agent/issues/100 (spec: https://github.com/stefandevo/glm-acp-agent/issues/99)

## Purpose

ACP clients (Paseo, Zed, Copilot ACP) fill their `/` autocomplete from the agent's advertised command list. `glm-acp-agent` never sent one, so the slash menu stayed empty even when the workspace had commands or skills on disk. This adds the `available_commands_update` notification, populates it from the session's `cwd`, and honours `/name` when the client sends it back as prompt text.

## Key Changes

- **`src/protocol/slash-commands.ts` (new)** — discovers commands from `<cwd>/.claude/commands/*.md` (nested files become `dir:name`) and `<cwd>/.claude/skills/<name>/SKILL.md`, plus the same two directories under `~/.claude`. Project definitions shadow user-level ones. `description` / `argument-hint` come from YAML frontmatter (keys matched case-insensitively), falling back to the body's first heading, then its first line, then the command name. Bodies, descriptions, list length, and walk depth are all capped; every I/O error is swallowed so a broken file can't fail `session/new`.
- **`session/new`, `session/load`, `session/fork`, `session/resume` emit the snapshot.** Fork notifies on the **new** session id, and load notifies after replay.
- **The send is deferred past the method response.** A client only learns a session's id from the `session/new` / `session/fork` response, so a notification written ahead of it names a session the client has never heard of — clients drop those. Scheduling on the next macrotask puts it behind the response (and behind the replayed transcript on load), which is also when a client is ready to paint the menu.
- **Commands are scanned once per session** and cached on `SessionState`, rather than re-walking `.claude` on every prompt — this also keeps the advertised list and the honoured list from drifting apart mid-session.
- **`session/prompt` honours `/name`.** A leading `/name` matching an advertised command is expanded into the definition's body, substituting `$ARGUMENTS` where the file asks for it and otherwise appending the typed arguments. Expansion happens on the raw prompt blocks, before image preprocessing, so an image annotation can't mask the prefix. Unknown `/foo` is left untouched and reaches the model as prose, so typing a slash by accident never fails a turn.
- **Session titles use the typed command**, not the expanded body.
- **README** — Features bullets, a `Slash commands` section documenting the on-disk layout and precedence, and the project-structure tree.

Advertised names carry no leading slash; the client prepends it.

## Checks

- `npm test` — 274 pass / 0 fail (17 new: discovery, frontmatter fallbacks, precedence, `/name` parsing and rendering, all four session entry points, and an end-to-end assertion over the real ACP ndjson transport).
- `npm run lint` — clean.
- Drove the built binary over real stdio against a seeded `.claude/` tree. The notification arrives after the `session/new` response, names both a skill and a command, and carries `input.hint` only on the one declaring `argument-hint`:

  ```json
  {
    "sessionId": "d4f8b074-…",
    "update": {
      "sessionUpdate": "available_commands_update",
      "availableCommands": [
        { "name": "audit", "description": "Audit dependencies for known advisories" },
        { "name": "commit", "description": "Commit staged changes as a conventional commit",
          "input": { "hint": "<scope and intent>" } }
      ]
    }
  }
  ```

Test files that exercise discovery point `HOME` at a tempdir, since the scanner also reads `~/.claude`.

## Out of scope

A full Claude Code skill runtime (hooks, allowed-tools sandboxing, marketplaces), per the issue.

## Relation to the fork on #99

Issue #99 carries a work summary from @Mineru98 describing the same feature on `Mineru98/glm-acp-agent@feat/99-available-commands-update`. This branch was written independently against current `main`; the fork was read afterwards, as a cross-check.

One improvement was adopted from it: matching frontmatter keys case-insensitively (`Description:` now resolves).

Differences worth recording, since they are the parts that decide whether the feature actually works in a client:

- **Notification timing.** The fork `await`s the notification inline, so it reaches the wire ahead of the `session/new` / `fork` response that carries the session id — the drop case the issue flagged as a risk. This branch defers past the response and asserts that ordering end to end.
- **Nested commands.** The fork's flat `readdirSync` and its `[A-Za-z0-9_-]` name pattern silently drop `commands/review/pr.md`; here it is advertised as `review:pr`.
- **Discovery cost.** The fork calls `discoverSlashCommands` inside the prompt path, re-walking `.claude` and re-reading every file on every turn.
- **Session title.** The fork expands into `plainText`, so the first turn titles the session with the entire command body.
- **`$ARGUMENTS`** is not substituted on the fork, so command files using the placeholder get it left literal.