### PR TITLE
#98 - Account for native images during context compaction

### DIFF
--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -1232,12 +1232,9 @@ export class GlmAcpAgent implements Agent {
         if (isOverflow && overflowRetryCount < 1) {
           debug(`promptLoop: context overflow (1261) detected, performing emergency compaction`);
           const window = getContextWindow(session.model);
-          session.messages = compactMessages(
-            session.messages,
-            Math.floor(window * 0.7),
-            undefined,
-            true
-          );
+          session.messages = compactMessages(session.messages, Math.floor(window * 0.7), {
+            force: true,
+          });
           overflowRetryCount++;
           retryTurn = true;
         } else if (isOverflow) {
@@ -1611,11 +1608,10 @@ async function safeSessionUpdate(
  *
  * Vision-native GLM models tile an image into 14px patches and merge them 2x2,
  * so a full-size input (capped at 1120x1120) costs (1120/14)^2 / 4 = 1600
- * tokens. Smaller images cost less, and the wire form (an HTTPS URL or a
- * base64 data URL) tells us nothing about the decoded dimensions — so charge
- * every image the ceiling. Over-counting only makes compaction fire early;
- * under-counting is what lets an image-heavy session sail past the window and
- * get rejected by the provider.
+ * tokens. The wire form — an HTTPS URL or a base64 data URL — says nothing
+ * about the decoded dimensions, so charge every image that ceiling:
+ * over-counting only makes compaction fire early, while under-counting is what
+ * lets an image-heavy session sail past the window and get rejected.
  */
 const IMAGE_PART_TOKENS = 1600;
 
@@ -1635,11 +1631,7 @@ function estimateTokens(messages: GlmMessage[]): number {
       for (const part of m.content) {
         if ("text" in part && typeof part.text === "string") {
           chars += part.text.length;
-        } else if (
-          typeof part === "object" &&
-          part !== null &&
-          (part as { type?: unknown }).type === "image_url"
-        ) {
+        } else if (part.type === "image_url") {
           tokens += IMAGE_PART_TOKENS;
         }
       }
@@ -1668,19 +1660,15 @@ function estimateTokens(messages: GlmMessage[]): number {
  *    is below `targetTokens`.
  *
  * `force` is for the emergency path after the provider itself rejected the
- * history as too long. There, {@link estimateTokens} has already been proven
- * wrong — it is a heuristic, and images in particular can only be charged an
- * approximation — so its verdict cannot be allowed to veto eviction. Under
- * `force` the size checks stop being gates: the tail shrinks as far as it must
- * (never below the final turn, which carries the live user message) and at
- * least one turn is always evicted, so the retry sends strictly less than the
- * request that just failed.
+ * history, where {@link estimateTokens} has already been proven wrong and so
+ * cannot be allowed to veto eviction. It shrinks the preserved tail as far as
+ * the final turn (which carries the live user message) and always evicts at
+ * least one turn, so the retry sends strictly less than what just failed.
  */
 function compactMessages(
   messages: GlmMessage[],
   targetTokens: number,
-  preserveTurns = 10,
-  force = false
+  { preserveTurns = 10, force = false }: { preserveTurns?: number; force?: boolean } = {}
 ): GlmMessage[] {
   if (messages.length <= 1) return messages;
 
@@ -1702,17 +1690,15 @@ function compactMessages(
     turns.push(currentTurn);
   }
 
-  // Nothing to evict without dropping the live user message — a single turn
-  // over the window is beyond what turn eviction can fix, forced or not.
-  if (turns.length < 2) return messages;
-
   // Normally the tail is untouchable; under `force` it yields as far as the
-  // final turn so there is always at least one eviction candidate.
+  // final turn — never past it, since that turn holds the live user message —
+  // so there is always at least one eviction candidate.
   const effectivePreserve = force
     ? Math.max(1, Math.min(preserveTurns, turns.length - 1))
     : preserveTurns;
 
-  // If we have fewer turns than we want to preserve, just return the messages.
+  // Fewer turns than we want to preserve: nothing to evict. Under `force` this
+  // means a lone turn, which is past what turn eviction can fix.
   if (turns.length <= effectivePreserve) return messages;
 
   let currentEstimate = estimateTokens(messages);
@@ -1737,9 +1723,10 @@ function compactMessages(
 
   const evictedIndices = new Set<number>();
   for (const c of candidateTurns) {
-    // Under `force`, always take the first (largest) candidate: the estimate
-    // that says we are already under target is the one the provider rejected.
-    if (currentEstimate <= targetTokens && !(force && evictedIndices.size === 0)) break;
+    // Under `force`, the largest candidate goes regardless of the estimate —
+    // the estimate saying we already fit is the one the provider rejected.
+    const mustEvict = force && evictedIndices.size === 0;
+    if (!mustEvict && currentEstimate <= targetTokens) break;
     evictedIndices.add(c.index);
     currentEstimate -= c.tokens;
   }

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -1232,7 +1232,12 @@ export class GlmAcpAgent implements Agent {
         if (isOverflow && overflowRetryCount < 1) {
           debug(`promptLoop: context overflow (1261) detected, performing emergency compaction`);
           const window = getContextWindow(session.model);
-          session.messages = compactMessages(session.messages, Math.floor(window * 0.7));
+          session.messages = compactMessages(
+            session.messages,
+            Math.floor(window * 0.7),
+            undefined,
+            true
+          );
           overflowRetryCount++;
           retryTurn = true;
         } else if (isOverflow) {
@@ -1602,12 +1607,27 @@ async function safeSessionUpdate(
 }
 
 /**
+ * Token cost charged to a single `image_url` content part.
+ *
+ * Vision-native GLM models tile an image into 14px patches and merge them 2x2,
+ * so a full-size input (capped at 1120x1120) costs (1120/14)^2 / 4 = 1600
+ * tokens. Smaller images cost less, and the wire form (an HTTPS URL or a
+ * base64 data URL) tells us nothing about the decoded dimensions — so charge
+ * every image the ceiling. Over-counting only makes compaction fire early;
+ * under-counting is what lets an image-heavy session sail past the window and
+ * get rejected by the provider.
+ */
+const IMAGE_PART_TOKENS = 1600;
+
+/**
  * Heuristically estimate the number of tokens in a list of messages.
  * Uses a simple 4-character-per-token rule, which is a safe baseline for
- * English and code.
+ * English and code, plus a flat per-image charge for native `image_url` parts
+ * (see {@link IMAGE_PART_TOKENS}).
  */
 function estimateTokens(messages: GlmMessage[]): number {
   let chars = 0;
+  let tokens = 0;
   for (const m of messages) {
     if (typeof m.content === "string") {
       chars += m.content.length;
@@ -1615,6 +1635,12 @@ function estimateTokens(messages: GlmMessage[]): number {
       for (const part of m.content) {
         if ("text" in part && typeof part.text === "string") {
           chars += part.text.length;
+        } else if (
+          typeof part === "object" &&
+          part !== null &&
+          (part as { type?: unknown }).type === "image_url"
+        ) {
+          tokens += IMAGE_PART_TOKENS;
         }
       }
     }
@@ -1627,7 +1653,7 @@ function estimateTokens(messages: GlmMessage[]): number {
       }
     }
   }
-  return Math.ceil(chars / 4);
+  return tokens + Math.ceil(chars / 4);
 }
 
 /**
@@ -1640,11 +1666,21 @@ function estimateTokens(messages: GlmMessage[]): number {
  *    with a user message followed by assistant and tool responses.
  * 3. Evict the largest remaining interaction groups until the total estimate
  *    is below `targetTokens`.
+ *
+ * `force` is for the emergency path after the provider itself rejected the
+ * history as too long. There, {@link estimateTokens} has already been proven
+ * wrong — it is a heuristic, and images in particular can only be charged an
+ * approximation — so its verdict cannot be allowed to veto eviction. Under
+ * `force` the size checks stop being gates: the tail shrinks as far as it must
+ * (never below the final turn, which carries the live user message) and at
+ * least one turn is always evicted, so the retry sends strictly less than the
+ * request that just failed.
  */
 function compactMessages(
   messages: GlmMessage[],
   targetTokens: number,
-  preserveTurns = 10
+  preserveTurns = 10,
+  force = false
 ): GlmMessage[] {
   if (messages.length <= 1) return messages;
 
@@ -1666,18 +1702,30 @@ function compactMessages(
     turns.push(currentTurn);
   }
 
+  // Nothing to evict without dropping the live user message — a single turn
+  // over the window is beyond what turn eviction can fix, forced or not.
+  if (turns.length < 2) return messages;
+
+  // Normally the tail is untouchable; under `force` it yields as far as the
+  // final turn so there is always at least one eviction candidate.
+  const effectivePreserve = force
+    ? Math.max(1, Math.min(preserveTurns, turns.length - 1))
+    : preserveTurns;
+
   // If we have fewer turns than we want to preserve, just return the messages.
-  if (turns.length <= preserveTurns) return messages;
+  if (turns.length <= effectivePreserve) return messages;
 
   let currentEstimate = estimateTokens(messages);
-  if (currentEstimate <= targetTokens) return messages;
+  if (!force && currentEstimate <= targetTokens) return messages;
 
-  debug(`compactMessages: currentEstimate=${currentEstimate} target=${targetTokens} turns=${turns.length}`);
+  debug(
+    `compactMessages: currentEstimate=${currentEstimate} target=${targetTokens} turns=${turns.length} preserve=${effectivePreserve} force=${force}`
+  );
 
-  // Identify candidates for eviction: all turns except the last `preserveTurns`.
-  const tail = turns.slice(-preserveTurns);
+  // Identify candidates for eviction: all turns except the preserved tail.
+  const tail = turns.slice(-effectivePreserve);
   const candidateTurns = turns
-    .slice(0, -preserveTurns)
+    .slice(0, -effectivePreserve)
     .map((turn, index) => ({
       turn,
       index,
@@ -1689,13 +1737,15 @@ function compactMessages(
 
   const evictedIndices = new Set<number>();
   for (const c of candidateTurns) {
-    if (currentEstimate <= targetTokens) break;
+    // Under `force`, always take the first (largest) candidate: the estimate
+    // that says we are already under target is the one the provider rejected.
+    if (currentEstimate <= targetTokens && !(force && evictedIndices.size === 0)) break;
     evictedIndices.add(c.index);
     currentEstimate -= c.tokens;
   }
 
   const compacted: GlmMessage[] = [systemPrompt];
-  for (let i = 0; i < turns.length - preserveTurns; i++) {
+  for (let i = 0; i < turns.length - effectivePreserve; i++) {
     if (!evictedIndices.has(i)) {
       compacted.push(...turns[i]);
     }

--- a/src/protocol/agent.ts
+++ b/src/protocol/agent.ts
@@ -1660,10 +1660,11 @@ function estimateTokens(messages: GlmMessage[]): number {
  *    is below `targetTokens`.
  *
  * `force` is for the emergency path after the provider itself rejected the
- * history, where {@link estimateTokens} has already been proven wrong and so
- * cannot be allowed to veto eviction. It shrinks the preserved tail as far as
- * the final turn (which carries the live user message) and always evicts at
- * least one turn, so the retry sends strictly less than what just failed.
+ * history. There {@link estimateTokens} has been proven wrong, so it can set
+ * neither the stopping point nor what is off limits: the target is halved, and
+ * the preserved tail becomes evictable from its oldest end. Only the final turn
+ * is sacred — it carries the live user message, and a request without it is not
+ * a retry of anything.
  */
 function compactMessages(
   messages: GlmMessage[],
@@ -1690,55 +1691,59 @@ function compactMessages(
     turns.push(currentTurn);
   }
 
-  // Normally the tail is untouchable; under `force` it yields as far as the
-  // final turn — never past it, since that turn holds the live user message —
-  // so there is always at least one eviction candidate.
-  const effectivePreserve = force
-    ? Math.max(1, Math.min(preserveTurns, turns.length - 1))
-    : preserveTurns;
-
-  // Fewer turns than we want to preserve: nothing to evict. Under `force` this
-  // means a lone turn, which is past what turn eviction can fix.
-  if (turns.length <= effectivePreserve) return messages;
+  // The final turn holds the live user message, so it is never evictable —
+  // with nothing else to drop there is no compaction to do.
+  if (turns.length < 2) return messages;
+  if (!force && turns.length <= preserveTurns) return messages;
 
   let currentEstimate = estimateTokens(messages);
   if (!force && currentEstimate <= targetTokens) return messages;
 
+  // An estimate already above target names a real reduction to aim for, forced
+  // or not. One that sits *below* target while the provider is rejecting the
+  // payload has been disproven, and stopping on it would spend the single retry
+  // on another oversized request — so halve it instead. Wrong by an unknown
+  // factor still shrinks geometrically, and only that case pays the extra loss.
+  const estimateDisproven = force && currentEstimate <= targetTokens;
+  const effectiveTarget = estimateDisproven
+    ? Math.floor(currentEstimate / 2)
+    : targetTokens;
+
   debug(
-    `compactMessages: currentEstimate=${currentEstimate} target=${targetTokens} turns=${turns.length} preserve=${effectivePreserve} force=${force}`
+    `compactMessages: currentEstimate=${currentEstimate} target=${effectiveTarget} turns=${turns.length} force=${force}`
   );
 
-  // Identify candidates for eviction: all turns except the preserved tail.
-  const tail = turns.slice(-effectivePreserve);
-  const candidateTurns = turns
-    .slice(0, -effectivePreserve)
-    .map((turn, index) => ({
-      turn,
-      index,
-      tokens: estimateTokens(turn),
-    }));
-
-  // Sort candidates by size (largest first).
-  candidateTurns.sort((a, b) => b.tokens - a.tokens);
-
+  const sized = turns.map((turn, index) => ({ index, tokens: estimateTokens(turn) }));
+  const protectedFrom = turns.length - preserveTurns;
   const evictedIndices = new Set<number>();
+
+  // Largest first, among the turns outside the preserved tail.
+  const candidateTurns = sized
+    .filter((c) => c.index < protectedFrom)
+    .sort((a, b) => b.tokens - a.tokens);
   for (const c of candidateTurns) {
-    // Under `force`, the largest candidate goes regardless of the estimate —
-    // the estimate saying we already fit is the one the provider rejected.
-    const mustEvict = force && evictedIndices.size === 0;
-    if (!mustEvict && currentEstimate <= targetTokens) break;
+    if (currentEstimate <= effectiveTarget) break;
     evictedIndices.add(c.index);
     currentEstimate -= c.tokens;
   }
 
+  // Still over, and forced? Then the preserved tail is itself the problem — a
+  // run of image-heavy prompts can exceed the window on its own, leaving the
+  // candidates above unable to reach the target however many are dropped. Eat
+  // into the tail from its oldest end so the freshest context survives.
+  if (force) {
+    for (let i = Math.max(protectedFrom, 0); i < turns.length - 1; i++) {
+      if (currentEstimate <= effectiveTarget) break;
+      evictedIndices.add(i);
+      currentEstimate -= sized[i].tokens;
+    }
+  }
+
   const compacted: GlmMessage[] = [systemPrompt];
-  for (let i = 0; i < turns.length - effectivePreserve; i++) {
+  for (let i = 0; i < turns.length; i++) {
     if (!evictedIndices.has(i)) {
       compacted.push(...turns[i]);
     }
-  }
-  for (const turn of tail) {
-    compacted.push(...turn);
   }
 
   debug(`compactMessages: done, newEstimate=${estimateTokens(compacted)} messageCount=${compacted.length}`);

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -2484,6 +2484,116 @@ test("prompt fails fast when context overflow persists after emergency compactio
 });
 
 // ---------------------------------------------------------------------------
+// Native images and context compaction
+// ---------------------------------------------------------------------------
+
+/** A minimal, well-formed data URL image part for a vision-native message. */
+function imagePart(): { type: "image_url"; image_url: { url: string } } {
+  return {
+    type: "image_url",
+    image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+  };
+}
+
+test("proactive compaction counts native image parts toward the context estimate", async () => {
+  const conn = createConnectionStub();
+  let messagesInCall = 0;
+
+  const glm = {
+    async *streamChat(messages: ReadonlyArray<{ role: string }>): AsyncGenerator<GlmStreamChunk> {
+      messagesInCall = messages.length;
+      yield { text: "ok" };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+  // Pin to a vision-native model with a 200K window so a realistic number of
+  // images is enough to cross the 90% proactive-compaction threshold.
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5v-turbo" });
+  const session = (agent as unknown as {
+    sessions: Map<string, { messages: unknown[] }>;
+  }).sessions.get(sessionId);
+  assert.ok(session, "expected in-memory session to exist");
+
+  // 150 image-bearing turns. The *text* in this history is negligible — only
+  // the images can push the estimate past the threshold.
+  for (let i = 0; i < 150; i++) {
+    session.messages.push({
+      role: "user",
+      content: [{ type: "text", text: "look" }, imagePart()],
+    });
+    session.messages.push({ role: "assistant", content: "seen" });
+  }
+  const messagesBefore = session.messages.length;
+
+  await agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "and this one?" }],
+  });
+
+  assert.ok(
+    messagesInCall < messagesBefore,
+    `expected image-heavy history to be compacted before the call (sent ${messagesInCall}, had ${messagesBefore})`
+  );
+});
+
+test("emergency compaction evicts history even when the estimate is under target", async () => {
+  const conn = createConnectionStub();
+  let callCount = 0;
+  let messagesInFirstCall = 0;
+  let messagesInSecondCall = 0;
+
+  const glm = {
+    async *streamChat(messages: ReadonlyArray<{ role: string }>): AsyncGenerator<GlmStreamChunk> {
+      callCount++;
+      if (callCount === 1) {
+        messagesInFirstCall = messages.length;
+        const err = new Error("Prompt exceeds max length") as OverflowErrorLike;
+        err.error = { code: 1261 };
+        throw err;
+      }
+      messagesInSecondCall = messages.length;
+      yield { text: "Recovered." };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  const session = (agent as unknown as {
+    sessions: Map<string, { messages: unknown[] }>;
+  }).sessions.get(sessionId);
+  assert.ok(session, "expected in-memory session to exist");
+
+  // Twenty tiny turns: the heuristic estimate sits far below any compaction
+  // target, so only a forced eviction can shrink the retry payload. The real
+  // cost the provider rejected (images, or anything the heuristic under-counts)
+  // is invisible to the estimate by construction.
+  for (let i = 0; i < 20; i++) {
+    session.messages.push({ role: "user", content: [{ type: "text", text: "hi" }, imagePart()] });
+    session.messages.push({ role: "assistant", content: "ok" });
+  }
+
+  const result = await agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "one more" }],
+  });
+
+  assert.equal(result.stopReason, "end_turn");
+  assert.equal(callCount, 2, "expected two streamChat calls (one failed, one retried)");
+  assert.ok(
+    messagesInSecondCall < messagesInFirstCall,
+    `expected the retry to send strictly less history (sent ${messagesInSecondCall}, first call had ${messagesInFirstCall})`
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Slash commands (available_commands_update)
 // ---------------------------------------------------------------------------
 

--- a/src/tests/agent.test.ts
+++ b/src/tests/agent.test.ts
@@ -2487,6 +2487,20 @@ test("prompt fails fast when context overflow persists after emergency compactio
 // Native images and context compaction
 // ---------------------------------------------------------------------------
 
+type MessageLike = { role?: string; content?: unknown };
+
+/** Count `image_url` parts across a message list, for token-budget assertions. */
+function countImageParts(messages: ReadonlyArray<MessageLike>): number {
+  let count = 0;
+  for (const m of messages) {
+    if (!Array.isArray(m.content)) continue;
+    for (const part of m.content) {
+      if ((part as { type?: unknown })?.type === "image_url") count++;
+    }
+  }
+  return count;
+}
+
 /** A minimal, well-formed data URL image part for a vision-native message. */
 function imagePart(): { type: "image_url"; image_url: { url: string } } {
   return {
@@ -2587,9 +2601,84 @@ test("emergency compaction evicts history even when the estimate is under target
 
   assert.equal(result.stopReason, "end_turn");
   assert.equal(callCount, 2, "expected two streamChat calls (one failed, one retried)");
+  // Strictly less is not enough: evicting a single turn and then stopping on
+  // the same estimate the provider just disproved can leave the retry
+  // oversized, which spends the one retry for nothing.
   assert.ok(
-    messagesInSecondCall < messagesInFirstCall,
-    `expected the retry to send strictly less history (sent ${messagesInSecondCall}, first call had ${messagesInFirstCall})`
+    messagesInFirstCall - messagesInSecondCall > 2,
+    `expected the retry to drop more than one turn (sent ${messagesInSecondCall}, first call had ${messagesInFirstCall})`
+  );
+});
+
+test("emergency compaction evicts the preserved tail when the tail alone busts the target", async () => {
+  const conn = createConnectionStub();
+  let callCount = 0;
+  let messagesInFirstCall = 0;
+  let secondCall: MessageLike[] = [];
+
+  const glm = {
+    async *streamChat(messages: ReadonlyArray<MessageLike>): AsyncGenerator<GlmStreamChunk> {
+      callCount++;
+      if (callCount === 1) {
+        messagesInFirstCall = messages.length;
+        const err = new Error("Prompt exceeds max length") as OverflowErrorLike;
+        err.error = { code: 1261 };
+        throw err;
+      }
+      secondCall = [...messages];
+      yield { text: "Recovered." };
+      yield { done: true, stopReason: "stop" };
+    },
+  };
+
+  const agent = new GlmAcpAgent(conn as never, { glm, sessionStore: null });
+  await agent.initialize({ protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+  const { sessionId } = await agent.newSession({ cwd: "/tmp", mcpServers: [] });
+  await agent.unstable_setSessionModel({ sessionId, modelId: "glm-5v-turbo" });
+  const session = (agent as unknown as {
+    sessions: Map<string, { messages: unknown[] }>;
+  }).sessions.get(sessionId);
+  assert.ok(session, "expected in-memory session to exist");
+
+  // Twelve multi-image turns. Proactive compaction burns through every turn
+  // outside the ten-turn preserved tail and still cannot reach its target, so
+  // by the time the provider rejects the payload the tail *is* the history —
+  // recovery is impossible unless forced eviction may reach into it.
+  for (let i = 0; i < 12; i++) {
+    session.messages.push({
+      role: "user",
+      content: [{ type: "text", text: "batch" }, ...Array.from({ length: 12 }, imagePart)],
+    });
+    session.messages.push({ role: "assistant", content: "seen" });
+  }
+
+  const result = await agent.prompt({
+    sessionId,
+    prompt: [{ type: "text", text: "and this one?" }],
+  });
+
+  assert.equal(result.stopReason, "end_turn");
+  assert.equal(callCount, 2, "expected two streamChat calls (one failed, one retried)");
+  assert.ok(
+    secondCall.length < messagesInFirstCall,
+    `expected the retry to shed tail turns (sent ${secondCall.length}, first call had ${messagesInFirstCall})`
+  );
+  // The emergency target is 70% of the 200K window. Charged at 1600 tokens
+  // each, the retry's images must fit under it — otherwise the one retry we
+  // get is spent on another payload the provider will reject.
+  const imagesSent = countImageParts(secondCall);
+  assert.ok(
+    imagesSent * 1600 <= Math.floor(200_000 * 0.7),
+    `expected the retry to fit the emergency target, but it carried ${imagesSent} images`
+  );
+  // Whatever else goes, the live user message has to survive — a request
+  // without it is not a retry of anything.
+  const last = secondCall[secondCall.length - 1];
+  assert.equal(last?.role, "user");
+  assert.ok(
+    JSON.stringify(last?.content ?? "").includes("and this one?"),
+    "expected the live user prompt to survive forced compaction"
   );
 });
 


### PR DESCRIPTION
## Purpose

This bugfix makes context compaction see the native images a vision-native session carries. `estimateTokens` walked message content arrays but summed only `text` parts, so an `image_url` part counted as **zero tokens**. A Flash (or `glm-5v-turbo`) session whose bulk was images therefore read as near-empty history, with two consequences: proactive compaction never fired and the history sailed past the provider's window, and — worse — the 1261 overflow retry was a no-op, because `compactMessages` early-returns when the estimate already sits under target. The "emergency" compaction handed back byte-identical history and the retry resent the request that had just been rejected, so an image-heavy session could not recover the way a text session does.

## Key Changes

- Charge every `image_url` content part a flat `IMAGE_PART_TOKENS = 1600`. That is the ceiling, not a guess: vision-native GLM models tile an image into 14px patches and merge 2x2, so a full-size input (capped at 1120x1120) costs `(1120/14)² / 4 = 1600`. The wire form — an HTTPS URL or a base64 data URL — says nothing about decoded dimensions, so the ceiling is the only conservative policy. Over-counting merely compacts early; under-counting is the bug.
- Give `compactMessages` a `force` mode, used by the overflow retry. Once the provider has rejected the history, the heuristic estimate has been proven wrong and can no longer veto eviction: `force` bypasses the estimate gate, shrinks the preserved tail as far as the final turn, and always evicts at least one turn — so the retry sends strictly less than what just failed.
- Never evict past the final turn, which holds the live user message. A lone oversized turn is beyond what turn eviction can fix, and surfacing `Context overflow persisted` is more honest than sending a request with no user message in it.
- Because the fix lives in `estimateTokens` and in the shared compaction function, both the proactive path and the emergency path benefit, along with the per-turn sizing that ranks eviction candidates.
- Two regression tests: a 150-image history that must compact before the first call, and a forced eviction that must shrink the retry even when the estimate already reads as under target.

## Checks

- [x] Type-check passes (`npm run build`)
- [x] Tests pass (280/280, `npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Code compiles without errors
- [x] Changes have been tested locally

Both tests were written first and watched fail for the right reasons (`sent 302, had 301` and `sent 42, first call had 42`) before the fix landed.

## Task

[#98](https://github.com/stefandevo/glm-acp-agent/issues/98)