### PR TITLE
#102 - Preserve the typed prompt for replay

### DIFF
--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -160,6 +160,18 @@ interface SessionState {
   thoughtLevel: ThoughtLevel;
   /** Slash commands discovered under this session's cwd, advertised to the client. */
   commands: SlashCommand[];
+  /**
+   * Replay text for user messages whose stored content is not what the user
+   * typed — a slash command expanded into its body, an image swapped for its
+   * vision annotation. The model reads `messages`; the client's transcript
+   * reads this.
+   *
+   * Keyed by message identity rather than by position: `compactMessages`
+   * evicts whole turns from `messages`, and an index-keyed map would then
+   * point at the wrong message. A WeakMap also drops evicted entries on its
+   * own. Serialized to indices at save time and rebuilt on load.
+   */
+  displayText: WeakMap<GlmMessage & object, string>;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -389,6 +401,7 @@ export class GlmAcpAgent implements Agent {
       mode: "default",
       thoughtLevel,
       commands: discoverSlashCommands(params.cwd),
+      displayText: new WeakMap(),
     });
 
     this.scheduleAvailableCommands(sessionId);
@@ -744,10 +757,7 @@ export class GlmAcpAgent implements Agent {
     // Clients invoke an advertised command by sending `/name …` as ordinary
     // prompt text, so expand it here into the instructions its definition
     // holds. Unknown `/foo` is left alone and reaches the model as prose.
-    const { blocks: promptBlocks, invocation } = expandPromptCommand(
-      params.prompt,
-      session.commands
-    );
+    const promptBlocks = expandPromptCommand(params.prompt, session.commands);
     const visionNative = isVisionNativeModel(session.model);
     const preprocessed = visionNative
       ? { blocks: promptBlocks, cleanups: [] }
@@ -756,10 +766,21 @@ export class GlmAcpAgent implements Agent {
           this.visionClient,
           abortController.signal
         );
-    const { content: userContent, plainText: userText } = visionNative
+    const { content: userContent } = visionNative
       ? renderVisionNativePromptBlocks(preprocessed.blocks)
       : renderPromptBlocks(preprocessed.blocks);
-    session.messages.push({ role: "user", content: userContent });
+    const userMessage: GlmMessage = { role: "user", content: userContent };
+    session.messages.push(userMessage);
+
+    // What the user typed, rendered from the blocks as they arrived — before
+    // command expansion and image analysis rewrote them for the model. Kept
+    // separately so `session/load` replays the conversation the user had (and
+    // the title names it), not the one the model saw. Persisted only when the
+    // two actually diverge.
+    const displayText = renderPromptBlocks(params.prompt).plainText;
+    if (displayText !== stringifyUserMessage(userContent)) {
+      session.displayText.set(userMessage, displayText);
+    }
 
     // Echo back the client-supplied messageId on every response (success,
     // cancelled, or error) so the client can correlate the turn.
@@ -785,7 +806,7 @@ export class GlmAcpAgent implements Agent {
       const titleUpdate: { title?: string | null } =
         session.title === null
           ? (() => {
-              const derived = (invocation ?? userText)
+              const derived = displayText
                 .slice(0, 80)
                 .replace(/\s+/g, " ")
                 .trim();
@@ -934,13 +955,18 @@ export class GlmAcpAgent implements Agent {
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
       commands: discoverSlashCommands(params.cwd),
+      displayText: deserializeDisplayText(persisted.messages, persisted.displayText),
     };
     this.sessions.set(params.sessionId, restored);
 
     // Replay user/assistant text turns so the client can rehydrate its UI.
     // Tool / system messages are skipped — they're internal and the client
     // doesn't render them on its own.
-    await this.replayMessages(params.sessionId, persisted.messages);
+    await this.replayMessages(
+      params.sessionId,
+      persisted.messages,
+      restored.displayText
+    );
 
     this.scheduleAvailableCommands(params.sessionId);
 
@@ -968,10 +994,11 @@ export class GlmAcpAgent implements Agent {
     const newSessionId = randomUUID();
     const forkedTitle =
       persisted.title === null ? null : `${persisted.title} (fork)`;
+    const forkedMessages = structuredClone(persisted.messages);
     const forked: SessionState = {
       cwd: params.cwd,
       // Deep-clone messages so the fork doesn't share state with the parent.
-      messages: structuredClone(persisted.messages),
+      messages: forkedMessages,
       abortController: null,
       promptPromise: null,
       title: forkedTitle,
@@ -982,6 +1009,9 @@ export class GlmAcpAgent implements Agent {
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
       commands: discoverSlashCommands(params.cwd),
+      // Re-key onto the cloned messages: the parent's map is keyed by the
+      // originals, which the fork no longer holds.
+      displayText: deserializeDisplayText(forkedMessages, persisted.displayText),
     };
     this.sessions.set(newSessionId, forked);
     this.persistSession(newSessionId, forked);
@@ -1023,6 +1053,7 @@ export class GlmAcpAgent implements Agent {
       mode: persisted.mode,
       thoughtLevel: resolveThoughtLevel(persisted.model, persisted.thoughtLevel ?? "max"),
       commands: discoverSlashCommands(params.cwd),
+      displayText: deserializeDisplayText(persisted.messages, persisted.displayText),
     };
     this.sessions.set(params.sessionId, restored);
 
@@ -1046,6 +1077,7 @@ export class GlmAcpAgent implements Agent {
   // ---------------------------------------------------------------------------
 
   private snapshot(sessionId: string, session: SessionState): PersistedSession {
+    const displayText = serializeDisplayText(session.messages, session.displayText);
     return {
       sessionId,
       cwd: session.cwd,
@@ -1055,6 +1087,9 @@ export class GlmAcpAgent implements Agent {
       model: session.model,
       mode: session.mode,
       thoughtLevel: session.thoughtLevel,
+      // Omitted entirely for conversations where nothing diverges, which is
+      // the common case — an ordinary session gains no on-disk weight.
+      ...(displayText ? { displayText } : {}),
     };
   }
 
@@ -1083,11 +1118,13 @@ export class GlmAcpAgent implements Agent {
 
   private async replayMessages(
     sessionId: string,
-    messages: GlmMessage[]
+    messages: GlmMessage[],
+    displayText: SessionState["displayText"]
   ): Promise<void> {
     for (const msg of messages) {
       if (msg.role === "user") {
-        const text = stringifyUserMessage(msg.content);
+        // Prefer what the user typed over what we handed the model.
+        const text = displayText.get(msg) ?? stringifyUserMessage(msg.content);
         if (text.length === 0) continue;
         await this.connection.sessionUpdate({
           sessionId,
@@ -1362,7 +1399,9 @@ function renderPromptBlocks(blocks: ReadonlyArray<PromptRequest["prompt"][number
         break;
       }
       case "image": {
-        // Defensive: image blocks should have been preprocessed away upstream.
+        // Reached on the display-text pass, which renders the untouched
+        // prompt; on the model-facing pass images have been preprocessed away
+        // into `<image_analysis>` annotations upstream.
         textParts.push(`[image: ${block.mimeType}]`);
         break;
       }
@@ -1471,6 +1510,41 @@ function escapeAttribute(value: string): string {
     .replaceAll(">", "&gt;");
 }
 
+/**
+ * Project the identity-keyed display map onto indices into `messages`, ready
+ * to persist. Returns `undefined` when nothing diverges so the field can be
+ * left off the record entirely.
+ */
+function serializeDisplayText(
+  messages: ReadonlyArray<GlmMessage>,
+  displayText: SessionState["displayText"]
+): Record<string, string> | undefined {
+  let out: Record<string, string> | undefined;
+  messages.forEach((message, index) => {
+    const text = displayText.get(message);
+    if (text === undefined) return;
+    out ??= {};
+    out[String(index)] = text;
+  });
+  return out;
+}
+
+/** Rebuild the identity-keyed display map from a persisted index map. */
+function deserializeDisplayText(
+  messages: ReadonlyArray<GlmMessage>,
+  persisted: Record<string, string> | undefined
+): SessionState["displayText"] {
+  const out = new WeakMap<GlmMessage & object, string>();
+  if (!persisted) return out;
+  for (const [key, text] of Object.entries(persisted)) {
+    const message = messages[Number(key)];
+    // A hand-edited or truncated record can point past the end of the array;
+    // dropping the entry just falls back to replaying the stored content.
+    if (message) out.set(message, text);
+  }
+  return out;
+}
+
 /** Flatten the `content` of a user message into a plain string for replay. */
 function stringifyUserMessage(content: unknown): string {
   if (typeof content === "string") return content;
@@ -1538,30 +1612,24 @@ function availableCommandsState(
  * a client may place an image or resource block ahead of what the user typed,
  * and the command would otherwise reach the model as a literal `/name`.
  *
- * Returns the blocks unchanged (and a null `invocation`) when that text does
- * not start with an advertised command. `invocation` carries the text the user
- * actually typed so the session title doesn't end up being the expanded body.
+ * Returns the blocks unchanged when that text does not start with an
+ * advertised command. The caller keeps the original blocks around to derive
+ * the replay/title text, so nothing here needs to report the typed form back.
  */
 function expandPromptCommand(
   blocks: PromptRequest["prompt"],
   commands: ReadonlyArray<SlashCommand>
-): { blocks: PromptRequest["prompt"]; invocation: string | null } {
+): PromptRequest["prompt"] {
   const index = blocks.findIndex(
     (block) => block.type === "text" && block.text.trim().length > 0
   );
   const typed = blocks[index];
-  if (typed?.type !== "text") return { blocks, invocation: null };
+  if (typed?.type !== "text") return blocks;
   const parsed = parseSlashCommand(typed.text, commands);
-  if (!parsed) return { blocks, invocation: null };
+  if (!parsed) return blocks;
   const expanded = [...blocks];
   expanded[index] = { ...typed, text: renderSlashCommand(parsed) };
-  return {
-    blocks: expanded,
-    invocation:
-      parsed.args.length > 0
-        ? `/${parsed.command.name} ${parsed.args}`
-        : `/${parsed.command.name}`,
-  };
+  return expanded;
 }
 
 /**

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -766,9 +766,9 @@ export class GlmAcpAgent implements Agent {
           this.visionClient,
           abortController.signal
         );
-    const { content: userContent } = visionNative
+    const userContent = visionNative
       ? renderVisionNativePromptBlocks(preprocessed.blocks)
-      : renderPromptBlocks(preprocessed.blocks);
+      : renderPromptBlocks(preprocessed.blocks).content;
     const userMessage: GlmMessage = { role: "user", content: userContent };
     session.messages.push(userMessage);
 
@@ -1414,18 +1414,15 @@ function renderPromptBlocks(blocks: ReadonlyArray<PromptRequest["prompt"][number
   return { content: plainText, plainText };
 }
 
-function renderVisionNativePromptBlocks(blocks: ReadonlyArray<PromptRequest["prompt"][number]>): {
-  content: ChatCompletionContentPart[];
-  plainText: string;
-} {
+function renderVisionNativePromptBlocks(
+  blocks: ReadonlyArray<PromptRequest["prompt"][number]>
+): ChatCompletionContentPart[] {
   const content: ChatCompletionContentPart[] = [];
-  const plainTextParts: string[] = [];
   let imageIndex = 0;
 
   const pushText = (text: string) => {
     if (text.length === 0) return;
     content.push({ type: "text", text });
-    plainTextParts.push(text);
   };
 
   for (const block of blocks) {
@@ -1450,7 +1447,6 @@ function renderVisionNativePromptBlocks(blocks: ReadonlyArray<PromptRequest["pro
         const imageUrl = toVisionNativeImageUrl(block);
         if (imageUrl) {
           content.push({ type: "image_url", image_url: { url: imageUrl } });
-          plainTextParts.push(`[image: ${block.mimeType}]`);
         } else {
           pushText(
             `<image_unsupported_format index="${imageIndex}" mime="${escapeAttribute(block.mimeType)}">Only image/jpeg, image/jpg, image/png inputs can be sent to the native vision model. Attach a supported HTTPS image URL or supported base64 image data.</image_unsupported_format>`
@@ -1466,7 +1462,7 @@ function renderVisionNativePromptBlocks(blocks: ReadonlyArray<PromptRequest["pro
     }
   }
 
-  return { content, plainText: plainTextParts.join("\n") };
+  return content;
 }
 
 function toVisionNativeImageUrl(block: Extract<PromptRequest["prompt"][number], { type: "image" }>): string | null {

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -171,7 +171,7 @@ interface SessionState {
    * point at the wrong message. A WeakMap also drops evicted entries on its
    * own. Serialized to indices at save time and rebuilt on load.
    */
-  displayText: WeakMap<GlmMessage & object, string>;
+  displayText: WeakMap<GlmMessage, string>;
 }
 
 /** ACP stop reasons that the prompt loop can produce internally. */
@@ -1087,8 +1087,8 @@ export class GlmAcpAgent implements Agent {
       model: session.model,
       mode: session.mode,
       thoughtLevel: session.thoughtLevel,
-      // Omitted entirely for conversations where nothing diverges, which is
-      // the common case — an ordinary session gains no on-disk weight.
+      // Absent for the common case where nothing diverges, so an ordinary
+      // session gains no on-disk weight.
       ...(displayText ? { displayText } : {}),
     };
   }
@@ -1123,7 +1123,6 @@ export class GlmAcpAgent implements Agent {
   ): Promise<void> {
     for (const msg of messages) {
       if (msg.role === "user") {
-        // Prefer what the user typed over what we handed the model.
         const text = displayText.get(msg) ?? stringifyUserMessage(msg.content);
         if (text.length === 0) continue;
         await this.connection.sessionUpdate({
@@ -1399,9 +1398,8 @@ function renderPromptBlocks(blocks: ReadonlyArray<PromptRequest["prompt"][number
         break;
       }
       case "image": {
-        // Reached on the display-text pass, which renders the untouched
-        // prompt; on the model-facing pass images have been preprocessed away
-        // into `<image_analysis>` annotations upstream.
+        // Only the display-text pass sees these; the model-facing pass has had
+        // its images preprocessed into `<image_analysis>` annotations upstream.
         textParts.push(`[image: ${block.mimeType}]`);
         break;
       }
@@ -1520,12 +1518,12 @@ function serializeDisplayText(
   displayText: SessionState["displayText"]
 ): Record<string, string> | undefined {
   let out: Record<string, string> | undefined;
-  messages.forEach((message, index) => {
+  for (const [index, message] of messages.entries()) {
     const text = displayText.get(message);
-    if (text === undefined) return;
+    if (text === undefined) continue;
     out ??= {};
     out[String(index)] = text;
-  });
+  }
   return out;
 }
 
@@ -1534,7 +1532,7 @@ function deserializeDisplayText(
   messages: ReadonlyArray<GlmMessage>,
   persisted: Record<string, string> | undefined
 ): SessionState["displayText"] {
-  const out = new WeakMap<GlmMessage & object, string>();
+  const out = new WeakMap<GlmMessage, string>();
   if (!persisted) return out;
   for (const [key, text] of Object.entries(persisted)) {
     const message = messages[Number(key)];

--- a/src/protocol/session-store.ts
+++ b/src/protocol/session-store.ts
@@ -8,7 +8,7 @@ import type { GlmMessage, ThoughtLevel } from "../llm/glm-client.js";
  * shape of `PersistedSession` changes incompatibly so future loaders can
  * migrate (or reject) old records instead of silently producing garbage.
  */
-export const SESSION_SCHEMA_VERSION = 3 as const;
+export const SESSION_SCHEMA_VERSION = 4 as const;
 
 /**
  * On-disk representation of a session. Only fields that need to survive a
@@ -35,6 +35,17 @@ export interface PersistedSession {
    * the migration (and load-time resolution) default it to "max".
    */
   thoughtLevel?: ThoughtLevel;
+  /**
+   * Replay text for user messages whose stored `content` differs from what the
+   * user actually typed — a slash command expanded into its body, an image
+   * replaced by its vision annotation. Keys are indices into `messages`;
+   * entries are written only where the two texts diverge, so an ordinary
+   * conversation persists no sidecar at all.
+   *
+   * Indices are re-derived from message identity on every save, so they stay
+   * correct across the compaction that drops turns from `messages`.
+   */
+  displayText?: Record<string, string>;
 }
 
 /** Light-weight summary of a persisted session — used by `listSessions`. */
@@ -106,9 +117,11 @@ export class SessionStore {
       return undefined;
     }
     // Handle schema migrations. We support v1 (pre-modes), v2 (with mode
-    // field), and v3 (with thoughtLevel). Defaulting thoughtLevel to "max"
-    // is safe: it's GLM-5.3's own default effort, and load-time resolution
-    // clamps it to a valid level for the session's actual model.
+    // field), v3 (with thoughtLevel), and v4 (with displayText). Defaulting
+    // thoughtLevel to "max" is safe: it's GLM-5.3's own default effort, and
+    // load-time resolution clamps it to a valid level for the session's
+    // actual model. `displayText` needs no backfill — its absence already
+    // means "replay the stored content", which is what older records did.
     const version = parsed.schemaVersion ?? 1;
     if (version === 1) {
       // Migration: add mode + thoughtLevel fields with default values.
@@ -126,6 +139,10 @@ export class SessionStore {
         thoughtLevel: "max",
         schemaVersion: SESSION_SCHEMA_VERSION,
       };
+    }
+    if (version === 3) {
+      // Migration: no new data to backfill, just retag at the current version.
+      return { ...parsed, schemaVersion: SESSION_SCHEMA_VERSION };
     }
     if (version !== SESSION_SCHEMA_VERSION) {
       // Forward-incompatible record written by a newer agent build.

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -2987,3 +2987,30 @@ test("v3 sessions (no displayText) migrate and replay their stored content", asy
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test("resumeSession carries the sidecar forward so a later save keeps it", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const { glm } = captureUserMessage();
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "/deploy staging" }] });
+
+    // Resume replays nothing, but it must still rebuild the sidecar: the next
+    // prompt re-persists the session, and a dropped map would quietly rewrite
+    // the record without it.
+    const resumed = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    await resumed.resumeSession({ sessionId, cwd, mcpServers: [] });
+    await resumed.prompt({ sessionId, prompt: [{ type: "text", text: "and now?" }] });
+
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await reopened.loadSession({ sessionId, cwd, mcpServers: [] });
+
+    assert.deepEqual(replayedUserTexts(conn), ["/deploy staging", "and now?"]);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -5,7 +5,7 @@ import { tmpdir as osTmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 import { GlmAcpAgent } from "../protocol/agent.js";
 import type { GlmStreamChunk } from "../llm/glm-client.js";
-import { SessionStore } from "../protocol/session-store.js";
+import { SessionStore, SESSION_SCHEMA_VERSION } from "../protocol/session-store.js";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
 
 // Defence in depth: even though every test below opts out via `sessionStore: null`,
@@ -1363,7 +1363,7 @@ test("v2 sessions (no thoughtLevel) migrate and resolve to the model default on 
     // The store migrates the raw record, defaulting thoughtLevel to "max".
     const store = new SessionStore(dir);
     const migrated = store.load(sessionId);
-    assert.equal(migrated?.schemaVersion, 3);
+    assert.equal(migrated?.schemaVersion, SESSION_SCHEMA_VERSION);
     assert.equal(migrated?.thoughtLevel, "max");
 
     // On load the agent clamps that to the session's model (glm-4.7 → "on").
@@ -2772,5 +2772,218 @@ test("prompt titles the session with the typed command, not the expanded body", 
     assert.equal((info?.update as { title?: string }).title, "/deploy staging");
   } finally {
     cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Display text (what the UI replays) vs. model text (what the model sees)
+// ---------------------------------------------------------------------------
+
+/** Pull the replayed `user_message_chunk` texts out of a connection stub. */
+function replayedUserTexts(conn: ReturnType<typeof createConnectionStub>): string[] {
+  return conn.updates
+    .filter((u) => (u.update as { sessionUpdate: string }).sessionUpdate === "user_message_chunk")
+    .map((u) => (u.update as { content: { text: string } }).content.text);
+}
+
+test("loadSession replays the typed slash invocation, not the expanded body", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const { glm } = captureUserMessage();
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/deploy staging" }],
+    });
+
+    // A fresh agent reads the record back from disk, exactly as a client
+    // reopening the conversation would.
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await reopened.loadSession({ sessionId, cwd, mcpServers: [] });
+
+    assert.deepEqual(replayedUserTexts(conn), ["/deploy staging"]);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("the model still sees the expanded command body after a reload", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const { glm, ref } = captureUserMessage();
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "/deploy staging" }],
+    });
+    assert.match(ref.value, /^<slash_command name="deploy"/);
+
+    const reopened = new GlmAcpAgent(createConnectionStub() as never, {
+      glm,
+      sessionStore: store,
+    });
+    await reopened.loadSession({ sessionId, cwd, mcpServers: [] });
+    const persisted = store.load(sessionId);
+    const user = persisted?.messages.find((m) => m.role === "user");
+    assert.match(String(user?.content), /^<slash_command name="deploy"/);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("loadSession replays an image placeholder, not the vision annotation", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
+    const visionClient = {
+      async callTool() {
+        return { content: [{ type: "text", text: "It is a kitten." }] };
+      },
+      async dispose() {},
+    };
+    const agent = new GlmAcpAgent(createConnectionStub() as never, {
+      glm,
+      visionClient,
+      sessionStore: store,
+    });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.prompt({
+      sessionId,
+      prompt: [
+        { type: "text", text: "What is in this image?" },
+        { type: "image", data: "", mimeType: "image/png", uri: "https://example.com/cat.png" },
+      ],
+    });
+
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, visionClient, sessionStore: store });
+    await reopened.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+
+    assert.deepEqual(replayedUserTexts(conn), [
+      "What is in this image?\n[image: image/png]",
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("plain prompts are replayed verbatim and store no display-text sidecar", async () => {
+  const { store, cleanup } = makeTempStore();
+  try {
+    const glm = makeStreamingGlm([[{ text: "ok" }, { done: true, stopReason: "stop" }]]);
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "just prose" }] });
+
+    assert.equal(store.load(sessionId)?.displayText, undefined);
+
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await reopened.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    assert.deepEqual(replayedUserTexts(conn), ["just prose"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a forked session replays the typed invocation too", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const { glm } = captureUserMessage();
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "/deploy staging" }] });
+
+    const fork = await agent.unstable_forkSession({ sessionId, cwd, mcpServers: [] });
+
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await reopened.loadSession({ sessionId: fork.sessionId, cwd, mcpServers: [] });
+
+    assert.deepEqual(replayedUserTexts(conn), ["/deploy staging"]);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("display text survives a compaction that drops earlier turns", async () => {
+  const { store, cleanup: cleanupStore } = makeTempStore();
+  const { cwd, cleanup: cleanupCwd } = makeTempCwd(COMMAND_FIXTURE);
+  try {
+    const { glm } = captureUserMessage();
+    const agent = new GlmAcpAgent(createConnectionStub() as never, { glm, sessionStore: store });
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    // glm-5-turbo has the smallest catalogued window (128k), so a handful of
+    // fat turns is enough to trip proactive compaction.
+    await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5-turbo" });
+
+    // Compaction preserves the last 10 interaction groups and evicts the
+    // largest of the rest, so every surviving message shifts index. A sidecar
+    // keyed by position would follow the wrong message afterwards.
+    const filler = "x".repeat(40_000);
+    for (let i = 0; i < 12; i++) {
+      await agent.prompt({ sessionId, prompt: [{ type: "text", text: `turn ${i} ${filler}` }] });
+    }
+    await agent.prompt({ sessionId, prompt: [{ type: "text", text: "/deploy staging" }] });
+
+    const conn = createConnectionStub();
+    const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
+    await reopened.loadSession({ sessionId, cwd, mcpServers: [] });
+
+    const texts = replayedUserTexts(conn);
+    assert.ok(
+      texts.length < 13,
+      `expected compaction to drop turns, got ${texts.length} replayed user messages`
+    );
+    assert.equal(texts[texts.length - 1], "/deploy staging");
+    // The sidecar must not have leaked onto any other surviving turn.
+    assert.equal(texts.filter((t) => t === "/deploy staging").length, 1);
+  } finally {
+    cleanupCwd();
+    cleanupStore();
+  }
+});
+
+test("v3 sessions (no displayText) migrate and replay their stored content", async () => {
+  const dir = mkdtempSync(pathJoin(osTmpdir(), "glm-acp-migrate-"));
+  const sessionId = "abcd1234-abcd-abcd-abcd-abcdabcd1234";
+  try {
+    const v3 = {
+      schemaVersion: 3,
+      sessionId,
+      cwd: "/tmp",
+      messages: [
+        { role: "system", content: "you are a coding assistant" },
+        { role: "user", content: "ping" },
+        { role: "assistant", content: "pong" },
+      ],
+      title: "old session",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "glm-4.7",
+      mode: "default",
+      thoughtLevel: "on",
+    };
+    writeFileSync(pathJoin(dir, `${sessionId}.json`), JSON.stringify(v3), "utf8");
+
+    const store = new SessionStore(dir);
+    const migrated = store.load(sessionId);
+    assert.equal(migrated?.schemaVersion, SESSION_SCHEMA_VERSION);
+    assert.equal(migrated?.displayText, undefined);
+
+    const conn = createConnectionStub();
+    const agent = new GlmAcpAgent(conn as never, { sessionStore: store });
+    await agent.loadSession({ sessionId, cwd: "/tmp", mcpServers: [] });
+    assert.deepEqual(replayedUserTexts(conn), ["ping"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -2926,27 +2926,47 @@ test("display text survives a compaction that drops earlier turns", async () => 
     // fat turns is enough to trip proactive compaction.
     await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5-turbo" });
 
-    // Compaction preserves the last 10 interaction groups and evicts the
-    // largest of the rest, so every surviving message shifts index. A sidecar
-    // keyed by position would follow the wrong message afterwards.
+    // Ordering is the whole point: the command has to land *before* the turns
+    // that trigger eviction, and stay inside the preserved tail, so its entry
+    // already exists when compaction renumbers the messages around it. Run the
+    // command last instead and eviction is over before there is anything to
+    // misplace — the test would then pass against a naive index-keyed map.
     const filler = "x".repeat(40_000);
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 3; i++) {
       await agent.prompt({ sessionId, prompt: [{ type: "text", text: `turn ${i} ${filler}` }] });
     }
     await agent.prompt({ sessionId, prompt: [{ type: "text", text: "/deploy staging" }] });
+    const keysBefore = Object.keys(store.load(sessionId)?.displayText ?? {});
+    assert.equal(keysBefore.length, 1);
+
+    for (let i = 3; i < 12; i++) {
+      await agent.prompt({ sessionId, prompt: [{ type: "text", text: `turn ${i} ${filler}` }] });
+    }
+
+    const persisted = store.load(sessionId);
+    const keysAfter = Object.keys(persisted?.displayText ?? {});
+    assert.equal(keysAfter.length, 1);
+    assert.notDeepEqual(
+      keysAfter,
+      keysBefore,
+      "expected compaction to evict leading turns and renumber the entry"
+    );
+    // Renumbered onto the command itself, not whatever now sits at the old index.
+    assert.match(
+      String(persisted?.messages[Number(keysAfter[0])]?.content),
+      /^<slash_command name="deploy"/
+    );
 
     const conn = createConnectionStub();
     const reopened = new GlmAcpAgent(conn as never, { glm, sessionStore: store });
     await reopened.loadSession({ sessionId, cwd, mcpServers: [] });
 
     const texts = replayedUserTexts(conn);
-    assert.ok(
-      texts.length < 13,
-      `expected compaction to drop turns, got ${texts.length} replayed user messages`
-    );
-    assert.equal(texts[texts.length - 1], "/deploy staging");
-    // The sidecar must not have leaked onto any other surviving turn.
+    assert.ok(texts.length < 13, `expected dropped turns, got ${texts.length} replayed`);
     assert.equal(texts.filter((t) => t === "/deploy staging").length, 1);
+    // `turn 3` was the prompt immediately after the command, so this pins the
+    // replayed invocation to the right position in the surviving transcript.
+    assert.ok(texts[texts.indexOf("/deploy staging") + 1]?.startsWith("turn 3 "));
   } finally {
     cleanupCwd();
     cleanupStore();


### PR DESCRIPTION
## Purpose

This bugfix separates the text the model reads from the text the UI replays. Persisted user messages carried whatever we handed the model — the expanded `<slash_command>` wrapper, and the `<image_analysis>` annotations spliced in by `preprocessImageBlocks` — so `session/load` replayed the command body and its source path back to the client instead of the `/deploy staging` the user actually typed.

Rather than a slash-command-specific patch, this adds the general display-text sidecar the deferral called for: one mechanism covering both slash commands and image annotations, so the next thing that rewrites a prompt for the model gets correct replay for free.

## Key Changes

- Render each prompt twice — once from the expanded/preprocessed blocks for the model, once from `params.prompt` untouched for the UI — and record the second only when the two diverge.
- Key the sidecar by **message identity**, not position: `compactMessages` evicts whole turns from `messages`, and an index-keyed map would then point at the wrong message. Indices are re-derived at save time and rebuilt on load, fork, and resume; a `WeakMap` also drops evicted entries on its own.
- Bump `SESSION_SCHEMA_VERSION` 3 → 4 with a no-backfill migration — the sidecar's absence already means "replay the stored content", which is exactly what older records did. It is omitted from the record entirely when nothing diverges, so an ordinary session gains no on-disk weight.
- Drop the one-off `invocation` return from `expandPromptCommand`, now subsumed by the general display text. This also stops an image-only prompt titling the session with the vision analysis blob.
- Point the existing v2-migration test at the `SESSION_SCHEMA_VERSION` constant so the next bump won't need to touch it.

## Behavior notes

- Sessions persisted before this change replay exactly as they do today — the expanded text. There is no way to recover a typed invocation that was never stored.
- The bump costs a downgrade: a v4 record read by an older build resolves as "session not found". Kept because it matches this repo's own precedent — 2 → 3 was the same shape of change, an added optional field (`thoughtLevel`).

## Checks

- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test` — 286/286)
- [x] Lint passes (`npm run lint`)
- [x] Changes have been tested locally

Written test-first: 8 new tests covering the typed invocation on replay, the model still seeing the expanded body after a reload, the image placeholder in place of the vision annotation, no sidecar for plain prompts, fork and resume, survival across a real compaction that evicts turns, and the v3 → v4 migration. The resume test was verified to be a real guard by temporarily reverting the resume path and confirming it fails.

## Task

[#102](https://github.com/stefandevo/glm-acp-agent/issues/102)